### PR TITLE
fix: use inline packaging in PR Preview Bot

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -24,7 +24,18 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Package extension
-        run: bash scripts/package.sh dist dev
+        run: |
+          mkdir -p dist
+          zip -r dist/ask-ai-extension-dev.zip \
+            manifest.json \
+            background.js \
+            content.js \
+            detection.js \
+            presets.js \
+            prompt.js \
+            trigger.js \
+            popup.js \
+            icons/
 
       - name: Upload extension artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- PR Preview Bot workflow (`pr-preview.yml`) was failing with exit code 127 because it referenced `scripts/package.sh` which doesn't exist on this branch
- Replaced with inline `zip` command matching the approach used in `ci.yml`
- This fixes the failing `preview` check on PR #14

## Root Cause
The `feat/creative-ci-workflows` branch was created from `main` before `scripts/package.sh` was added (it only exists on the `feat/ci-cd-improvements` branch). The workflow assumed the script would be present.

## Test plan
- [ ] Verify PR Preview Bot check passes after merge
- [ ] Verify the generated artifact contains all expected extension files

🤖 Generated with [Claude Code](https://claude.com/claude-code)