### PR TITLE
fix: prevent screenshot mode when extension disabled

### DIFF
--- a/trigger.js
+++ b/trigger.js
@@ -461,12 +461,12 @@ document.addEventListener('mousedown', (e) => {
   }
   if (screenshotOverlay) return;
 
+  if (!dobbyEnabled) return;
+
   longPressStartX = e.clientX;
   longPressStartY = e.clientY;
 
-  if (dobbyEnabled) {
-    _showProgressRing(e.clientX, e.clientY);
-  }
+  _showProgressRing(e.clientX, e.clientY);
 
   longPressTimer = setTimeout(() => {
     startScreenshotMode();


### PR DESCRIPTION
## Summary
- Long-press timer was not guarded by `dobbyEnabled`, so screenshot mode activated even when extension was toggled off
- Moved the `dobbyEnabled` check to early-return before setting up the timer
- Also simplified progress ring call (no longer needs its own `dobbyEnabled` guard)

## Test plan
- [x] All 379 tests pass
- [ ] Manual: toggle extension off, hold mouse 1s — should NOT trigger screenshot mode or progress ring

🤖 Generated with [Claude Code](https://claude.com/claude-code)