### PR TITLE
feat: toolbar popup with enable/disable toggle

### DIFF
--- a/bubble.js
+++ b/bubble.js
@@ -102,8 +102,8 @@ function getStyles(theme) {
       border-bottom: 1px solid ${isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)'};
       font-size: 12px;
       color: ${isDark ? '#a1a1aa' : '#71717a'};
-      max-height: 60px;
-      overflow: hidden;
+      max-height: 80px;
+      overflow-y: auto;
       line-height: 1.4;
     }
     .selected-text-preview .label {

--- a/manifest.json
+++ b/manifest.json
@@ -15,6 +15,13 @@
     "matches": ["<all_urls>"],
     "js": ["detection.js", "presets.js", "prompt.js", "history.js", "api.js", "bubble.js", "trigger.js", "content.js"]
   }],
+  "action": {
+    "default_popup": "popup.html",
+    "default_icon": {
+      "16": "icons/icon16.png",
+      "48": "icons/icon48.png"
+    }
+  },
   "options_ui": {
     "page": "options.html",
     "open_in_tab": true

--- a/popup.html
+++ b/popup.html
@@ -40,7 +40,16 @@
     height: 20px;
     cursor: pointer;
   }
-  .toggle input { display: none; }
+  .toggle input {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+  }
+  .toggle input:focus-visible + .slider {
+    outline: 2px solid #7c3aed;
+    outline-offset: 2px;
+  }
   .slider {
     position: absolute;
     inset: 0;
@@ -80,7 +89,7 @@
   <div class="toggle-row">
     <span class="status" id="status">Enabled</span>
     <label class="toggle">
-      <input type="checkbox" id="enabled" checked>
+      <input type="checkbox" id="enabled" checked aria-label="Enable or disable Dobby AI">
       <span class="slider"></span>
     </label>
   </div>

--- a/popup.js
+++ b/popup.js
@@ -12,8 +12,8 @@ toggle.addEventListener('change', () => {
   const enabled = toggle.checked;
   chrome.storage.local.set({ dobbyEnabled: enabled });
   status.textContent = enabled ? 'Enabled' : 'Disabled';
-  // Notify all tabs to update state
-  chrome.tabs.query({}, (tabs) => {
+  // Notify content-script tabs (filter to http/https to avoid chrome:// errors)
+  chrome.tabs.query({ url: ['http://*/*', 'https://*/*'] }, (tabs) => {
     tabs.forEach((tab) => {
       chrome.tabs.sendMessage(tab.id, { type: 'DOBBY_TOGGLE', enabled }).catch(() => {});
     });

--- a/tests/trigger.test.js
+++ b/tests/trigger.test.js
@@ -23,6 +23,7 @@ const {
   showTrigger,
   hideTrigger,
   _resetTriggerForTesting,
+  _setDobbyEnabled,
 } = await import('../trigger.js');
 
 beforeEach(() => {
@@ -130,6 +131,20 @@ describe('event-driven behavior', () => {
     vi.useFakeTimers();
     createTriggerButton();
     mockSelection('ab');
+
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    vi.advanceTimersByTime(20);
+
+    const btn = document.getElementById('dobby-ai-trigger');
+    expect(btn.style.display).toBe('none');
+    vi.useRealTimers();
+  });
+
+  it('mouseup does not show trigger when dobbyEnabled is false', () => {
+    vi.useFakeTimers();
+    createTriggerButton();
+    _setDobbyEnabled(false);
+    mockSelection('hello world');
 
     document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
     vi.advanceTimersByTime(20);

--- a/trigger.js
+++ b/trigger.js
@@ -136,8 +136,8 @@ function showPresetSelector() {
 
   // Selected text preview
   const preview = document.createElement('div');
-  const previewText = lastSelectedText.length > 80
-    ? lastSelectedText.substring(0, 80) + '...'
+  const previewText = lastSelectedText.length > 300
+    ? lastSelectedText.substring(0, 300) + '...'
     : lastSelectedText;
   Object.assign(preview.style, {
     padding: '5px 7px',
@@ -147,8 +147,8 @@ function showPresetSelector() {
     borderRadius: '6px',
     marginBottom: '4px',
     lineHeight: '1.35',
-    maxHeight: '42px',
-    overflow: 'hidden',
+    maxHeight: '80px',
+    overflowY: 'auto',
     wordBreak: 'break-word',
     borderLeft: isDark ? '2px solid rgba(167,139,250,0.5)' : '2px solid rgba(124,58,237,0.3)',
   });
@@ -326,6 +326,9 @@ function _resetTriggerForTesting() {
   lastSelectedText = '';
   lastSelectionRect = null;
   lastAnchorNode = null;
+  dobbyEnabled = true;
 }
 
-if (typeof module !== 'undefined') module.exports = { createTriggerButton, showTrigger, hideTrigger, _resetTriggerForTesting };
+function _setDobbyEnabled(val) { dobbyEnabled = val; }
+
+if (typeof module !== 'undefined') module.exports = { createTriggerButton, showTrigger, hideTrigger, _resetTriggerForTesting, _setDobbyEnabled };


### PR DESCRIPTION
## Summary
- New toolbar popup (`popup.html` + `popup.js`) with on/off toggle
- State persists via `chrome.storage.local` (default: enabled)
- Toggle broadcasts `DOBBY_TOGGLE` message to all open tabs immediately
- Content scripts (`trigger.js`) check `dobbyEnabled` before showing trigger
- Popup follows OS dark mode via `prefers-color-scheme`
- Settings link opens the options page

## Test plan
- [x] All 206 tests pass
- [ ] Click extension icon → popup shows with toggle
- [ ] Toggle off → trigger stops appearing on text selection
- [ ] Toggle on → trigger reappears
- [ ] Reload browser → state persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)