### PR TITLE
fix: detect braceless code patterns in content detection

### DIFF
--- a/detection.js
+++ b/detection.js
@@ -21,11 +21,12 @@ function detectContentType(text, anchorNode) {
   const hasBraces = /[{}]/.test(text);
   const hasSemicolons = /;/.test(text);
   const hasIndentation = /^\s{2,}/m.test(text);
-  const codeKeywords = (text.match(/\b(function|const|let|var|def|class|import|return|if|else|for|while)\b/g) || []).length;
+  const codeKeywords = (text.match(/\b(function|const|let|var|def|class|import|export|return|if|else|for|while|console|require|async|await|typeof)\b/g) || []).length;
 
   if ((hasBraces && hasSemicolons) ||
       (hasBraces && codeKeywords >= 2) ||
-      (hasIndentation && hasSemicolons && codeKeywords >= 1)) {
+      (hasIndentation && hasSemicolons && codeKeywords >= 1) ||
+      (hasSemicolons && codeKeywords >= 2)) {
     return 'code';
   }
 

--- a/tests/detection.test.js
+++ b/tests/detection.test.js
@@ -67,6 +67,21 @@ describe('detectContentType', () => {
       expect(detectContentType('hello world', anchorNode)).toBe('code');
     });
 
+    it('detects braceless JavaScript code with semicolons and keywords', () => {
+      const text = 'const x = [1,4]; console.log(x);';
+      expect(detectContentType(text, null)).toBe('code');
+    });
+
+    it('detects braceless multi-statement code', () => {
+      const text = 'let a = 10; let b = 20; return a + b;';
+      expect(detectContentType(text, null)).toBe('code');
+    });
+
+    it('detects braceless code with var and import keywords', () => {
+      const text = 'import fs from "fs"; var data = fs.readFileSync("file.txt");';
+      expect(detectContentType(text, null)).toBe('code');
+    });
+
     it('does NOT falsely detect prose that mentions programming terms', () => {
       const text = 'The function of this committee is to review import regulations and export policies.';
       expect(detectContentType(text, null)).not.toBe('code');


### PR DESCRIPTION
## Summary
- Add 4th heuristic `(hasSemicolons && codeKeywords >= 2)` to detect code without `{}` braces (e.g., `const x = [1,4]; console.log(x);`)
- Expand keyword list with `console`, `require`, `async`, `await`, `typeof`, `export` for better coverage
- Add 3 new test cases for braceless code patterns

## Test plan
- [x] All 92 existing + new tests pass (`npm test`)
- [x] Braceless code like `const x = [1,4]; console.log(x);` now correctly detected as code
- [x] Prose with programming terms (e.g., "The function of this committee...export policies") still NOT falsely detected as code

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)