### PR TITLE
feat: enhanced smart detection engine with sub-types and rich metadata

### DIFF
--- a/detection.js
+++ b/detection.js
@@ -1,47 +1,357 @@
 // Content type detection — determines smart presets based on selected text
-// Implemented by Engineer A
+// Enhanced in v1.1: rich detection objects with sub-type, confidence, and metadata
 
 /**
  * Detect the content type of selected text.
  * @param {string} text - The selected text
  * @param {Node|null} anchorNode - The DOM node where selection starts
- * @returns {'code'|'foreign'|'long'|'default'}
+ * @returns {{ type: string, subType: string|null, confidence: number, wordCount: number, charCount: number }}
  */
 function detectContentType(text, anchorNode) {
-  // Check if selection is inside <pre> or <code>
+  const charCount = text.length;
+  const wordCount = text.trim() === '' ? 0 : text.trim().split(/\s+/).length;
+
+  // --- Priority 1: Code in <pre> or <code> DOM node ---
   if (anchorNode) {
     let node = anchorNode;
     while (node) {
       const tag = node.nodeName?.toLowerCase();
-      if (tag === 'pre' || tag === 'code') return 'code';
+      if (tag === 'pre' || tag === 'code') {
+        const subType = detectCodeLanguage(text);
+        return { type: 'code', subType, confidence: 0.95, wordCount, charCount };
+      }
       node = node.parentElement;
     }
   }
 
+  // --- Priority 2: Code heuristics ---
+  const codeResult = detectCodeHeuristics(text);
+  if (codeResult) {
+    const subType = detectCodeLanguage(text);
+    return { type: 'code', subType, confidence: codeResult.confidence, wordCount, charCount };
+  }
+
+  // --- Priority 3: Error / stack trace ---
+  const errorResult = detectError(text);
+  if (errorResult) {
+    return { type: 'error', subType: null, confidence: errorResult.confidence, wordCount, charCount };
+  }
+
+  // --- Priority 4: Math / formula ---
+  const mathResult = detectMath(text);
+  if (mathResult) {
+    return { type: 'math', subType: null, confidence: mathResult.confidence, wordCount, charCount };
+  }
+
+  // --- Priority 5: List / structured data ---
+  const dataResult = detectData(text);
+  if (dataResult) {
+    return { type: 'data', subType: null, confidence: dataResult.confidence, wordCount, charCount };
+  }
+
+  // --- Priority 6: Email / message ---
+  const emailResult = detectEmail(text);
+  if (emailResult) {
+    return { type: 'email', subType: null, confidence: emailResult.confidence, wordCount, charCount };
+  }
+
+  // --- Priority 7: Foreign language ---
+  const foreignResult = detectForeign(text);
+  if (foreignResult) {
+    return { type: 'foreign', subType: foreignResult.subType, confidence: foreignResult.confidence, wordCount, charCount };
+  }
+
+  // --- Priority 8: Long text ---
+  if (wordCount > 200) {
+    return { type: 'long', subType: null, confidence: 0.9, wordCount, charCount };
+  }
+
+  // --- Default ---
+  return { type: 'default', subType: null, confidence: 1.0, wordCount, charCount };
+}
+
+// ─── Code heuristics ────────────────────────────────────────────────────────
+
+function detectCodeHeuristics(text) {
   const hasBraces = /[{}]/.test(text);
   const hasSemicolons = /;/.test(text);
   const hasIndentation = /^\s{2,}/m.test(text);
-  const codeKeywords = (text.match(/\b(function|const|let|var|def|class|import|export|return|if|else|for|while|console|require|async|await|typeof)\b/g) || []).length;
+  const codeKeywords = (text.match(/\b(function|func|fn|const|let|var|def|class|import|export|return|if|else|for|while|console|require|async|await|typeof|print|puts|self|end|package|impl|trait|struct|enum|pub|mod)\b/g) || []).length;
+
+  // SQL detection (separate path — SQL has its own syntax)
+  if (/\b(SELECT|INSERT|UPDATE|DELETE|CREATE|ALTER|DROP)\b/i.test(text) &&
+      /\b(FROM|INTO|TABLE|WHERE|SET|VALUES)\b/i.test(text)) {
+    return { confidence: 0.9 };
+  }
 
   if ((hasBraces && hasSemicolons) ||
       (hasBraces && codeKeywords >= 2) ||
+      (hasBraces && hasIndentation && codeKeywords >= 1) ||
       (hasIndentation && hasSemicolons && codeKeywords >= 1) ||
-      (hasSemicolons && codeKeywords >= 2)) {
-    return 'code';
+      (hasSemicolons && codeKeywords >= 2) ||
+      (hasIndentation && codeKeywords >= 2)) {
+    const signals = [hasBraces, hasSemicolons, hasIndentation, codeKeywords >= 2].filter(Boolean).length;
+    const confidence = Math.min(0.95, 0.6 + signals * 0.1);
+    return { confidence };
   }
+  return null;
+}
+
+// ─── Programming language sub-type detection ────────────────────────────────
+
+function detectCodeLanguage(text) {
+  const scores = {
+    javascript: 0,
+    python: 0,
+    rust: 0,
+    go: 0,
+    sql: 0,
+    java: 0,
+    'c/c++': 0,
+    ruby: 0,
+    php: 0,
+  };
+
+  // JavaScript signals
+  if (/\b(const|let|var)\b/.test(text)) scores.javascript += 2;
+  if (/=>/.test(text)) scores.javascript += 2;
+  if (/\bconsole\.(log|warn|error)\b/.test(text)) scores.javascript += 3;
+  if (/\b(require|module\.exports)\b/.test(text)) scores.javascript += 3;
+  if (/\b(document|window|addEventListener)\b/.test(text)) scores.javascript += 2;
+  if (/\basync\b.*\bawait\b/.test(text)) scores.javascript += 1;
+  if (/\btypeof\b/.test(text)) scores.javascript += 1;
+
+  // Python signals
+  if (/\bdef\s+\w+\s*\(/.test(text)) scores.python += 3;
+  if (/\bself\b/.test(text)) scores.python += 2;
+  if (/\belif\b/.test(text)) scores.python += 3;
+  if (/\bprint\s*\(/.test(text)) scores.python += 2;
+  if (/^\s*#(?!include|define|pragma).*$/m.test(text)) scores.python += 1;
+  if (/\b(True|False|None)\b/.test(text)) scores.python += 2;
+  if (/\bimport\s+\w+/.test(text) && !/\bfrom\s+['"]/.test(text)) scores.python += 1;
+
+  // Rust signals
+  if (/\bfn\s+\w+/.test(text)) scores.rust += 3;
+  if (/\blet\s+mut\b/.test(text)) scores.rust += 3;
+  if (/\b(impl|trait|enum|struct)\b/.test(text)) scores.rust += 3;
+  if (/\b(println!|vec!|format!)\b/.test(text)) scores.rust += 3;
+  if (/->/.test(text) && /\bfn\b/.test(text)) scores.rust += 2;
+  if (/&(mut\s+)?\w+/.test(text) && /\bfn\b/.test(text)) scores.rust += 1;
+
+  // Go signals
+  if (/\bfunc\s+\w+/.test(text)) scores.go += 3;
+  if (/\bpackage\s+\w+/.test(text)) scores.go += 3;
+  if (/\bfmt\.\w+/.test(text)) scores.go += 3;
+  if (/\b:=\b/.test(text)) scores.go += 3;
+  if (/\bgo\s+(func|routine)\b/.test(text)) scores.go += 2;
+  if (/\bdefer\b/.test(text)) scores.go += 2;
+
+  // SQL signals
+  if (/\b(SELECT|INSERT|UPDATE|DELETE|CREATE|ALTER|DROP)\b/i.test(text) &&
+      /\b(FROM|INTO|TABLE|WHERE|SET|VALUES)\b/i.test(text)) scores.sql += 4;
+  if (/\b(JOIN|LEFT\s+JOIN|INNER\s+JOIN|GROUP\s+BY|ORDER\s+BY)\b/i.test(text)) scores.sql += 3;
+  if (/\b(VARCHAR|INTEGER|BOOLEAN|TEXT|PRIMARY\s+KEY)\b/i.test(text)) scores.sql += 2;
+
+  // Java signals
+  if (/\bpublic\s+(static\s+)?(void|class|int|String)\b/.test(text)) scores.java += 3;
+  if (/\bSystem\.out\.print(ln)?\b/.test(text)) scores.java += 3;
+  if (/\bnew\s+\w+\(/.test(text) && /\bclass\b/.test(text)) scores.java += 2;
+  if (/\b(extends|implements|@Override)\b/.test(text)) scores.java += 3;
+  if (/\bprivate\s+\w+/.test(text)) scores.java += 1;
+
+  // C/C++ signals
+  if (/\b(#include|#define|#pragma)\b/.test(text)) scores['c/c++'] += 3;
+  if (/\b(printf|scanf|malloc|free|sizeof)\b/.test(text)) scores['c/c++'] += 3;
+  if (/\b(int|char|float|double|void)\s+\w+\s*\(/.test(text)) scores['c/c++'] += 2;
+  if (/\bstd::/.test(text)) scores['c/c++'] += 3;
+  if (/\b(cout|cin|endl)\b/.test(text)) scores['c/c++'] += 3;
+  if (/->/.test(text) && /\b(struct|typedef)\b/.test(text)) scores['c/c++'] += 2;
+
+  // Ruby signals
+  if (/\bdo\s*\|/.test(text)) scores.ruby += 3;
+  if (/\bend\b/.test(text) && /\b(def|class|module|if|do)\b/.test(text)) scores.ruby += 2;
+  if (/\bputs\b/.test(text)) scores.ruby += 2;
+  if (/\brequire\s+['"]/.test(text) && !/\brequire\s*\(/.test(text)) scores.ruby += 2;
+  if (/\battr_(reader|writer|accessor)\b/.test(text)) scores.ruby += 3;
+
+  // PHP signals
+  if (/\$\w+/.test(text) && /->/.test(text)) scores.php += 2;
+  if (/<\?php/.test(text)) scores.php += 4;
+  if (/\becho\b/.test(text) && /\$\w+/.test(text)) scores.php += 2;
+  if (/\b(function\s+\w+|class\s+\w+)\b/.test(text) && /\$\w+/.test(text)) scores.php += 2;
+
+  // Find the highest scoring language
+  let best = null;
+  let bestScore = 0;
+  for (const [lang, score] of Object.entries(scores)) {
+    if (score > bestScore) {
+      bestScore = score;
+      best = lang;
+    }
+  }
+
+  // Require a minimum score threshold for confident sub-type detection
+  return bestScore >= 3 ? best : null;
+}
+
+// ─── Error / stack trace detection ──────────────────────────────────────────
+
+function detectError(text) {
+  let signals = 0;
+
+  if (/\b(Error|Exception|TypeError|ReferenceError|SyntaxError|RangeError|ValueError|KeyError|RuntimeError|NullPointerException|IndexOutOfBoundsException)\b/.test(text)) signals += 2;
+  if (/\bTraceback\b.*\bcall\s+last\b/i.test(text)) signals += 3;
+  if (/\bat\s+[\w$.]+\s*\(.*:\d+:\d+\)/.test(text)) signals += 3;
+  if (/^\s+at\s+/m.test(text) && signals > 0) signals += 1;
+  if (/\b(FATAL|WARN|ERROR|SEVERE)\b.*\d{2,4}[:\-/]\d{2}/.test(text)) signals += 2;
+  if (/File\s+"[^"]+",\s+line\s+\d+/i.test(text)) signals += 3;
+  if (/\b(stack\s*trace|caused\s+by|exception\s+in)\b/i.test(text)) signals += 2;
+
+  if (signals >= 3) {
+    const confidence = Math.min(0.95, 0.6 + signals * 0.08);
+    return { confidence };
+  }
+  return null;
+}
+
+// ─── Math / formula detection ───────────────────────────────────────────────
+
+function detectMath(text) {
+  let signals = 0;
+
+  // LaTeX patterns
+  if (/\\(frac|sqrt|sum|int|prod|lim|infty|alpha|beta|gamma|delta|theta|pi|sigma|omega|partial|nabla)\b/.test(text)) signals += 3;
+  if (/\\\[.*\\\]/.test(text) || /\$\$.*\$\$/.test(text) || /\\\(.*\\\)/.test(text)) signals += 3;
+
+  // Mathematical operators and notation
+  if (/[=<>]\s*[+-]?\s*\d/.test(text) && /[+\-*/^]/.test(text) && /\d/.test(text)) {
+    // Check it looks formulaic, not just prose with numbers
+    const mathChars = (text.match(/[=+\-*/^()∑∏∫√≤≥≠±∞∂∇∈∉⊂⊃∪∩]/g) || []).length;
+    if (mathChars >= 3) signals += 2;
+  }
+
+  // Unicode math symbols
+  if (/[∑∏∫√≤≥≠±∞∂∇∈∉⊂⊃∪∩]/.test(text)) signals += 2;
+
+  // Equation-like patterns: x^2, f(x), etc.
+  if (/\b[a-z]\s*\^\s*\d/.test(text) || /\b[a-z]\s*\(\s*[a-z]\s*\)/.test(text)) signals += 1;
+
+  if (signals >= 3) {
+    const confidence = Math.min(0.9, 0.5 + signals * 0.1);
+    return { confidence };
+  }
+  return null;
+}
+
+// ─── List / structured data detection ───────────────────────────────────────
+
+function detectData(text) {
+  let signals = 0;
+
+  // JSON-like structure
+  if (/^\s*[\[{]/.test(text) && /[\]}]\s*$/.test(text)) {
+    if (/"\w+"\s*:/.test(text)) signals += 3;
+  }
+
+  // XML/HTML-like tags (not just a single tag, but structured data)
+  if (/<\w+>[\s\S]*<\/\w+>/.test(text) && (text.match(/<\w+>/g) || []).length >= 3) signals += 2;
+
+  // CSV patterns: multiple lines with consistent comma/tab separation
+  const lines = text.trim().split('\n');
+  if (lines.length >= 3) {
+    const commaLines = lines.filter(l => l.includes(','));
+    const tabLines = lines.filter(l => l.includes('\t'));
+    if (commaLines.length >= lines.length * 0.7) {
+      const fieldCounts = commaLines.map(l => l.split(',').length);
+      if (fieldCounts.length >= 2 && new Set(fieldCounts).size <= 2) signals += 3;
+    }
+    if (tabLines.length >= lines.length * 0.7) signals += 3;
+  }
+
+  // Numbered or bullet list patterns
+  const bulletLines = lines.filter(l => /^\s*(\d+[.)]\s|[-*+]\s|•\s)/.test(l));
+  if (bulletLines.length >= 3 && bulletLines.length >= lines.length * 0.5) signals += 3;
+
+  if (signals >= 3) {
+    const confidence = Math.min(0.9, 0.5 + signals * 0.1);
+    return { confidence };
+  }
+  return null;
+}
+
+// ─── Email / message detection ──────────────────────────────────────────────
+
+function detectEmail(text) {
+  let signals = 0;
+
+  if (/^(Subject|From|To|Cc|Bcc|Date):\s/m.test(text)) signals += 3;
+  if (/\b(Dear|Hi|Hello|Hey)\s+\w+/i.test(text) &&
+      /\b(Regards|Best|Thanks|Sincerely|Cheers)\b/i.test(text)) signals += 3;
+  if (/\b(Dear|Hi|Hello|Hey)\s+\w+/i.test(text) && wordCount(text) > 20) signals += 1;
+  if (/\b(reply|forward|attachment|attached)\b/i.test(text)) signals += 1;
+
+  if (signals >= 3) {
+    const confidence = Math.min(0.9, 0.5 + signals * 0.1);
+    return { confidence };
+  }
+  return null;
+}
+
+function wordCount(text) {
+  return text.trim() === '' ? 0 : text.trim().split(/\s+/).length;
+}
+
+// ─── Foreign language detection + sub-type ──────────────────────────────────
+
+function detectForeign(text) {
+  if (text.length === 0) return null;
 
   const nonLatinChars = (text.match(/[\u0400-\u04FF\u0600-\u06FF\u0900-\u097F\u0E00-\u0E7F\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF\uAC00-\uD7AF]/g) || []).length;
-  if (text.length > 0 && nonLatinChars / text.length > 0.3) {
-    return 'foreign';
+  if (nonLatinChars / text.length <= 0.3) return null;
+
+  const subType = detectNaturalLanguage(text);
+  const confidence = Math.min(0.95, 0.6 + (nonLatinChars / text.length) * 0.4);
+  return { subType, confidence };
+}
+
+function detectNaturalLanguage(text) {
+  // Count characters in each script range
+  const counts = {
+    japanese: (text.match(/[\u3040-\u309F\u30A0-\u30FF]/g) || []).length,
+    chinese: (text.match(/[\u4E00-\u9FFF]/g) || []).length,
+    korean: (text.match(/[\uAC00-\uD7AF]/g) || []).length,
+    arabic: (text.match(/[\u0600-\u06FF]/g) || []).length,
+    russian: (text.match(/[\u0400-\u04FF]/g) || []).length,
+    hindi: (text.match(/[\u0900-\u097F]/g) || []).length,
+    thai: (text.match(/[\u0E00-\u0E7F]/g) || []).length,
+  };
+
+  // Japanese: if hiragana/katakana present, it's Japanese even with CJK
+  if (counts.japanese > 0) return 'japanese';
+
+  // Find highest count among remaining
+  let best = null;
+  let bestCount = 0;
+  for (const [lang, count] of Object.entries(counts)) {
+    if (lang === 'japanese') continue;
+    if (count > bestCount) {
+      bestCount = count;
+      best = lang;
+    }
   }
 
-  const wordCount = text.trim().split(/\s+/).length;
-  if (wordCount > 200) {
-    return 'long';
-  }
-
-  return 'default';
+  return best;
 }
 
 // Export for testing (no-op in browser)
-if (typeof module !== 'undefined') module.exports = { detectContentType };
+if (typeof module !== 'undefined') module.exports = {
+  detectContentType,
+  detectCodeLanguage,
+  detectCodeHeuristics,
+  detectError,
+  detectMath,
+  detectData,
+  detectEmail,
+  detectForeign,
+  detectNaturalLanguage,
+};

--- a/popup.js
+++ b/popup.js
@@ -336,8 +336,14 @@ function showPopup(selectedText, anchorNode) {
   hidePopup();
   hideTrigger();
 
-  const contentType = detectContentType(selectedText, anchorNode);
-  const presetConfig = PRESETS[contentType];
+  const detection = detectContentType(selectedText, anchorNode);
+  const contentType = detection.type;
+  const subType = detection.subType;
+  const presetConfig = {
+    suggested: (typeof getSuggestedPresetsForType === 'function')
+      ? getSuggestedPresetsForType(contentType, subType)
+      : PRESETS[contentType].suggested,
+  };
 
   // Create container + shadow root
   popupContainer = document.createElement('div');
@@ -363,7 +369,7 @@ function showPopup(selectedText, anchorNode) {
   }
 
   // Build preset chip HTML
-  const allPresets = getAllPresetsForType(contentType);
+  const allPresets = getAllPresetsForType(contentType, subType);
 
   // Load saved preferences then render
   chrome.storage.local.get(['lastAI', 'pageContext'], (stored) => {

--- a/presets.js
+++ b/presets.js
@@ -1,11 +1,163 @@
 // Preset configurations per content type
-// Implemented by Engineer A
+// Enhanced in v1.1: sub-type-specific instructions + new content types
 
 /**
  * PRESETS - Maps content type to suggested and additional presets
  * COMMON_PRESETS - Shared presets available for all content types
- * getAllPresetsForType(contentType) - Returns merged preset list for a type
+ * getAllPresetsForType(contentType, subType) - Returns merged preset list for a type
+ * getSuggestedPresetsForType(contentType, subType) - Returns suggested presets (sub-type aware)
  */
+
+// Sub-type specific preset overrides for code
+const CODE_SUBTYPE_PRESETS = {
+  javascript: {
+    suggested: [
+      { label: 'Explain this JavaScript', instruction: 'Explain the following JavaScript code' },
+      { label: 'Debug this', instruction: 'Debug the following JavaScript code and identify any issues' },
+      { label: 'Convert to TypeScript', instruction: 'Convert the following JavaScript code to TypeScript' },
+    ],
+    all: [
+      { label: 'Add types', instruction: 'Add TypeScript type annotations to the following JavaScript code' },
+      { label: 'Write tests', instruction: 'Write unit tests for the following JavaScript code' },
+      { label: 'Optimize', instruction: 'Optimize the following JavaScript code' },
+    ]
+  },
+  python: {
+    suggested: [
+      { label: 'Explain this Python', instruction: 'Explain the following Python code' },
+      { label: 'Debug this', instruction: 'Debug the following Python code and identify any issues' },
+      { label: 'Add type hints', instruction: 'Add type hints to the following Python code' },
+    ],
+    all: [
+      { label: 'Write tests', instruction: 'Write unit tests for the following Python code' },
+      { label: 'Optimize', instruction: 'Optimize the following Python code' },
+      { label: 'Make Pythonic', instruction: 'Rewrite the following code to be more Pythonic' },
+    ]
+  },
+  rust: {
+    suggested: [
+      { label: 'Explain this Rust', instruction: 'Explain the following Rust code' },
+      { label: 'Debug this', instruction: 'Debug the following Rust code and identify any issues' },
+      { label: 'Optimize', instruction: 'Optimize the following Rust code' },
+    ],
+    all: [
+      { label: 'Write tests', instruction: 'Write unit tests for the following Rust code' },
+      { label: 'Add docs', instruction: 'Add documentation comments to the following Rust code' },
+    ]
+  },
+  go: {
+    suggested: [
+      { label: 'Explain this Go', instruction: 'Explain the following Go code' },
+      { label: 'Debug this', instruction: 'Debug the following Go code and identify any issues' },
+      { label: 'Optimize', instruction: 'Optimize the following Go code' },
+    ],
+    all: [
+      { label: 'Write tests', instruction: 'Write unit tests for the following Go code' },
+      { label: 'Add docs', instruction: 'Add GoDoc comments to the following Go code' },
+    ]
+  },
+  sql: {
+    suggested: [
+      { label: 'Explain this SQL', instruction: 'Explain the following SQL query' },
+      { label: 'Optimize query', instruction: 'Optimize the following SQL query for performance' },
+      { label: 'Debug this', instruction: 'Debug the following SQL and identify any issues' },
+    ],
+    all: [
+      { label: 'Add indexes', instruction: 'Suggest indexes for the following SQL query' },
+      { label: 'Convert to...', instruction: 'Convert the following SQL to' },
+    ]
+  },
+  java: {
+    suggested: [
+      { label: 'Explain this Java', instruction: 'Explain the following Java code' },
+      { label: 'Debug this', instruction: 'Debug the following Java code and identify any issues' },
+      { label: 'Optimize', instruction: 'Optimize the following Java code' },
+    ],
+    all: [
+      { label: 'Write tests', instruction: 'Write unit tests for the following Java code' },
+      { label: 'Add Javadoc', instruction: 'Add Javadoc comments to the following Java code' },
+    ]
+  },
+  'c/c++': {
+    suggested: [
+      { label: 'Explain this C/C++', instruction: 'Explain the following C/C++ code' },
+      { label: 'Debug this', instruction: 'Debug the following C/C++ code and identify any issues' },
+      { label: 'Find memory issues', instruction: 'Check the following C/C++ code for memory leaks and safety issues' },
+    ],
+    all: [
+      { label: 'Write tests', instruction: 'Write unit tests for the following C/C++ code' },
+      { label: 'Optimize', instruction: 'Optimize the following C/C++ code' },
+    ]
+  },
+  ruby: {
+    suggested: [
+      { label: 'Explain this Ruby', instruction: 'Explain the following Ruby code' },
+      { label: 'Debug this', instruction: 'Debug the following Ruby code and identify any issues' },
+      { label: 'Optimize', instruction: 'Optimize the following Ruby code' },
+    ],
+    all: [
+      { label: 'Write tests', instruction: 'Write RSpec tests for the following Ruby code' },
+      { label: 'Make idiomatic', instruction: 'Rewrite the following to be more idiomatic Ruby' },
+    ]
+  },
+  php: {
+    suggested: [
+      { label: 'Explain this PHP', instruction: 'Explain the following PHP code' },
+      { label: 'Debug this', instruction: 'Debug the following PHP code and identify any issues' },
+      { label: 'Optimize', instruction: 'Optimize the following PHP code' },
+    ],
+    all: [
+      { label: 'Write tests', instruction: 'Write PHPUnit tests for the following PHP code' },
+      { label: 'Add types', instruction: 'Add type declarations to the following PHP code' },
+    ]
+  },
+};
+
+// Sub-type specific preset overrides for foreign languages
+const FOREIGN_SUBTYPE_PRESETS = {
+  japanese: {
+    suggested: [
+      { label: 'Translate from Japanese', instruction: 'Translate the following Japanese text to English' },
+      { label: 'Explain', instruction: 'Explain the following Japanese text' },
+    ],
+  },
+  chinese: {
+    suggested: [
+      { label: 'Translate from Chinese', instruction: 'Translate the following Chinese text to English' },
+      { label: 'Explain', instruction: 'Explain the following Chinese text' },
+    ],
+  },
+  korean: {
+    suggested: [
+      { label: 'Translate from Korean', instruction: 'Translate the following Korean text to English' },
+      { label: 'Explain', instruction: 'Explain the following Korean text' },
+    ],
+  },
+  arabic: {
+    suggested: [
+      { label: 'Translate from Arabic', instruction: 'Translate the following Arabic text to English' },
+      { label: 'Explain', instruction: 'Explain the following Arabic text' },
+    ],
+  },
+  russian: {
+    suggested: [
+      { label: 'Translate from Russian', instruction: 'Translate the following Russian text to English' },
+      { label: 'Explain', instruction: 'Explain the following Russian text' },
+    ],
+  },
+  hindi: {
+    suggested: [
+      { label: 'Translate from Hindi', instruction: 'Translate the following Hindi text to English' },
+      { label: 'Explain', instruction: 'Explain the following Hindi text' },
+    ],
+  },
+  thai: {
+    suggested: [
+      { label: 'Translate from Thai', instruction: 'Translate the following Thai text to English' },
+      { label: 'Explain', instruction: 'Explain the following Thai text' },
+    ],
+  },
+};
 
 const PRESETS = {
   code: {
@@ -26,6 +178,46 @@ const PRESETS = {
       { label: 'Explain', instruction: 'Explain the following text' },
     ],
     all: []
+  },
+  error: {
+    suggested: [
+      { label: 'Explain error', instruction: 'Explain the following error and what caused it' },
+      { label: 'Suggest fix', instruction: 'Suggest a fix for the following error' },
+      { label: 'Find root cause', instruction: 'Analyze the following error and find the root cause' },
+    ],
+    all: [
+      { label: 'Simplify message', instruction: 'Explain this error message in simple terms' },
+    ]
+  },
+  email: {
+    suggested: [
+      { label: 'Draft reply', instruction: 'Draft a professional reply to the following email' },
+      { label: 'Summarize email', instruction: 'Summarize the following email' },
+      { label: 'Make professional', instruction: 'Rewrite the following email more professionally' },
+    ],
+    all: [
+      { label: 'Extract action items', instruction: 'Extract action items from the following email' },
+    ]
+  },
+  data: {
+    suggested: [
+      { label: 'Analyze data', instruction: 'Analyze the following data' },
+      { label: 'Convert to table', instruction: 'Convert the following data to a formatted table' },
+      { label: 'Summarize items', instruction: 'Summarize the following items' },
+    ],
+    all: [
+      { label: 'Find patterns', instruction: 'Find patterns in the following data' },
+    ]
+  },
+  math: {
+    suggested: [
+      { label: 'Explain formula', instruction: 'Explain the following formula or equation' },
+      { label: 'Solve this', instruction: 'Solve the following mathematical problem' },
+      { label: 'Simplify', instruction: 'Simplify the following mathematical expression' },
+    ],
+    all: [
+      { label: 'Step by step', instruction: 'Solve the following step by step' },
+    ]
   },
   long: {
     suggested: [
@@ -52,10 +244,41 @@ const COMMON_PRESETS = [
   { label: 'Key points', instruction: 'Extract the key points from the following' },
 ];
 
-function getAllPresetsForType(contentType) {
-  const typeAll = PRESETS[contentType].all || [];
+/**
+ * Returns suggested presets, using sub-type-specific ones when available.
+ * @param {string} contentType
+ * @param {string|null} subType
+ * @returns {Array<{label: string, instruction: string}>}
+ */
+function getSuggestedPresetsForType(contentType, subType) {
+  if (subType && contentType === 'code' && CODE_SUBTYPE_PRESETS[subType]) {
+    return CODE_SUBTYPE_PRESETS[subType].suggested;
+  }
+  if (subType && contentType === 'foreign' && FOREIGN_SUBTYPE_PRESETS[subType]) {
+    return FOREIGN_SUBTYPE_PRESETS[subType].suggested;
+  }
+  return PRESETS[contentType].suggested;
+}
+
+/**
+ * Returns all presets (type-specific + common) for a given content type and sub-type.
+ * Deduplicates common presets against suggested and type-specific all presets.
+ * @param {string} contentType
+ * @param {string|null} [subType]
+ * @returns {Array<{label: string, instruction: string}>}
+ */
+function getAllPresetsForType(contentType, subType) {
+  const suggested = getSuggestedPresetsForType(contentType, subType || null);
+
+  let typeAll;
+  if (subType && contentType === 'code' && CODE_SUBTYPE_PRESETS[subType]) {
+    typeAll = CODE_SUBTYPE_PRESETS[subType].all || [];
+  } else {
+    typeAll = PRESETS[contentType].all || [];
+  }
+
   const labels = new Set([
-    ...PRESETS[contentType].suggested.map(p => p.label),
+    ...suggested.map(p => p.label),
     ...typeAll.map(p => p.label),
   ]);
   const common = COMMON_PRESETS.filter(p => !labels.has(p.label));
@@ -63,4 +286,11 @@ function getAllPresetsForType(contentType) {
 }
 
 // Export for testing (no-op in browser)
-if (typeof module !== 'undefined') module.exports = { PRESETS, COMMON_PRESETS, getAllPresetsForType };
+if (typeof module !== 'undefined') module.exports = {
+  PRESETS,
+  COMMON_PRESETS,
+  CODE_SUBTYPE_PRESETS,
+  FOREIGN_SUBTYPE_PRESETS,
+  getAllPresetsForType,
+  getSuggestedPresetsForType,
+};

--- a/tests/detection.test.js
+++ b/tests/detection.test.js
@@ -1,13 +1,55 @@
-import { detectContentType } from '../detection.js';
+import {
+  detectContentType,
+  detectCodeLanguage,
+  detectError,
+  detectMath,
+  detectData,
+  detectEmail,
+  detectForeign,
+  detectNaturalLanguage,
+} from '../detection.js';
 
 describe('detectContentType', () => {
+  // Helper: returns just the type string for backward-compat style assertions
+  const detectType = (text, node) => detectContentType(text, node).type;
+
+  describe('return format', () => {
+    it('returns a rich object with type, subType, confidence, wordCount, charCount', () => {
+      const result = detectContentType('hello world', null);
+      expect(result).toHaveProperty('type');
+      expect(result).toHaveProperty('subType');
+      expect(result).toHaveProperty('confidence');
+      expect(result).toHaveProperty('wordCount');
+      expect(result).toHaveProperty('charCount');
+    });
+
+    it('confidence is between 0 and 1', () => {
+      const result = detectContentType('hello world', null);
+      expect(result.confidence).toBeGreaterThan(0);
+      expect(result.confidence).toBeLessThanOrEqual(1);
+    });
+
+    it('wordCount and charCount are correct', () => {
+      const text = 'hello world foo';
+      const result = detectContentType(text, null);
+      expect(result.wordCount).toBe(3);
+      expect(result.charCount).toBe(text.length);
+    });
+
+    it('wordCount is 0 for empty string', () => {
+      const result = detectContentType('', null);
+      expect(result.wordCount).toBe(0);
+      expect(result.charCount).toBe(0);
+    });
+  });
+
   describe('code detection', () => {
     it('detects JavaScript code with braces and semicolons', () => {
       const text = `function hello() {
   const x = 1;
   return x;
 }`;
-      expect(detectContentType(text, null)).toBe('code');
+      expect(detectType(text, null)).toBe('code');
     });
 
     it('detects JavaScript code with braces and multiple keywords', () => {
@@ -15,14 +57,14 @@ describe('detectContentType', () => {
   const result = transform(x)
   return result
 }`;
-      expect(detectContentType(text, null)).toBe('code');
+      expect(detectType(text, null)).toBe('code');
     });
 
     it('detects Python code with indentation, semicolons, and keywords', () => {
       const text = `  def process(data):
     import json;
     return json.loads(data)`;
-      expect(detectContentType(text, null)).toBe('code');
+      expect(detectType(text, null)).toBe('code');
     });
 
     it('detects code with class definition and braces', () => {
@@ -31,7 +73,7 @@ describe('detectContentType', () => {
     this.state = {};
   }
 }`;
-      expect(detectContentType(text, null)).toBe('code');
+      expect(detectType(text, null)).toBe('code');
     });
 
     it('detects code when anchorNode is inside <pre> tag', () => {
@@ -42,7 +84,7 @@ describe('detectContentType', () => {
           parentElement: null
         }
       };
-      expect(detectContentType('any text here', anchorNode)).toBe('code');
+      expect(detectType('any text here', anchorNode)).toBe('code');
     });
 
     it('detects code when anchorNode is inside <code> tag', () => {
@@ -50,7 +92,7 @@ describe('detectContentType', () => {
         nodeName: 'CODE',
         parentElement: null
       };
-      expect(detectContentType('plain text', anchorNode)).toBe('code');
+      expect(detectType('plain text', anchorNode)).toBe('code');
     });
 
     it('detects code when anchorNode is nested inside <code> within other elements', () => {
@@ -64,106 +106,363 @@ describe('detectContentType', () => {
           }
         }
       };
-      expect(detectContentType('hello world', anchorNode)).toBe('code');
+      expect(detectType('hello world', anchorNode)).toBe('code');
+    });
+
+    it('returns high confidence for code inside <pre> tag', () => {
+      const anchorNode = { nodeName: 'PRE', parentElement: null };
+      const result = detectContentType('any text', anchorNode);
+      expect(result.confidence).toBe(0.95);
     });
 
     it('detects braceless JavaScript code with semicolons and keywords', () => {
       const text = 'const x = [1,4]; console.log(x);';
-      expect(detectContentType(text, null)).toBe('code');
+      expect(detectType(text, null)).toBe('code');
     });
 
     it('detects braceless multi-statement code', () => {
       const text = 'let a = 10; let b = 20; return a + b;';
-      expect(detectContentType(text, null)).toBe('code');
+      expect(detectType(text, null)).toBe('code');
     });
 
     it('detects braceless code with var and import keywords', () => {
       const text = 'import fs from "fs"; var data = fs.readFileSync("file.txt");';
-      expect(detectContentType(text, null)).toBe('code');
+      expect(detectType(text, null)).toBe('code');
     });
 
     it('does NOT falsely detect prose that mentions programming terms', () => {
       const text = 'The function of this committee is to review import regulations and export policies.';
-      expect(detectContentType(text, null)).not.toBe('code');
+      expect(detectType(text, null)).not.toBe('code');
     });
 
     it('does NOT detect text with a single code keyword as code', () => {
       const text = 'We should let the team know about the function schedule.';
-      expect(detectContentType(text, null)).not.toBe('code');
+      expect(detectType(text, null)).not.toBe('code');
+    });
+  });
+
+  describe('code language sub-type detection', () => {
+    it('detects JavaScript sub-type for console.log code', () => {
+      const text = `const x = 42;
+console.log(x);`;
+      const result = detectContentType(text, null);
+      expect(result.type).toBe('code');
+      expect(result.subType).toBe('javascript');
+    });
+
+    it('detects Python sub-type for def/self code', () => {
+      const text = `def greet(self):
+    print("hello")
+    self.name = "test"`;
+      const result = detectContentType(text, null);
+      expect(result.type).toBe('code');
+      expect(result.subType).toBe('python');
+    });
+
+    it('detects Rust sub-type for fn/let mut code', () => {
+      const text = `fn main() {
+    let mut x = 5;
+    println!("Value: {}", x);
+}`;
+      const result = detectContentType(text, null);
+      expect(result.type).toBe('code');
+      expect(result.subType).toBe('rust');
+    });
+
+    it('detects Go sub-type for func/fmt code', () => {
+      const text = `func main() {
+    fmt.Println("hello")
+    x := 42
+}`;
+      const result = detectContentType(text, null);
+      expect(result.type).toBe('code');
+      expect(result.subType).toBe('go');
+    });
+
+    it('detects SQL sub-type for SELECT/FROM query', () => {
+      const text = `SELECT name, age FROM users WHERE age > 18 ORDER BY name;`;
+      const result = detectContentType(text, null);
+      expect(result.type).toBe('code');
+      expect(result.subType).toBe('sql');
+    });
+
+    it('detects Java sub-type for public static void code', () => {
+      const text = `public static void main(String[] args) {
+    System.out.println("Hello");
+}`;
+      const result = detectContentType(text, null);
+      expect(result.type).toBe('code');
+      expect(result.subType).toBe('java');
+    });
+
+    it('detects C/C++ sub-type for #include/printf code', () => {
+      const text = `#include <stdio.h>
+int main() {
+    printf("hello world");
+    return 0;
+}`;
+      const result = detectContentType(text, null);
+      expect(result.type).toBe('code');
+      expect(result.subType).toBe('c/c++');
+    });
+
+    it('detects Ruby sub-type for do/end blocks', () => {
+      const text = `class Greeter
+  def greet
+    puts "hello"
+  end
+end`;
+      const result = detectContentType(text, null);
+      expect(result.type).toBe('code');
+      expect(result.subType).toBe('ruby');
+    });
+
+    it('detects PHP sub-type for <?php code', () => {
+      const text = `<?php
+function greet($name) {
+    echo "Hello, " . $name;
+}`;
+      const result = detectContentType(text, null);
+      expect(result.type).toBe('code');
+      expect(result.subType).toBe('php');
+    });
+
+    it('returns null sub-type for ambiguous code', () => {
+      const text = `if (x > 0) {
+  return true;
+}`;
+      const result = detectContentType(text, null);
+      expect(result.type).toBe('code');
+      // subType may be null if no language scores high enough
+    });
+  });
+
+  describe('error/stack trace detection', () => {
+    it('detects JavaScript stack trace', () => {
+      const text = `TypeError: Cannot read property 'name' of undefined
+    at Object.getName (app.js:12:5)
+    at main (index.js:4:10)`;
+      expect(detectType(text, null)).toBe('error');
+    });
+
+    it('detects Python traceback', () => {
+      const text = `Traceback (most recent call last):
+  File "main.py", line 10, in <module>
+    result = process(data)
+ValueError: invalid literal`;
+      expect(detectType(text, null)).toBe('error');
+    });
+
+    it('detects Java exception with stack trace', () => {
+      const text = `NullPointerException: Cannot invoke method on null object
+    at com.example.App.run(App.java:15)
+    at com.example.Main.main(Main.java:8)`;
+      expect(detectType(text, null)).toBe('error');
+    });
+
+    it('detects log-style error with timestamp', () => {
+      const text = `ERROR 2024-01-15 10:23:45 - Connection refused
+FATAL 2024-01-15 10:23:46 - Application shutting down
+Caused by: java.net.ConnectException`;
+      expect(detectType(text, null)).toBe('error');
+    });
+
+    it('does NOT detect text that merely mentions the word error', () => {
+      const text = 'The error rate in our system has decreased significantly over the past month.';
+      expect(detectType(text, null)).not.toBe('error');
+    });
+  });
+
+  describe('math/formula detection', () => {
+    it('detects LaTeX formula', () => {
+      const text = '\\frac{a}{b} + \\sqrt{c^2 + d^2} = \\sum_{i=1}^{n} x_i';
+      expect(detectType(text, null)).toBe('math');
+    });
+
+    it('detects unicode math symbols', () => {
+      const text = 'f(x) = ∑ aᵢxⁱ, where ∫ f(x)dx = ∞';
+      expect(detectType(text, null)).toBe('math');
+    });
+
+    it('detects display math with $$', () => {
+      const text = '$$E = mc^2$$ and \\frac{1}{2}mv^2';
+      expect(detectType(text, null)).toBe('math');
+    });
+
+    it('does NOT detect simple arithmetic in prose', () => {
+      const text = 'The price is $5 and the quantity is 10.';
+      expect(detectType(text, null)).not.toBe('math');
+    });
+  });
+
+  describe('list/structured data detection', () => {
+    it('detects CSV data', () => {
+      const text = `name,age,city
+Alice,30,NYC
+Bob,25,LA
+Carol,28,SF`;
+      expect(detectType(text, null)).toBe('data');
+    });
+
+    it('detects JSON-like structure', () => {
+      const text = `{
+  "name": "Alice",
+  "age": 30,
+  "city": "NYC"
+}`;
+      expect(detectType(text, null)).toBe('data');
+    });
+
+    it('detects tab-separated values', () => {
+      const text = "name\tage\tcity\nAlice\t30\tNYC\nBob\t25\tLA\nCarol\t28\tSF";
+      expect(detectType(text, null)).toBe('data');
+    });
+
+    it('detects bullet lists', () => {
+      const text = `- First item here
+- Second item here
+- Third item here
+- Fourth item here`;
+      expect(detectType(text, null)).toBe('data');
+    });
+
+    it('does NOT detect a single line of text as data', () => {
+      const text = 'Just a simple sentence with no structure.';
+      expect(detectType(text, null)).not.toBe('data');
+    });
+  });
+
+  describe('email/message detection', () => {
+    it('detects email with headers', () => {
+      const text = `Subject: Meeting tomorrow
+From: alice@example.com
+To: bob@example.com
+
+Hi Bob, let's meet at 3pm. Best regards, Alice`;
+      expect(detectType(text, null)).toBe('email');
+    });
+
+    it('detects email with greeting and sign-off', () => {
+      const text = `Dear John,
+
+I hope this message finds you well. I wanted to follow up on our conversation regarding the project timeline. Please let me know if you have any questions.
+
+Best regards,
+Alice`;
+      expect(detectType(text, null)).toBe('email');
+    });
+
+    it('does NOT detect casual text as email', () => {
+      const text = 'Hello world, this is just a test.';
+      expect(detectType(text, null)).not.toBe('email');
     });
   });
 
   describe('foreign language detection', () => {
     it('detects Chinese text as foreign', () => {
       const text = '这是一段中文文本，用于测试外语检测功能。';
-      expect(detectContentType(text, null)).toBe('foreign');
+      expect(detectType(text, null)).toBe('foreign');
     });
 
-    it('detects Japanese text as foreign', () => {
+    it('detects Japanese text as foreign with japanese sub-type', () => {
       const text = 'これは日本語のテストテキストです。外国語の検出をテストします。';
-      expect(detectContentType(text, null)).toBe('foreign');
+      const result = detectContentType(text, null);
+      expect(result.type).toBe('foreign');
+      expect(result.subType).toBe('japanese');
     });
 
-    it('detects Arabic text as foreign', () => {
+    it('detects Arabic text as foreign with arabic sub-type', () => {
       const text = 'هذا نص عربي لاختبار كشف اللغة الأجنبية في النظام';
-      expect(detectContentType(text, null)).toBe('foreign');
+      const result = detectContentType(text, null);
+      expect(result.type).toBe('foreign');
+      expect(result.subType).toBe('arabic');
     });
 
-    it('detects Korean text as foreign', () => {
+    it('detects Korean text as foreign with korean sub-type', () => {
       const text = '이것은 한국어 테스트 텍스트입니다. 외국어 감지를 테스트합니다.';
-      expect(detectContentType(text, null)).toBe('foreign');
+      const result = detectContentType(text, null);
+      expect(result.type).toBe('foreign');
+      expect(result.subType).toBe('korean');
+    });
+
+    it('detects Chinese text with chinese sub-type', () => {
+      const text = '这是一段中文文本用于测试。';
+      const result = detectContentType(text, null);
+      expect(result.type).toBe('foreign');
+      expect(result.subType).toBe('chinese');
+    });
+
+    it('detects Russian text with russian sub-type', () => {
+      const text = 'Это текст на русском языке для тестирования системы обнаружения.';
+      const result = detectContentType(text, null);
+      expect(result.type).toBe('foreign');
+      expect(result.subType).toBe('russian');
+    });
+
+    it('detects Hindi text with hindi sub-type', () => {
+      const text = 'यह हिंदी में एक परीक्षण पाठ है जो भाषा का पता लगाने के लिए है।';
+      const result = detectContentType(text, null);
+      expect(result.type).toBe('foreign');
+      expect(result.subType).toBe('hindi');
+    });
+
+    it('detects Thai text with thai sub-type', () => {
+      const text = 'นี่คือข้อความทดสอบภาษาไทยสำหรับระบบตรวจจับภาษา';
+      const result = detectContentType(text, null);
+      expect(result.type).toBe('foreign');
+      expect(result.subType).toBe('thai');
     });
 
     it('does NOT detect accented Latin text (French) as foreign', () => {
       const text = "L'apprentissage automatique est une branche de l'intelligence artificielle qui permet aux systemes d'apprendre.";
-      expect(detectContentType(text, null)).not.toBe('foreign');
+      expect(detectType(text, null)).not.toBe('foreign');
     });
 
     it('does NOT detect emoji-heavy text as foreign', () => {
       const text = 'Hello world! This is a great day! Feeling happy and excited about the new project launch!';
-      expect(detectContentType(text, null)).not.toBe('foreign');
+      expect(detectType(text, null)).not.toBe('foreign');
     });
 
     it('does NOT detect mixed English with a few non-Latin characters as foreign', () => {
       const text = 'The word for hello in Japanese is konnichiwa (こんにちは), which is a common greeting used during the day.';
-      expect(detectContentType(text, null)).not.toBe('foreign');
+      expect(detectType(text, null)).not.toBe('foreign');
     });
   });
 
   describe('long text detection', () => {
     it('detects text with more than 200 words as long', () => {
       const words = Array(201).fill('word').join(' ');
-      expect(detectContentType(words, null)).toBe('long');
+      expect(detectType(words, null)).toBe('long');
     });
 
     it('does NOT detect text with exactly 200 words as long', () => {
       const words = Array(200).fill('word').join(' ');
-      expect(detectContentType(words, null)).not.toBe('long');
+      expect(detectType(words, null)).not.toBe('long');
     });
 
     it('detects a realistic long paragraph as long', () => {
       const sentences = Array(30).fill('This is a sentence with several words in it to test length detection.').join(' ');
-      expect(detectContentType(sentences, null)).toBe('long');
+      expect(detectType(sentences, null)).toBe('long');
     });
   });
 
   describe('default detection', () => {
     it('returns default for short English text', () => {
       const text = 'This is a simple sentence.';
-      expect(detectContentType(text, null)).toBe('default');
+      expect(detectType(text, null)).toBe('default');
     });
 
     it('returns default for a moderate English paragraph', () => {
       const text = 'The quick brown fox jumps over the lazy dog. This is a well-known English pangram that contains every letter of the alphabet.';
-      expect(detectContentType(text, null)).toBe('default');
+      expect(detectType(text, null)).toBe('default');
     });
 
     it('returns default for empty text', () => {
-      expect(detectContentType('', null)).toBe('default');
+      expect(detectType('', null)).toBe('default');
     });
 
     it('returns default for a single word', () => {
-      expect(detectContentType('hello', null)).toBe('default');
+      expect(detectType('hello', null)).toBe('default');
     });
   });
 
@@ -173,7 +472,7 @@ describe('detectContentType', () => {
   // 你好世界
   console.log("hello");
 }`;
-      expect(detectContentType(text, null)).toBe('code');
+      expect(detectType(text, null)).toBe('code');
     });
 
     it('prioritizes anchorNode code detection over everything', () => {
@@ -181,7 +480,125 @@ describe('detectContentType', () => {
         nodeName: 'CODE',
         parentElement: null
       };
-      expect(detectContentType('这是中文文本', anchorNode)).toBe('code');
+      expect(detectType('这是中文文本', anchorNode)).toBe('code');
     });
+
+    it('prioritizes code over error for code that contains Error keyword', () => {
+      const text = `function handleError() {
+  throw new TypeError("invalid");
+}`;
+      expect(detectType(text, null)).toBe('code');
+    });
+
+    it('prioritizes error over email for error messages with greeting-like text', () => {
+      const text = `Dear developer,
+
+Error: Connection refused
+    at connect (net.js:12:5)
+Caused by: ECONNREFUSED
+
+Best regards, Error Handler`;
+      // Has email signals but error signals are stronger and higher priority
+      expect(detectType(text, null)).toBe('error');
+    });
+  });
+});
+
+describe('detectCodeLanguage', () => {
+  it('returns null for ambiguous code', () => {
+    expect(detectCodeLanguage('x = 1')).toBeNull();
+  });
+
+  it('detects javascript for arrow functions', () => {
+    expect(detectCodeLanguage('const fn = () => { return 42; }')).toBe('javascript');
+  });
+
+  it('detects python for elif keyword', () => {
+    expect(detectCodeLanguage('if x:\n  pass\nelif y:\n  pass')).toBe('python');
+  });
+
+  it('detects sql for SELECT FROM WHERE', () => {
+    expect(detectCodeLanguage('SELECT id FROM users WHERE active = true')).toBe('sql');
+  });
+});
+
+describe('detectNaturalLanguage', () => {
+  it('detects japanese when hiragana present', () => {
+    expect(detectNaturalLanguage('テスト文章です')).toBe('japanese');
+  });
+
+  it('detects korean for hangul text', () => {
+    expect(detectNaturalLanguage('한국어 텍스트')).toBe('korean');
+  });
+
+  it('detects arabic for arabic script', () => {
+    expect(detectNaturalLanguage('نص عربي')).toBe('arabic');
+  });
+
+  it('detects russian for cyrillic text', () => {
+    expect(detectNaturalLanguage('Русский текст')).toBe('russian');
+  });
+});
+
+describe('detectError', () => {
+  it('returns null for normal text', () => {
+    expect(detectError('This is fine')).toBeNull();
+  });
+
+  it('detects stack trace with at lines', () => {
+    const result = detectError(`TypeError: undefined is not a function
+    at Object.run (app.js:5:3)
+    at main (index.js:1:1)`);
+    expect(result).not.toBeNull();
+    expect(result.confidence).toBeGreaterThan(0.5);
+  });
+});
+
+describe('detectMath', () => {
+  it('returns null for normal text', () => {
+    expect(detectMath('Hello world')).toBeNull();
+  });
+
+  it('detects LaTeX commands', () => {
+    const result = detectMath('\\frac{1}{2} + \\sqrt{4} = \\sum x');
+    expect(result).not.toBeNull();
+  });
+});
+
+describe('detectData', () => {
+  it('returns null for simple text', () => {
+    expect(detectData('Hello world')).toBeNull();
+  });
+
+  it('detects CSV with consistent columns', () => {
+    const result = detectData('a,b,c\n1,2,3\n4,5,6\n7,8,9');
+    expect(result).not.toBeNull();
+  });
+});
+
+describe('detectEmail', () => {
+  it('returns null for normal text', () => {
+    expect(detectEmail('Just a sentence.')).toBeNull();
+  });
+
+  it('detects email with Subject header', () => {
+    const result = detectEmail('Subject: Hello\nFrom: test@test.com\nDear friend,\nBest regards');
+    expect(result).not.toBeNull();
+  });
+});
+
+describe('detectForeign', () => {
+  it('returns null for empty text', () => {
+    expect(detectForeign('')).toBeNull();
+  });
+
+  it('returns null for Latin text', () => {
+    expect(detectForeign('Hello world')).toBeNull();
+  });
+
+  it('returns object with subType for CJK text', () => {
+    const result = detectForeign('这是中文文本测试内容');
+    expect(result).not.toBeNull();
+    expect(result.subType).toBe('chinese');
   });
 });

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -16,7 +16,7 @@ globalThis.chrome = {
 };
 
 // Mock dependencies that popup.js expects in global scope
-globalThis.detectContentType = vi.fn(() => 'default');
+globalThis.detectContentType = vi.fn(() => ({ type: 'default', subType: null, confidence: 1.0, wordCount: 2, charCount: 10 }));
 globalThis.PRESETS = {
   code: {
     suggested: [
@@ -60,7 +60,10 @@ globalThis.COMMON_PRESETS = [
   { label: 'Expand', instruction: 'Expand on the following' },
   { label: 'Key points', instruction: 'Extract the key points from the following' },
 ];
-globalThis.getAllPresetsForType = vi.fn((contentType) => {
+globalThis.getSuggestedPresetsForType = vi.fn((contentType, subType) => {
+  return PRESETS[contentType].suggested;
+});
+globalThis.getAllPresetsForType = vi.fn((contentType, subType) => {
   const typeAll = PRESETS[contentType].all || [];
   const labels = new Set([
     ...PRESETS[contentType].suggested.map(p => p.label),
@@ -159,7 +162,7 @@ describe('showPopup and hidePopup', () => {
     vi.clearAllMocks();
     // Reset chrome storage mock to return defaults
     chrome.storage.local.get.mockImplementation((keys, cb) => cb({}));
-    detectContentType.mockReturnValue('default');
+    detectContentType.mockReturnValue({ type: 'default', subType: null, confidence: 1.0, wordCount: 2, charCount: 10 });
   });
 
   afterEach(() => {
@@ -223,15 +226,15 @@ describe('showPopup and hidePopup', () => {
   });
 
   it('uses code presets when detectContentType returns code', () => {
-    detectContentType.mockReturnValue('code');
+    detectContentType.mockReturnValue({ type: 'code', subType: 'javascript', confidence: 0.9, wordCount: 3, charCount: 20 });
     showPopup('function test() {}', null);
-    expect(getAllPresetsForType).toHaveBeenCalledWith('code');
+    expect(getAllPresetsForType).toHaveBeenCalledWith('code', 'javascript');
   });
 
   it('uses foreign presets when detectContentType returns foreign', () => {
-    detectContentType.mockReturnValue('foreign');
+    detectContentType.mockReturnValue({ type: 'foreign', subType: 'japanese', confidence: 0.85, wordCount: 3, charCount: 17 });
     showPopup('some foreign text', null);
-    expect(getAllPresetsForType).toHaveBeenCalledWith('foreign');
+    expect(getAllPresetsForType).toHaveBeenCalledWith('foreign', 'japanese');
   });
 });
 

--- a/tests/presets.test.js
+++ b/tests/presets.test.js
@@ -1,9 +1,16 @@
-import { PRESETS, COMMON_PRESETS, getAllPresetsForType } from '../presets.js';
+import {
+  PRESETS,
+  COMMON_PRESETS,
+  CODE_SUBTYPE_PRESETS,
+  FOREIGN_SUBTYPE_PRESETS,
+  getAllPresetsForType,
+  getSuggestedPresetsForType,
+} from '../presets.js';
 
 describe('PRESETS structure', () => {
-  const expectedTypes = ['code', 'foreign', 'long', 'default'];
+  const expectedTypes = ['code', 'foreign', 'error', 'email', 'data', 'math', 'long', 'default'];
 
-  it('has all four content types', () => {
+  it('has all eight content types', () => {
     for (const type of expectedTypes) {
       expect(PRESETS[type]).toBeDefined();
     }
@@ -50,6 +57,92 @@ describe('COMMON_PRESETS', () => {
   });
 });
 
+describe('CODE_SUBTYPE_PRESETS', () => {
+  const languages = ['javascript', 'python', 'rust', 'go', 'sql', 'java', 'c/c++', 'ruby', 'php'];
+
+  it('has presets for all supported programming languages', () => {
+    for (const lang of languages) {
+      expect(CODE_SUBTYPE_PRESETS[lang]).toBeDefined();
+      expect(CODE_SUBTYPE_PRESETS[lang].suggested.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every sub-type preset has label and instruction strings', () => {
+    for (const lang of languages) {
+      const presets = [
+        ...CODE_SUBTYPE_PRESETS[lang].suggested,
+        ...(CODE_SUBTYPE_PRESETS[lang].all || []),
+      ];
+      for (const preset of presets) {
+        expect(typeof preset.label).toBe('string');
+        expect(typeof preset.instruction).toBe('string');
+      }
+    }
+  });
+
+  it('JavaScript presets reference JavaScript in instructions', () => {
+    const jsPresets = CODE_SUBTYPE_PRESETS.javascript.suggested;
+    expect(jsPresets.some(p => p.instruction.includes('JavaScript'))).toBe(true);
+  });
+
+  it('Python presets reference Python in instructions', () => {
+    const pyPresets = CODE_SUBTYPE_PRESETS.python.suggested;
+    expect(pyPresets.some(p => p.instruction.includes('Python'))).toBe(true);
+  });
+});
+
+describe('FOREIGN_SUBTYPE_PRESETS', () => {
+  const languages = ['japanese', 'chinese', 'korean', 'arabic', 'russian', 'hindi', 'thai'];
+
+  it('has presets for all supported natural languages', () => {
+    for (const lang of languages) {
+      expect(FOREIGN_SUBTYPE_PRESETS[lang]).toBeDefined();
+      expect(FOREIGN_SUBTYPE_PRESETS[lang].suggested.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('each language has a translate preset mentioning the language name', () => {
+    for (const lang of languages) {
+      const suggested = FOREIGN_SUBTYPE_PRESETS[lang].suggested;
+      const capitalize = lang.charAt(0).toUpperCase() + lang.slice(1);
+      const hasTranslate = suggested.some(p => p.instruction.includes(capitalize));
+      expect(hasTranslate).toBe(true);
+    }
+  });
+});
+
+describe('getSuggestedPresetsForType', () => {
+  it('returns generic code presets when subType is null', () => {
+    const result = getSuggestedPresetsForType('code', null);
+    expect(result).toEqual(PRESETS.code.suggested);
+  });
+
+  it('returns JavaScript-specific presets for code/javascript', () => {
+    const result = getSuggestedPresetsForType('code', 'javascript');
+    expect(result).toEqual(CODE_SUBTYPE_PRESETS.javascript.suggested);
+  });
+
+  it('returns Python-specific presets for code/python', () => {
+    const result = getSuggestedPresetsForType('code', 'python');
+    expect(result).toEqual(CODE_SUBTYPE_PRESETS.python.suggested);
+  });
+
+  it('returns Japanese-specific presets for foreign/japanese', () => {
+    const result = getSuggestedPresetsForType('foreign', 'japanese');
+    expect(result).toEqual(FOREIGN_SUBTYPE_PRESETS.japanese.suggested);
+  });
+
+  it('returns generic foreign presets for unknown foreign subType', () => {
+    const result = getSuggestedPresetsForType('foreign', 'swahili');
+    expect(result).toEqual(PRESETS.foreign.suggested);
+  });
+
+  it('returns generic presets for non-code/foreign types regardless of subType', () => {
+    const result = getSuggestedPresetsForType('error', 'something');
+    expect(result).toEqual(PRESETS.error.suggested);
+  });
+});
+
 describe('getAllPresetsForType', () => {
   it('returns type-specific all presets plus deduplicated common presets for code', () => {
     const result = getAllPresetsForType('code');
@@ -61,6 +154,16 @@ describe('getAllPresetsForType', () => {
     expect(labels).not.toContain('Explain code');
     expect(labels).not.toContain('Debug this');
     expect(labels).not.toContain('Optimize');
+  });
+
+  it('returns JavaScript-specific all presets when subType is javascript', () => {
+    const result = getAllPresetsForType('code', 'javascript');
+    const labels = result.map(p => p.label);
+    // JavaScript sub-type all presets
+    expect(labels).toContain('Optimize');
+    // Should NOT contain generic code "all" labels that JS overrides
+    // Common presets still present if not in suggested
+    expect(labels).toContain('Rewrite');
   });
 
   it('deduplicates common presets against suggested for foreign type', () => {
@@ -93,8 +196,34 @@ describe('getAllPresetsForType', () => {
     expect(labels).toContain('Rewrite');
   });
 
+  it('returns presets for new error type', () => {
+    const result = getAllPresetsForType('error');
+    const labels = result.map(p => p.label);
+    expect(labels).toContain('Simplify message');
+    expect(labels).toContain('Rewrite');
+  });
+
+  it('returns presets for new email type', () => {
+    const result = getAllPresetsForType('email');
+    const labels = result.map(p => p.label);
+    expect(labels).toContain('Extract action items');
+  });
+
+  it('returns presets for new data type', () => {
+    const result = getAllPresetsForType('data');
+    const labels = result.map(p => p.label);
+    expect(labels).toContain('Find patterns');
+  });
+
+  it('returns presets for new math type', () => {
+    const result = getAllPresetsForType('math');
+    const labels = result.map(p => p.label);
+    expect(labels).toContain('Step by step');
+  });
+
   it('has no duplicate labels in the returned array', () => {
-    for (const type of ['code', 'foreign', 'long', 'default']) {
+    const types = ['code', 'foreign', 'error', 'email', 'data', 'math', 'long', 'default'];
+    for (const type of types) {
       const result = getAllPresetsForType(type);
       const labels = result.map(p => p.label);
       expect(new Set(labels).size).toBe(labels.length);

--- a/tests/wirePopupEvents.test.js
+++ b/tests/wirePopupEvents.test.js
@@ -16,7 +16,7 @@ globalThis.chrome = {
 };
 
 // Mock dependencies
-globalThis.detectContentType = vi.fn(() => 'default');
+globalThis.detectContentType = vi.fn(() => ({ type: 'default', subType: null, confidence: 1.0, wordCount: 2, charCount: 10 }));
 globalThis.PRESETS = {
   default: {
     suggested: [
@@ -26,6 +26,9 @@ globalThis.PRESETS = {
   }
 };
 globalThis.COMMON_PRESETS = [];
+globalThis.getSuggestedPresetsForType = vi.fn((contentType, subType) => {
+  return PRESETS[contentType]?.suggested || [];
+});
 globalThis.getAllPresetsForType = vi.fn(() => []);
 globalThis.buildPrompt = vi.fn((text, instruction, ctx) => {
   if (instruction) return `${instruction}:\n\n${text}`;


### PR DESCRIPTION
## Summary
- **Rich detection objects**: `detectContentType()` now returns `{ type, subType, confidence, wordCount, charCount }` instead of a plain string
- **4 new content types**: error/stack trace, email/message, list/data, math/formula — each with tailored preset suggestions
- **Programming language sub-types**: JavaScript, Python, Rust, Go, SQL, Java, C/C++, Ruby, PHP — with language-specific presets (e.g., "Explain this JavaScript", "Add type hints" for Python)
- **Natural language sub-types**: Japanese, Chinese, Korean, Arabic, Russian, Hindi, Thai — with language-specific translate presets (e.g., "Translate from Japanese")
- **Updated callers**: `popup.js` updated to handle new detection return format and pass sub-types to preset functions
- **Comprehensive tests**: 204 tests passing across 7 test files, covering all new heuristics

## Files Changed
| File | Changes |
|------|---------|
| `detection.js` | Major: new detectors, sub-type detection, rich metadata return |
| `presets.js` | Major: `CODE_SUBTYPE_PRESETS`, `FOREIGN_SUBTYPE_PRESETS`, new type entries, `getSuggestedPresetsForType()` |
| `popup.js` | Minor: updated callers for new detection format |
| `tests/detection.test.js` | Major: 85 tests covering all detection heuristics |
| `tests/presets.test.js` | Major: 29 tests covering new types and sub-types |
| `tests/popup.test.js` | Minor: updated mocks for new return format |
| `tests/wirePopupEvents.test.js` | Minor: updated mocks for new return format |

## Test plan
- [x] All 204 existing + new tests pass
- [x] No regressions in existing code/foreign/long/default detection
- [x] New types (error, email, data, math) detected correctly
- [x] Sub-type detection works for all 9 programming languages
- [x] Sub-type detection works for all 7 natural languages
- [x] Priority ordering preserved (code > error > math > data > email > foreign > long > default)
- [x] Callers in popup.js work with new return format
- [ ] Manual testing in Chrome extension

Ref: #43 (v1.1 Roadmap — PR 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)