### PR TITLE
fix: position trigger button below-right of cursor

### DIFF
--- a/tests/trigger.test.js
+++ b/tests/trigger.test.js
@@ -74,11 +74,11 @@ describe('showTrigger', () => {
     expect(el.style.display).toBe('block');
   });
 
-  it('positions with offset from cursor', () => {
+  it('positions below-right of cursor', () => {
     showTrigger(200, 100);
     const el = document.getElementById('dobby-ai-trigger');
-    expect(el.style.left).toBe('208px'); // x + 8
-    expect(el.style.top).toBe('84px'); // y - 16
+    expect(el.style.left).toBe('212px'); // x + 12
+    expect(el.style.top).toBe('110px'); // y + 10
   });
 
   it('clamps left position to prevent off-screen rendering', () => {
@@ -88,10 +88,11 @@ describe('showTrigger', () => {
     expect(parseInt(el.style.left)).toBeLessThanOrEqual(936);
   });
 
-  it('clamps top position to minimum of 4px', () => {
-    showTrigger(100, 10);
+  it('clamps top position to viewport bottom', () => {
+    showTrigger(100, 800);
     const el = document.getElementById('dobby-ai-trigger');
-    expect(el.style.top).toBe('4px'); // Math.max(4, 10 - 16) = 4
+    // maxTop = 768 - 28 - 8 = 732 (jsdom defaults innerHeight=768, offsetHeight fallback=28)
+    expect(parseInt(el.style.top)).toBeLessThanOrEqual(732);
   });
 });
 

--- a/trigger.js
+++ b/trigger.js
@@ -26,10 +26,10 @@ function createTriggerButton() {
     backdropFilter: 'blur(12px)',
     WebkitBackdropFilter: 'blur(12px)',
     color: 'white',
-    padding: '5px 12px',
+    padding: '4px 10px',
     borderRadius: '20px',
-    fontSize: '13px',
-    fontWeight: '600',
+    fontSize: '12px',
+    fontWeight: '500',
     fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
     cursor: 'pointer',
     boxShadow: '0 4px 15px rgba(79,70,229,0.4)',
@@ -200,8 +200,10 @@ function showTrigger(x, y) {
   const buttonHeight = triggerButton.offsetHeight || 28;
   const maxLeft = window.innerWidth - buttonWidth - 8;
   const maxTop = window.innerHeight - buttonHeight - 8;
-  triggerButton.style.left = `${Math.min(Math.max(8, x + 8), maxLeft)}px`;
-  triggerButton.style.top = `${Math.min(Math.max(4, y - 16), maxTop)}px`;
+  // Position below-right of cursor: close enough to click, but not blocking
+  // the selected text or surrounding content
+  triggerButton.style.left = `${Math.min(Math.max(8, x + 12), maxLeft)}px`;
+  triggerButton.style.top = `${Math.min(Math.max(4, y + 10), maxTop)}px`;
 }
 
 function hideTrigger() {


### PR DESCRIPTION
## Summary
- Button now appears 12px right and 10px below the cursor — close enough to click but not covering selected text or surrounding content
- Slightly reduced button size (12px font, lighter weight) for a less intrusive appearance
- On scroll, re-shows at the selection's right edge (no cursor available)

## Test plan
- [x] All 206 tests pass
- [ ] Select text on a page — button appears just below-right of where you release the mouse
- [ ] Button doesn't overlap the selected text highlight
- [ ] Button stays on-screen near viewport edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)