### PR TITLE
fix: validate URLs in background.js to prevent open redirect

### DIFF
--- a/background.js
+++ b/background.js
@@ -41,12 +41,19 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
   }
 });
 
+// Allowed URL prefixes for AI tab requests
+const ALLOWED_URL_PREFIXES = ['https://chatgpt.com/', 'https://claude.ai/'];
+
+function isAllowedUrl(url) {
+  return typeof url === 'string' && ALLOWED_URL_PREFIXES.some(prefix => url.startsWith(prefix));
+}
+
 // Handle open-tab requests from content script
 chrome.runtime.onMessage.addListener((msg, sender) => {
-  if (msg.type === 'OPEN_AI_TAB') {
+  if (msg.type === 'OPEN_AI_TAB' && isAllowedUrl(msg.url)) {
     chrome.tabs.create({ url: msg.url });
   }
-  if (msg.type === 'COPY_AND_OPEN') {
+  if (msg.type === 'COPY_AND_OPEN' && isAllowedUrl(msg.url)) {
     chrome.tabs.create({ url: msg.url });
   }
 });

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -132,4 +132,19 @@ describe('message handler', () => {
     messageHandler({ type: 'UNKNOWN' });
     expect(mockTabsCreate).not.toHaveBeenCalled();
   });
+
+  it('rejects OPEN_AI_TAB with non-allowed URL', () => {
+    messageHandler({ type: 'OPEN_AI_TAB', url: 'https://evil.com/phishing' });
+    expect(mockTabsCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects COPY_AND_OPEN with non-allowed URL', () => {
+    messageHandler({ type: 'COPY_AND_OPEN', url: 'https://malicious.site/' });
+    expect(mockTabsCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects OPEN_AI_TAB with missing URL', () => {
+    messageHandler({ type: 'OPEN_AI_TAB' });
+    expect(mockTabsCreate).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- Add URL allowlist validation for `OPEN_AI_TAB` and `COPY_AND_OPEN` message handlers
- Only URLs starting with `https://chatgpt.com/` or `https://claude.ai/` are accepted
- Rejects arbitrary URLs that could be used for phishing via the extension

## Test plan
- [x] 3 new tests: rejects non-allowed URL, rejects missing URL, existing valid URL tests still pass
- [x] All 95 tests pass

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)