### PR TITLE
fix: icon button fallback size 80→36px

### DIFF
--- a/tests/trigger.test.js
+++ b/tests/trigger.test.js
@@ -84,8 +84,8 @@ describe('showTrigger', () => {
   it('clamps left position to prevent off-screen rendering', () => {
     showTrigger(1020, 100);
     const el = document.getElementById('dobby-ai-trigger');
-    // maxLeft = 1024 - 80 - 8 = 936 (jsdom defaults innerWidth=1024, offsetWidth fallback=80)
-    expect(parseInt(el.style.left)).toBeLessThanOrEqual(936);
+    // maxLeft = 1024 - 36 - 8 = 980 (jsdom defaults innerWidth=1024, offsetWidth fallback=36)
+    expect(parseInt(el.style.left)).toBeLessThanOrEqual(980);
   });
 
   it('clamps top position to viewport bottom', () => {

--- a/trigger.js
+++ b/trigger.js
@@ -196,8 +196,8 @@ function hidePresetSelector() {
 function showTrigger(x, y) {
   createTriggerButton();
   triggerButton.style.display = 'block';
-  const buttonWidth = triggerButton.offsetWidth || 80;
-  const buttonHeight = triggerButton.offsetHeight || 28;
+  const buttonWidth = triggerButton.offsetWidth || 36;
+  const buttonHeight = triggerButton.offsetHeight || 36;
   const maxLeft = window.innerWidth - buttonWidth - 8;
   const maxTop = window.innerHeight - buttonHeight - 8;
   // Position below-right of cursor: close enough to click, but not blocking


### PR DESCRIPTION
## Summary
- Update `offsetWidth` fallback from `80` to `36` and `offsetHeight` from `28` to `36` to match the new circular cockapoo icon button size
- Leftover from PR #51 squash merge that missed the last commit

## Test plan
- [x] All 206 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)