### PR TITLE
fix: guard getRangeAt with rangeCount check in trigger.js

### DIFF
--- a/trigger.js
+++ b/trigger.js
@@ -78,7 +78,7 @@ document.addEventListener('mouseup', (e) => {
     const selection = window.getSelection();
     const text = selection.toString().trim();
 
-    if (text.length >= 3) {
+    if (text.length >= 3 && selection.rangeCount > 0) {
       const range = selection.getRangeAt(0);
       const rect = range.getBoundingClientRect();
       showTrigger(rect);
@@ -96,7 +96,7 @@ window.addEventListener('scroll', () => {
   scrollTimer = setTimeout(() => {
     const selection = window.getSelection();
     const text = selection.toString().trim();
-    if (text.length >= 3) {
+    if (text.length >= 3 && selection.rangeCount > 0) {
       const range = selection.getRangeAt(0);
       const rect = range.getBoundingClientRect();
       showTrigger(rect);


### PR DESCRIPTION
## Summary
- Add `selection.rangeCount > 0` guard before `getRangeAt(0)` calls in mouseup and scroll handlers
- Prevents runtime errors when selection is cleared between `toString()` and `getRangeAt()` calls

## Test plan
- [x] All 92 existing tests pass
- [x] Change is defensive — adds guard without altering behavior for normal cases

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)