### PR TITLE
ci: add CI/CD pipeline with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test
+
+  lint-manifest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate manifest.json
+        run: |
+          node -e "
+            const fs = require('fs');
+            const manifest = JSON.parse(fs.readFileSync('manifest.json', 'utf8'));
+            const required = ['manifest_version', 'name', 'version', 'permissions'];
+            for (const key of required) {
+              if (!manifest[key]) {
+                console.error('Missing required field:', key);
+                process.exit(1);
+              }
+            }
+            if (manifest.manifest_version !== 3) {
+              console.error('Must use Manifest V3');
+              process.exit(1);
+            }
+            console.log('Manifest validation passed');
+            console.log('  Name:', manifest.name);
+            console.log('  Version:', manifest.version);
+            console.log('  Permissions:', manifest.permissions.join(', '));
+          "
+
+  package:
+    runs-on: ubuntu-latest
+    needs: [test, lint-manifest]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Package extension
+        run: |
+          mkdir -p dist
+          zip -r dist/ask-ai-extension.zip \
+            manifest.json \
+            background.js \
+            content.js \
+            detection.js \
+            presets.js \
+            prompt.js \
+            trigger.js \
+            popup.js \
+            icons/
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ask-ai-extension
+          path: dist/ask-ai-extension.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+      - run: npm test
+
+      - name: Validate version matches tag
+        run: |
+          TAG_VERSION=${GITHUB_REF#refs/tags/v}
+          MANIFEST_VERSION=$(node -e "console.log(JSON.parse(require('fs').readFileSync('manifest.json','utf8')).version)")
+          PACKAGE_VERSION=$(node -e "console.log(JSON.parse(require('fs').readFileSync('package.json','utf8')).version)")
+          if [ "$TAG_VERSION" != "$MANIFEST_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) doesn't match manifest.json ($MANIFEST_VERSION)"
+            exit 1
+          fi
+          if [ "$TAG_VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) doesn't match package.json ($PACKAGE_VERSION)"
+            exit 1
+          fi
+          echo "Version $TAG_VERSION validated"
+
+      - name: Package extension
+        run: |
+          mkdir -p dist
+          zip -r dist/ask-ai-extension-${GITHUB_REF#refs/tags/}.zip \
+            manifest.json \
+            background.js \
+            content.js \
+            detection.js \
+            presets.js \
+            prompt.js \
+            trigger.js \
+            popup.js \
+            icons/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/ask-ai-extension-*.zip
+          generate_release_notes: true
+
+      - name: Publish to Chrome Web Store
+        if: env.CHROME_CLIENT_ID != ''
+        env:
+          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+        run: |
+          # Get access token
+          ACCESS_TOKEN=$(curl -s -X POST "https://oauth2.googleapis.com/token" \
+            -d "client_id=$CHROME_CLIENT_ID" \
+            -d "client_secret=$CHROME_CLIENT_SECRET" \
+            -d "refresh_token=$CHROME_REFRESH_TOKEN" \
+            -d "grant_type=refresh_token" | node -e "process.stdin.on('data',d=>console.log(JSON.parse(d).access_token))")
+
+          # Upload zip
+          curl -s -X PUT \
+            "https://www.googleapis.com/upload/chromewebstore/v1.1/items/$CHROME_EXTENSION_ID" \
+            -H "Authorization: Bearer $ACCESS_TOKEN" \
+            -H "x-goog-api-version: 2" \
+            -T dist/ask-ai-extension-${GITHUB_REF#refs/tags/}.zip
+
+          # Publish
+          curl -s -X POST \
+            "https://www.googleapis.com/chromewebstore/v1.1/items/$CHROME_EXTENSION_ID/publish" \
+            -H "Authorization: Bearer $ACCESS_TOKEN" \
+            -H "x-goog-api-version: 2"
+
+          echo "Published to Chrome Web Store"


### PR DESCRIPTION
## Summary
- Add CI workflow (`ci.yml`): runs tests, validates manifest.json, packages extension as artifact on every PR
- Add Release workflow (`release.yml`): on `v*` tag push — runs tests, validates version consistency across manifest.json/package.json/tag, creates GitHub Release with zip, conditionally publishes to Chrome Web Store

## CI Jobs
- **test**: `npm ci && npm test` on Node 20
- **lint-manifest**: validates manifest has required fields and uses Manifest V3
- **package**: zips extension files and uploads as GitHub Actions artifact

## Release Flow
1. Push a tag: `git tag v1.0.0 && git push origin v1.0.0`
2. Workflow validates version matches across manifest.json, package.json, and tag
3. Creates GitHub Release with auto-generated notes and extension zip
4. Publishes to Chrome Web Store (requires secrets: `CHROME_CLIENT_ID`, `CHROME_CLIENT_SECRET`, `CHROME_REFRESH_TOKEN`, `CHROME_EXTENSION_ID`)

## Test plan
- [ ] CI workflow syntax is valid (GitHub validates on push)
- [ ] CI runs tests and manifest validation on this PR
- [ ] Release workflow only triggers on `v*` tags
- [ ] Chrome Web Store publish is conditional (`if: env.CHROME_CLIENT_ID != ''`)