### PR TITLE
feat: add Playwright-based demo GIF recorder

### DIFF
--- a/scripts/demos/pin-and-drag.js
+++ b/scripts/demos/pin-and-drag.js
@@ -1,0 +1,141 @@
+/**
+ * Demo: Pin and Drag
+ *
+ * Demonstrates the pin-toggle and drag-to-reposition features of the
+ * Dobby AI bubble.
+ *
+ * Steps:
+ *   1. Navigate to a content-rich page
+ *   2. Select text to trigger the bubble
+ *   3. Click the pin button
+ *   4. Drag the header to reposition
+ *   5. Click outside — bubble stays (pinned)
+ *   6. Unpin and click outside — bubble closes
+ */
+
+module.exports = async (page, capture, captureFor) => {
+  // 1. Go to a content-rich page
+  await page.goto('https://en.wikipedia.org/wiki/Artificial_intelligence', {
+    waitUntil: 'domcontentloaded',
+    timeout: 30000,
+  });
+  await page.waitForTimeout(2000); // let extension content scripts load
+  await capture('Page loaded');
+
+  // 2. Select some text to trigger the Dobby bubble
+  //    We triple-click on a paragraph to select a full line.
+  const paragraph = page.locator('#mw-content-text p').nth(1);
+  await paragraph.waitFor({ state: 'visible', timeout: 10000 });
+  const box = await paragraph.boundingBox();
+
+  // Triple-click to select the paragraph text
+  await page.mouse.click(box.x + 100, box.y + box.height / 2, { clickCount: 3 });
+  await page.waitForTimeout(800);
+  await capture('Text selected — trigger should appear');
+
+  // Click the trigger button (Dobby AI small floating button near selection)
+  // The trigger is a plain DOM element with id="dobby-ai-trigger"
+  await page.waitForTimeout(500);
+  const trigger = page.locator('#dobby-ai-trigger');
+  const triggerVisible = await trigger.isVisible().catch(() => false);
+
+  if (triggerVisible) {
+    await capture('Trigger button visible');
+    await trigger.click();
+    await page.waitForTimeout(1000);
+  } else {
+    // Fallback: the extension may show the bubble directly via preset chips.
+    // Select text manually via evaluate and dispatch event.
+    await page.evaluate(() => {
+      const p = document.querySelector('#mw-content-text p:nth-of-type(2)');
+      if (!p) return;
+      const range = document.createRange();
+      range.selectNodeContents(p);
+      const sel = window.getSelection();
+      sel.removeAllRanges();
+      sel.addRange(range);
+      document.dispatchEvent(new Event('mouseup', { bubbles: true }));
+    });
+    await page.waitForTimeout(1500);
+  }
+  await capture('Bubble should be visible');
+
+  // 3. Click the pin button inside the shadow DOM
+  await page.evaluate(() => {
+    const host = document.querySelector('#dobby-ai-bubble');
+    if (!host || !host.shadowRoot) return;
+    const pinBtn = host.shadowRoot.querySelector('.pin-btn');
+    if (pinBtn) pinBtn.click();
+  });
+  await page.waitForTimeout(600);
+  await capture('Pin button clicked — bubble is pinned');
+
+  // 4. Drag the header to reposition the bubble
+  const bubbleBox = await page.evaluate(() => {
+    const host = document.querySelector('#dobby-ai-bubble');
+    if (!host) return null;
+    const rect = host.getBoundingClientRect();
+    return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+  });
+
+  if (bubbleBox) {
+    const headerCenterX = bubbleBox.x + bubbleBox.width / 2;
+    const headerTopY = bubbleBox.y + 15; // header is ~30px tall, aim for center
+
+    await capture('Before drag');
+
+    // Drag the bubble ~150px to the right and ~80px down
+    await page.mouse.move(headerCenterX, headerTopY);
+    await page.mouse.down();
+    await page.waitForTimeout(200);
+
+    // Animate the drag for a smooth GIF
+    const steps = 10;
+    const dx = 150;
+    const dy = 80;
+    for (let i = 1; i <= steps; i++) {
+      await page.mouse.move(
+        headerCenterX + (dx * i) / steps,
+        headerTopY + (dy * i) / steps
+      );
+      if (i % 3 === 0) await capture('Dragging...');
+      await page.waitForTimeout(100);
+    }
+    await page.mouse.up();
+    await page.waitForTimeout(400);
+    await capture('Drag complete — bubble repositioned');
+  }
+
+  // 5. Click outside — bubble should stay because it's pinned
+  await page.mouse.click(50, 600);
+  await page.waitForTimeout(800);
+  await capture('Clicked outside — bubble stays (pinned)');
+
+  // Verify the bubble is still there
+  const stillVisible = await page.evaluate(() => {
+    const host = document.querySelector('#dobby-ai-bubble');
+    return host !== null;
+  });
+  console.log(`  Bubble still visible after outside click: ${stillVisible}`);
+
+  // 6. Unpin the bubble
+  await page.evaluate(() => {
+    const host = document.querySelector('#dobby-ai-bubble');
+    if (!host || !host.shadowRoot) return;
+    const pinBtn = host.shadowRoot.querySelector('.pin-btn');
+    if (pinBtn) pinBtn.click();
+  });
+  await page.waitForTimeout(600);
+  await capture('Unpinned');
+
+  // Click outside — bubble should close
+  await page.mouse.click(50, 600);
+  await page.waitForTimeout(800);
+  await capture('Clicked outside — bubble closed');
+
+  const gone = await page.evaluate(() => {
+    const host = document.querySelector('#dobby-ai-bubble');
+    return host === null;
+  });
+  console.log(`  Bubble removed after unpin + outside click: ${gone}`);
+};

