### PR TITLE
fix: simplify image prompt — let model decide

### DIFF
--- a/prompt.js
+++ b/prompt.js
@@ -19,7 +19,7 @@ function buildChatMessages(selectedText, instruction, includePageContext) {
   // System message sets the assistant's role
   messages.push({
     role: 'system',
-    content: 'You are Dobby AI, a helpful assistant. The user has selected text on a webpage and the full selected text is provided below. Do NOT attempt to access, fetch, or visit any URLs — the text content is already included in the message. A source URL may be provided as metadata only. Be concise and clear. Always respond in the same language as the selected text. When a visual diagram or image would help explain a concept, you may include it using markdown image syntax ![description](https://url). This does not involve fetching — you are just embedding a reference. Only include images from stable, well-known sources (e.g., Wikipedia, official documentation) where you are confident the URL exists. It is better to describe a diagram in text than to link a broken image.',
+    content: 'You are Dobby AI, a helpful assistant. The user has selected text on a webpage and the full selected text is provided below. Do NOT attempt to access, fetch, or visit any URLs — the text content is already included in the message. A source URL may be provided as metadata only. Be concise and clear. Always respond in the same language as the selected text. The chat supports rendering images via markdown syntax ![description](https://url). Include images when they help explain a concept or when the user asks for one.',
   });
 
   // Combine instruction + selected text in the user message so the model

--- a/tests/prompt.test.js
+++ b/tests/prompt.test.js
@@ -3,7 +3,7 @@ import { buildChatMessages, buildFollowUp, MAX_TEXT_LENGTH } from '../prompt.js'
 
 const SYSTEM_MSG = {
   role: 'system',
-  content: 'You are Dobby AI, a helpful assistant. The user has selected text on a webpage and the full selected text is provided below. Do NOT attempt to access, fetch, or visit any URLs — the text content is already included in the message. A source URL may be provided as metadata only. Be concise and clear. Always respond in the same language as the selected text. When a visual diagram or image would help explain a concept, you may include it using markdown image syntax ![description](https://url). This does not involve fetching — you are just embedding a reference. Only include images from stable, well-known sources (e.g., Wikipedia, official documentation) where you are confident the URL exists. It is better to describe a diagram in text than to link a broken image.',
+  content: 'You are Dobby AI, a helpful assistant. The user has selected text on a webpage and the full selected text is provided below. Do NOT attempt to access, fetch, or visit any URLs — the text content is already included in the message. A source URL may be provided as metadata only. Be concise and clear. Always respond in the same language as the selected text. The chat supports rendering images via markdown syntax ![description](https://url). Include images when they help explain a concept or when the user asks for one.',
 };
 
 describe('MAX_TEXT_LENGTH', () => {


### PR DESCRIPTION
## Summary
- Previous prompt was over-constrained with hedging ("it is better to describe...", "only stable sources") which discouraged the model from including images
- Simplified to: "The chat supports rendering images via markdown syntax. Include images when they help explain a concept or when the user asks for one."
- Let the model naturally decide when images are appropriate

## Test plan
- [x] All 219 tests pass
- [ ] Select text about a visual concept, model should include images when helpful
- [ ] Explicitly ask for an image, model should comply

🤖 Generated with [Claude Code](https://claude.com/claude-code)