### PR TITLE
feat: scaffold extension with manifest and context menu

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,28 @@
+// Register context menu on install
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.contextMenus.create({
+    id: 'ask-ai',
+    title: 'Ask AI',
+    contexts: ['selection']
+  });
+});
+
+// Handle context menu click
+chrome.contextMenus.onClicked.addListener((info, tab) => {
+  if (info.menuItemId === 'ask-ai') {
+    chrome.tabs.sendMessage(tab.id, {
+      type: 'SHOW_POPUP',
+      text: info.selectionText
+    });
+  }
+});
+
+// Handle open-tab requests from content script
+chrome.runtime.onMessage.addListener((msg, sender) => {
+  if (msg.type === 'OPEN_AI_TAB') {
+    chrome.tabs.create({ url: msg.url });
+  }
+  if (msg.type === 'COPY_AND_OPEN') {
+    chrome.tabs.create({ url: msg.url });
+  }
+});

--- a/content.js
+++ b/content.js
@@ -1,0 +1,6 @@
+// Placeholder — will be built out in subsequent PRs
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg.type === 'SHOW_POPUP') {
+    console.log('[Ask AI] Context menu triggered with text:', msg.text.substring(0, 50));
+  }
+});

--- a/icons/icon128.svg
+++ b/icons/icon128.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="#4f46e5"><path d="M64 8l12 36 36 8-36 12-12 36-12-36-36-12 36-8z"/></svg>

--- a/icons/icon16.svg
+++ b/icons/icon16.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="#4f46e5"><path d="M8 1l1.5 4.5L14 7l-4.5 1.5L8 13l-1.5-4.5L2 7l4.5-1.5z"/></svg>

--- a/icons/icon48.svg
+++ b/icons/icon48.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="#4f46e5"><path d="M24 3l4.5 13.5L42 21l-13.5 4.5L24 39l-4.5-13.5L6 21l13.5-4.5z"/></svg>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,19 @@
+{
+  "manifest_version": 3,
+  "name": "Ask AI",
+  "version": "1.0.0",
+  "description": "Select text and send it to ChatGPT or Claude with smart prompts",
+  "permissions": ["contextMenus", "activeTab", "storage"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [{
+    "matches": ["<all_urls>"],
+    "js": ["content.js"]
+  }],
+  "icons": {
+    "16": "icons/icon16.svg",
+    "48": "icons/icon48.svg",
+    "128": "icons/icon128.svg"
+  }
+}


### PR DESCRIPTION
## Summary
- Set up Chrome Manifest V3 extension scaffold
- Register "Ask AI" context menu item that appears on text selection
- Add background service worker with message handlers for opening AI tabs
- Add placeholder content script
- Add SVG sparkle icons

Closes #1

## Test plan
- [ ] Load unpacked extension in `chrome://extensions/` (Developer mode)
- [ ] Select text on any page → right-click → verify "Ask AI" appears in context menu
- [ ] Click "Ask AI" → check browser console for `[Ask AI] Context menu triggered` log
- [ ] Verify extension icon displays in toolbar