--- a/scripts/demos/screenshot-mode.js
+++ b/scripts/demos/screenshot-mode.js
@@ -1,0 +1,115 @@
+/**
+ * Demo: Screenshot Mode
+ *
+ * Demonstrates the long-press screenshot capture flow:
+ *   1. Navigate to a content-rich page
+ *   2. Hold mouse for ~1s to trigger progress ring and enter screenshot mode
+ *   3. Drag to select a region
+ *   4. Confirmation toolbar appears
+ *   5. Click "Capture"
+ */
+
+module.exports = async (page, capture, captureFor) => {
+  // 1. Go to a content-rich page
+  await page.goto('https://en.wikipedia.org/wiki/Machine_learning', {
+    waitUntil: 'domcontentloaded',
+    timeout: 30000,
+  });
+  await page.waitForTimeout(2000); // let extension content scripts load
+  await capture('Page loaded');
+
+  // 2. Long-press to trigger progress ring and screenshot mode
+  //    The extension enters screenshot mode after holding mouse for 1000ms.
+  //    A progress ring appears after 500ms of holding.
+  const holdX = 640;
+  const holdY = 400;
+
+  await page.mouse.move(holdX, holdY);
+  await page.mouse.down();
+  await capture('Mouse down — hold starting');
+
+  // Capture frames during the 1s hold to show the progress ring animation
+  await page.waitForTimeout(500);
+  await capture('~500ms — progress ring should appear');
+
+  await page.waitForTimeout(300);
+  await capture('~800ms — progress ring animating');
+
+  await page.waitForTimeout(300);
+  // By now (1100ms total) screenshot mode should have activated
+  await capture('~1100ms — screenshot mode activated');
+
+  await page.mouse.up();
+  await page.waitForTimeout(400);
+  await capture('Mouse released — screenshot overlay visible');
+
+  // Verify screenshot overlay appeared
+  const overlayVisible = await page.evaluate(() => {
+    const overlays = document.querySelectorAll('div');
+    for (const el of overlays) {
+      const z = el.style.zIndex;
+      if (parseInt(z) > 999999) return true;
+    }
+    return false;
+  });
+  console.log(`  Screenshot overlay detected: ${overlayVisible}`);
+
+  // 3. Drag to select a region on the overlay
+  const dragStartX = 300;
+  const dragStartY = 200;
+  const dragEndX = 900;
+  const dragEndY = 550;
+
+  await page.mouse.move(dragStartX, dragStartY);
+  await page.waitForTimeout(200);
+  await page.mouse.down();
+  await capture('Drag start — selecting region');
+
+  // Animate the drag for a smooth GIF
+  const steps = 12;
+  const dx = dragEndX - dragStartX;
+  const dy = dragEndY - dragStartY;
+  for (let i = 1; i <= steps; i++) {
+    await page.mouse.move(
+      dragStartX + (dx * i) / steps,
+      dragStartY + (dy * i) / steps
+    );
+    if (i % 3 === 0) await capture('Dragging selection...');
+    await page.waitForTimeout(100);
+  }
+  await page.mouse.up();
+  await page.waitForTimeout(600);
+  await capture('Selection complete — toolbar should appear');
+
+  // 4. Verify the confirmation toolbar is visible
+  const toolbarVisible = await page.evaluate(() => {
+    const toolbar = document.querySelector('[data-screenshot-toolbar]');
+    return toolbar !== null;
+  });
+  console.log(`  Confirmation toolbar visible: ${toolbarVisible}`);
+  await page.waitForTimeout(400);
+  await capture('Confirmation toolbar visible');
+
+  // 5. Click the "Capture" button
+  const captureClicked = await page.evaluate(() => {
+    const toolbar = document.querySelector('[data-screenshot-toolbar]');
+    if (!toolbar) return false;
+    // The Capture button is the first button in the toolbar
+    const buttons = toolbar.querySelectorAll('button');
+    for (const btn of buttons) {
+      if (btn.textContent.trim() === 'Capture') {
+        btn.click();
+        return true;
+      }
+    }
+    return false;
+  });
+  console.log(`  Capture button clicked: ${captureClicked}`);
+
+  await page.waitForTimeout(1500);
+  await capture('After capture — bubble should appear with screenshot');
+
+  // Final frame: show the result
+  await page.waitForTimeout(1000);
+  await capture('Demo complete');
+};

