### PR TITLE
feat: add context menu fallback for CSP-blocked pages

### DIFF
--- a/background.js
+++ b/background.js
@@ -10,9 +10,33 @@ chrome.runtime.onInstalled.addListener(() => {
 // Handle context menu click
 chrome.contextMenus.onClicked.addListener((info, tab) => {
   if (info.menuItemId === 'ask-ai') {
+    // Try sending to content script first
     chrome.tabs.sendMessage(tab.id, {
       type: 'SHOW_POPUP',
       text: info.selectionText
+    }).catch(() => {
+      // Content script not available (CSP-blocked page) — open directly
+      chrome.storage.local.get(['lastAI', 'pageContext'], (stored) => {
+        const ai = stored.lastAI || 'chatgpt';
+        const baseUrls = {
+          chatgpt: 'https://chatgpt.com/',
+          claude: 'https://claude.ai/new'
+        };
+
+        let prompt = info.selectionText;
+        if (stored.pageContext !== false) {
+          prompt += `\n\nFrom: "${tab.title}" (${tab.url})`;
+        }
+
+        const encoded = encodeURIComponent(prompt);
+        const fullUrl = `${baseUrls[ai]}?q=${encoded}`;
+
+        if (fullUrl.length > 8000) {
+          chrome.tabs.create({ url: baseUrls[ai] });
+        } else {
+          chrome.tabs.create({ url: fullUrl });
+        }
+      });
     });
   }
 });

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock Chrome APIs before importing
+const mockCreate = vi.fn();
+const mockStorageGet = vi.fn();
+const mockSendMessage = vi.fn();
+const mockTabsCreate = vi.fn();
+
+global.chrome = {
+  runtime: {
+    onInstalled: { addListener: vi.fn() },
+    onMessage: { addListener: vi.fn() },
+  },
+  contextMenus: {
+    create: mockCreate,
+    onClicked: { addListener: vi.fn() },
+  },
+  tabs: {
+    sendMessage: mockSendMessage,
+    create: mockTabsCreate,
+  },
+  storage: {
+    local: { get: mockStorageGet },
+  },
+};
+
+// Import after mocks are set up
+await import('../background.js');
+
+// Capture handlers immediately after import, before any clearAllMocks
+const clickHandler = chrome.contextMenus.onClicked.addListener.mock.calls[0][0];
+const messageHandler = chrome.runtime.onMessage.addListener.mock.calls[0][0];
+
+describe('context menu registration', () => {
+  it('registers onInstalled listener', () => {
+    expect(chrome.runtime.onInstalled.addListener).toHaveBeenCalledOnce();
+  });
+
+  it('creates context menu with correct config on install', () => {
+    const installCallback = chrome.runtime.onInstalled.addListener.mock.calls[0][0];
+    installCallback();
+    expect(mockCreate).toHaveBeenCalledWith({
+      id: 'ask-ai',
+      title: 'Ask AI',
+      contexts: ['selection']
+    });
+  });
+});
+
+describe('context menu click handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sends SHOW_POPUP message to content script', () => {
+    mockSendMessage.mockResolvedValue(undefined);
+    clickHandler(
+      { menuItemId: 'ask-ai', selectionText: 'hello world' },
+      { id: 1 }
+    );
+    expect(mockSendMessage).toHaveBeenCalledWith(1, {
+      type: 'SHOW_POPUP',
+      text: 'hello world'
+    });
+  });
+
+  it('falls back to direct open when content script unavailable', async () => {
+    mockSendMessage.mockRejectedValue(new Error('no content script'));
+    mockStorageGet.mockImplementation((keys, cb) => {
+      cb({ lastAI: 'chatgpt', pageContext: true });
+    });
+
+    clickHandler(
+      { menuItemId: 'ask-ai', selectionText: 'test text' },
+      { id: 1, title: 'Test Page', url: 'https://example.com' }
+    );
+
+    // Wait for the promise rejection to be handled
+    await vi.waitFor(() => {
+      expect(mockTabsCreate).toHaveBeenCalled();
+    });
+
+    const url = mockTabsCreate.mock.calls[0][0].url;
+    expect(url).toContain('chatgpt.com');
+    expect(url).toContain(encodeURIComponent('test text'));
+  });
+
+  it('uses claude URL when lastAI is claude', async () => {
+    mockSendMessage.mockRejectedValue(new Error('no content script'));
+    mockStorageGet.mockImplementation((keys, cb) => {
+      cb({ lastAI: 'claude', pageContext: false });
+    });
+
+    clickHandler(
+      { menuItemId: 'ask-ai', selectionText: 'test' },
+      { id: 1, title: 'Page', url: 'https://x.com' }
+    );
+
+    await vi.waitFor(() => {
+      expect(mockTabsCreate).toHaveBeenCalled();
+    });
+
+    const url = mockTabsCreate.mock.calls[0][0].url;
+    expect(url).toContain('claude.ai');
+  });
+
+  it('ignores non-ask-ai menu items', () => {
+    clickHandler(
+      { menuItemId: 'other-item', selectionText: 'text' },
+      { id: 1 }
+    );
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('message handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('opens tab for OPEN_AI_TAB message', () => {
+    messageHandler({ type: 'OPEN_AI_TAB', url: 'https://chatgpt.com/?q=test' });
+    expect(mockTabsCreate).toHaveBeenCalledWith({ url: 'https://chatgpt.com/?q=test' });
+  });
+
+  it('opens tab for COPY_AND_OPEN message', () => {
+    messageHandler({ type: 'COPY_AND_OPEN', url: 'https://claude.ai/new' });
+    expect(mockTabsCreate).toHaveBeenCalledWith({ url: 'https://claude.ai/new' });
+  });
+
+  it('ignores unknown message types', () => {
+    messageHandler({ type: 'UNKNOWN' });
+    expect(mockTabsCreate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Add CSP fallback in `background.js`: when content script can't respond to context menu click, opens AI URL directly using `info.selectionText`
- Fallback reads user preferences (lastAI, pageContext) from storage
- Appends page context (title + URL) unless explicitly disabled
- Falls back to base URL without query param if encoded URL > 8000 chars
- 9 new unit tests with Chrome API mocks, all passing

Closes #5

## Test plan
- [ ] `npm test` — 62 tests pass across 4 test files
- [ ] Navigate to a CSP-restricted page (e.g. `chrome://extensions/`)
- [ ] Select text → right-click → "Ask AI" → verify new tab opens with AI URL
- [ ] Test with both ChatGPT and Claude preferences