### PR TITLE
fix: prevent screenshot mode on scrollbars and interactive elements

### DIFF
--- a/tests/trigger.test.js
+++ b/tests/trigger.test.js
@@ -353,4 +353,62 @@ describe('screenshot mode', () => {
     expect(toolbar).not.toBeNull();
     cancelScreenshotMode();
   });
+
+  it('does not start screenshot mode when clicking on scrollbar area', () => {
+    vi.useFakeTimers();
+    _setDobbyEnabled(true);
+    Object.defineProperty(document.documentElement, 'clientWidth', { value: 1024, configurable: true });
+    document.dispatchEvent(new MouseEvent('mousedown', {
+      button: 0, clientX: 1030, clientY: 100, bubbles: true,
+    }));
+    vi.advanceTimersByTime(1100);
+    expect(document.querySelectorAll('div[style*="crosshair"]').length).toBe(0);
+    vi.useRealTimers();
+  });
+
+  it('does not start screenshot mode when clicking on interactive elements', () => {
+    vi.useFakeTimers();
+    _setDobbyEnabled(true);
+    const button = document.createElement('button');
+    document.body.appendChild(button);
+    button.dispatchEvent(new MouseEvent('mousedown', {
+      button: 0, clientX: 100, clientY: 100, bubbles: true,
+    }));
+    vi.advanceTimersByTime(1100);
+    expect(document.querySelectorAll('div[style*="crosshair"]').length).toBe(0);
+    button.remove();
+    vi.useRealTimers();
+  });
+
+  it('does not start screenshot mode when clicking on a link', () => {
+    vi.useFakeTimers();
+    _setDobbyEnabled(true);
+    const link = document.createElement('a');
+    link.href = '#';
+    document.body.appendChild(link);
+    link.dispatchEvent(new MouseEvent('mousedown', {
+      button: 0, clientX: 100, clientY: 100, bubbles: true,
+    }));
+    vi.advanceTimersByTime(1100);
+    expect(document.querySelectorAll('div[style*="crosshair"]').length).toBe(0);
+    link.remove();
+    vi.useRealTimers();
+  });
+
+  it('does not start screenshot mode when clicking inside a role=button element', () => {
+    vi.useFakeTimers();
+    _setDobbyEnabled(true);
+    const div = document.createElement('div');
+    div.setAttribute('role', 'button');
+    const span = document.createElement('span');
+    div.appendChild(span);
+    document.body.appendChild(div);
+    span.dispatchEvent(new MouseEvent('mousedown', {
+      button: 0, clientX: 100, clientY: 100, bubbles: true,
+    }));
+    vi.advanceTimersByTime(1100);
+    expect(document.querySelectorAll('div[style*="crosshair"]').length).toBe(0);
+    div.remove();
+    vi.useRealTimers();
+  });
 });

--- a/trigger.js
+++ b/trigger.js
@@ -218,17 +218,27 @@ let screenshotStartY = 0;
 let screenshotRect = null;
 let screenshotDragStarted = false;
 
-function isInputElement(el) {
-  if (!el) return false;
-  const tag = el.tagName;
-  if (tag === 'INPUT' || tag === 'TEXTAREA') return true;
+const INTERACTIVE_TAGS = new Set([
+  'INPUT', 'TEXTAREA', 'SELECT', 'BUTTON', 'A', 'VIDEO', 'AUDIO', 'LABEL', 'OPTION',
+]);
+
+function isInteractiveElement(el) {
+  if (!el || !el.tagName) return false;
+  if (INTERACTIVE_TAGS.has(el.tagName)) return true;
   if (el.isContentEditable) return true;
+  if (el.closest && el.closest('button, a, select, label, [role="button"], [role="slider"], [role="scrollbar"]')) return true;
   return false;
+}
+
+function isScrollbarClick(e) {
+  return e.clientX >= document.documentElement.clientWidth ||
+    e.clientY >= document.documentElement.clientHeight;
 }
 
 document.addEventListener('mousedown', (e) => {
   if (e.button !== 0) return; // left click only
-  if (isInputElement(e.target)) return;
+  if (isInteractiveElement(e.target)) return;
+  if (isScrollbarClick(e)) return;
   if (triggerButton?.contains(e.target)) return;
   if (typeof _getBubbleContainer === 'function') {
     const bc = _getBubbleContainer();


### PR DESCRIPTION
## Summary
- Long-press on scrollbars, buttons, links, selects, and `role="button"`/`role="slider"` elements no longer triggers screenshot mode
- Renamed `isInputElement` → `isInteractiveElement` with expanded tag coverage
- Added `isScrollbarClick` check (detects clicks beyond `documentElement.clientWidth/clientHeight`)
- Defensive guard for `el.closest` on non-element targets

## Test plan
- [x] 4 new tests: scrollbar click, button, link, role=button — all verify no screenshot trigger
- [x] All 353 tests pass, no regressions
- [ ] Manual: hold scrollbar for >1s — should NOT trigger screenshot mode
- [ ] Manual: hold a button/link for >1s — should NOT trigger screenshot mode
- [ ] Manual: hold empty page area for >1s — should still trigger screenshot mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)