--- a/scripts/record-demo-README.md
+++ b/scripts/record-demo-README.md
@@ -1,0 +1,64 @@
+# Demo GIF Recorder
+
+Record demo GIFs of the Dobby AI Chrome extension using Playwright and ffmpeg.
+
+## Prerequisites
+
+- **Node.js** >= 18
+- **Playwright** — install with `npm i -D playwright` then `npx playwright install chromium`
+- **ffmpeg** — install with `brew install ffmpeg` (macOS) or `sudo apt install ffmpeg` (Linux)
+
+## Usage
+
+```bash
+node scripts/record-demo.js <demo-module> <output.gif> [--framerate N]
+```
+
+### Examples
+
+```bash
+# Record the pin-and-drag demo
+node scripts/record-demo.js demos/pin-and-drag.js pin-and-drag.gif
+
+# Record screenshot mode at 15 fps
+node scripts/record-demo.js demos/screenshot-mode.js screenshot-mode.gif --framerate 15
+```
+
+The script will:
+
+1. Launch Chromium with the extension loaded (non-headless, required for extensions)
+2. Run the demo scenario, capturing screenshots at key moments
+3. Stitch the frames into a GIF using ffmpeg
+4. Output the GIF path and clean up temp files
+
+## Writing a demo scenario
+
+Create a new file in `scripts/demos/`. Each demo module exports a single async function:
+
+```js
+module.exports = async (page, capture, captureFor) => {
+  // page       — Playwright Page object
+  // capture()  — takes a screenshot frame; call at key moments
+  // captureFor(durationMs, intervalMs, label) — capture continuously for a duration
+
+  await page.goto('https://example.com');
+  await capture('Page loaded');
+
+  // ... interact with the page and extension ...
+};
+```
+
+### Tips
+
+- The extension UI lives in Shadow DOM under `#dobby-ai-bubble`. Use `page.evaluate()` to reach into shadow roots.
+- Call `capture()` frequently during animations for smooth GIFs.
+- Use `page.waitForTimeout()` between steps so transitions are visible.
+- The trigger button has id `#dobby-ai-trigger`.
+- Screenshot mode activates after holding mouse down for 1 second.
+
+## Available demos
+
+| Demo | Description |
+|------|-------------|
+| `demos/pin-and-drag.js` | Pin toggle, drag-to-reposition, click-outside behavior |
+| `demos/screenshot-mode.js` | Long-press screenshot capture with region selection |

