### PR TITLE
feat: screenshot confirmation toolbar with reselect

### DIFF
--- a/tests/trigger.test.js
+++ b/tests/trigger.test.js
@@ -313,6 +313,17 @@ describe('screenshot mode', () => {
     cancelScreenshotMode();
   });
 
+  it('re-drag on overlay clears existing toolbar', () => {
+    startScreenshotMode();
+    const overlay = document.querySelector('div[style*="crosshair"]');
+    simulateDrag(overlay, 50, 50, 200, 200);
+    expect(overlay.querySelector('[data-screenshot-toolbar]')).not.toBeNull();
+    // Start a new drag (mousedown on overlay outside toolbar)
+    overlay.dispatchEvent(new MouseEvent('mousedown', { clientX: 300, clientY: 300, bubbles: true }));
+    expect(overlay.querySelector('[data-screenshot-toolbar]')).toBeNull();
+    cancelScreenshotMode();
+  });
+
   it('re-drag after reselect shows new toolbar', () => {
     startScreenshotMode();
     const overlay = document.querySelector('div[style*="crosshair"]');

--- a/trigger.js
+++ b/trigger.js
@@ -336,6 +336,9 @@ function startScreenshotMode() {
   screenshotOverlay.addEventListener('mousedown', (e) => {
     e.preventDefault();
     e.stopPropagation();
+    // Clear existing toolbar if user re-drags on overlay
+    const existingToolbar = screenshotOverlay.querySelector('[data-screenshot-toolbar]');
+    if (existingToolbar) existingToolbar.remove();
     screenshotDragStarted = true;
     screenshotStartX = e.clientX;
     screenshotStartY = e.clientY;
@@ -432,17 +435,21 @@ function _showConfirmToolbar(overlay, banner, rect) {
   confirmBtn.addEventListener('click', async (e) => {
     e.stopPropagation();
     cancelScreenshotMode();
-    if (typeof captureScreenshot === 'function') {
-      const captured = await captureScreenshot(rect);
-      if (captured) {
-        const bubbleRect = {
-          bottom: rect.y + rect.height + 8,
-          left: rect.x,
-          right: rect.x + rect.width,
-          top: rect.y,
-        };
-        showBubbleWithPresets(bubbleRect, '', null, [captured]);
+    try {
+      if (typeof captureScreenshot === 'function') {
+        const captured = await captureScreenshot(rect);
+        if (captured) {
+          const bubbleRect = {
+            bottom: rect.y + rect.height + 8,
+            left: rect.x,
+            right: rect.x + rect.width,
+            top: rect.y,
+          };
+          showBubbleWithPresets(bubbleRect, '', null, [captured]);
+        }
       }
+    } catch (err) {
+      console.error('[Dobby AI] Screenshot capture failed:', err);
     }
   });
 
@@ -457,8 +464,12 @@ function _showConfirmToolbar(overlay, banner, rect) {
   reselectBtn.addEventListener('click', (e) => {
     e.stopPropagation();
     toolbar.remove();
-    screenshotRect.style.display = 'none';
-    screenshotRect.style.border = '2px dashed #7c3aed';
+    Object.assign(screenshotRect.style, {
+      display: 'none',
+      border: '2px dashed #7c3aed',
+      width: '0px',
+      height: '0px',
+    });
     screenshotDragStarted = false;
     banner.textContent = 'Drag to select a region \u2022 ESC to cancel';
   });


### PR DESCRIPTION
## Summary
- Adds a confirmation toolbar (Capture / Reselect / Cancel) after dragging a screenshot region
- Users can review their selection before capturing, and reselect without leaving screenshot mode
- Banner text updates to "Confirm selection or reselect" after a valid drag
- Selection rectangle changes from dashed to solid border to indicate lock

## Test plan
- [x] 7 new unit tests for confirmation toolbar behavior (347 total, all passing)
- [x] Coverage at 84.59% (above 80% threshold)
- [ ] Manual: hold 1s to enter screenshot mode, drag a region, verify toolbar appears
- [ ] Manual: click Reselect, verify region resets and can drag again
- [ ] Manual: click Cancel, verify overlay dismissed
- [ ] Manual: click Capture, verify screenshot captured and bubble appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)