--- a/scripts/record-demo.js
+++ b/scripts/record-demo.js
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+/**
+ * record-demo.js — Record a demo GIF of the Dobby AI Chrome extension.
+ *
+ * Usage:
+ *   node scripts/record-demo.js <demo-module> <output.gif> [--framerate N]
+ *
+ * Examples:
+ *   node scripts/record-demo.js demos/pin-and-drag.js output.gif
+ *   node scripts/record-demo.js demos/screenshot-mode.js screenshot-demo.gif --framerate 15
+ *
+ * Requirements:
+ *   - Playwright (`npm i -D playwright` or `npx playwright install chromium`)
+ *   - ffmpeg on PATH
+ */
+
+const { chromium } = require('playwright');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { execSync } = require('child_process');
+
+// ---------------------------------------------------------------------------
+// CLI arguments
+// ---------------------------------------------------------------------------
+
+const args = process.argv.slice(2);
+
+function usage() {
+  console.error(
+    'Usage: node scripts/record-demo.js <demo-module> <output.gif> [--framerate N]'
+  );
+  process.exit(1);
+}
+
+if (args.length < 2) usage();
+
+const demoArg = args[0];
+const outputGif = path.resolve(args[1]);
+
+let framerate = 10;
+const frIdx = args.indexOf('--framerate');
+if (frIdx !== -1 && args[frIdx + 1]) {
+  framerate = parseInt(args[frIdx + 1], 10) || 10;
+}
+
+// Resolve the demo module relative to the scripts/ directory
+const scriptsDir = path.resolve(__dirname);
+const demoPath = path.resolve(scriptsDir, demoArg);
+
+if (!fs.existsSync(demoPath)) {
+  console.error(`Demo module not found: ${demoPath}`);
+  process.exit(1);
+}
+
+// The extension lives at the repository root (unpacked extension)
+const extensionPath = path.resolve(__dirname, '..');
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+(async () => {
+  // Create temp directory for screenshot frames
+  const framesDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dobby-demo-'));
+  let frameIndex = 0;
+
+  console.log(`Frames directory: ${framesDir}`);
+  console.log(`Extension path:   ${extensionPath}`);
+  console.log(`Demo module:      ${demoPath}`);
+  console.log(`Output:           ${outputGif}`);
+  console.log(`Framerate:        ${framerate} fps`);
+  console.log('');
+
+  // Verify ffmpeg is available
+  try {
+    execSync('ffmpeg -version', { stdio: 'ignore' });
+  } catch {
+    console.error(
+      'Error: ffmpeg not found on PATH. Install it first:\n' +
+        '  macOS:  brew install ffmpeg\n' +
+        '  Linux:  sudo apt install ffmpeg'
+    );
+    process.exit(1);
+  }
+
+  // Launch Chromium with the extension loaded
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dobby-profile-'));
+  const context = await chromium.launchPersistentContext(userDataDir, {
+    headless: false,
+    args: [
+      `--disable-extensions-except=${extensionPath}`,
+      `--load-extension=${extensionPath}`,
+      '--no-first-run',
+      '--disable-infobars',
+      '--disable-blink-features=AutomationControlled',
+    ],
+    viewport: { width: 1280, height: 720 },
+    ignoreDefaultArgs: ['--enable-automation'],
+  });
+
+  const page = context.pages()[0] || (await context.newPage());
+
+  /**
+   * capture() — take a screenshot and save it as the next frame.
+   * Call this at key moments in your demo script.
+   *
+   * @param {string} [label] Optional label logged to the console
+   */
+  async function capture(label) {
+    const frameName = `frame_${String(frameIndex).padStart(4, '0')}.png`;
+    const framePath = path.join(framesDir, frameName);
+    await page.screenshot({ path: framePath });
+    console.log(`  [frame ${frameIndex}] ${label || ''}`);
+    frameIndex++;
+  }
+
+  /**
+   * captureFor() — continuously capture frames for a given duration.
+   * Useful for recording animations or transitions.
+   *
+   * @param {number} durationMs  Total duration in milliseconds
+   * @param {number} [intervalMs=200] Interval between frames
+   * @param {string} [label]     Optional label prefix
+   */
+  async function captureFor(durationMs, intervalMs = 200, label = '') {
+    const start = Date.now();
+    while (Date.now() - start < durationMs) {
+      await capture(label || 'continuous');
+      await page.waitForTimeout(intervalMs);
+    }
+  }
+
+  try {
+    // Load the demo module
+    const demoFn = require(demoPath);
+    if (typeof demoFn !== 'function') {
+      console.error('Demo module must export an async function: module.exports = async (page, capture, captureFor) => { ... }');
+      process.exit(1);
+    }
+
+    console.log('Running demo scenario...\n');
+    await demoFn(page, capture, captureFor);
+    console.log(`\nDemo complete. ${frameIndex} frames captured.`);
+
+    if (frameIndex === 0) {
+      console.error('No frames were captured. Nothing to stitch.');
+      process.exit(1);
+    }
+
+    // Stitch frames into a GIF using ffmpeg
+    console.log('\nStitching GIF with ffmpeg...');
+    const ffmpegCmd = [
+      'ffmpeg', '-y',
+      `-framerate ${framerate}`,
+      `-i "${path.join(framesDir, 'frame_%04d.png')}"`,
+      '-vf "scale=800:-1:flags=lanczos,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse"',
+      `"${outputGif}"`,
+    ].join(' ');
+
+    execSync(ffmpegCmd, { stdio: 'inherit' });
+    console.log(`\nGIF saved to: ${outputGif}`);
+  } catch (err) {
+    console.error('Demo failed:', err);
+    process.exitCode = 1;
+  } finally {
+    // Clean up
+    await context.close();
+
+    // Remove frames directory
+    fs.rmSync(framesDir, { recursive: true, force: true });
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+    console.log('Cleaned up temp files.');
+  }
+})();


### PR DESCRIPTION
## Summary
- Added `scripts/record-demo.js` — reusable harness that launches Chromium with the extension loaded, runs a demo scenario, captures frames, and stitches into a GIF via ffmpeg
- Added two sample demo scenarios: `demos/pin-and-drag.js` and `demos/screenshot-mode.js`
- Usage: `node scripts/record-demo.js demos/pin-and-drag.js output.gif`

## Test plan
- [x] All JS files pass syntax validation
- [ ] Manual: `node scripts/record-demo.js demos/pin-and-drag.js pin-demo.gif` produces a GIF

🤖 Generated with [Claude Code](https://claude.com/claude-code)