### PR TITLE
fix: enable follow-up after clicking history entry

### DIFF
--- a/bubble.js
+++ b/bubble.js
@@ -890,6 +890,19 @@ async function showHistoryPanel(shadow) {
       responseEl.className = 'response-text';
       responseEl.innerHTML = renderMarkdown(entry.response);
       body.appendChild(responseEl);
+
+      // Restore conversation state so follow-up works
+      currentMessages = [];
+      if (entry.instruction) currentMessages.push({ role: 'system', content: entry.instruction });
+      if (entry.text) currentMessages.push({ role: 'user', content: entry.text });
+      if (entry.response) currentMessages.push({ role: 'assistant', content: entry.response });
+      responseText = entry.response || '';
+
+      const followUpInput = shadow.querySelector('.follow-up-input');
+      if (followUpInput) {
+        followUpInput.disabled = false;
+        followUpInput.focus();
+      }
     });
     panel.appendChild(el);
   });

--- a/tests/bubble.test.js
+++ b/tests/bubble.test.js
@@ -193,6 +193,36 @@ describe('bubble.js', () => {
       expect(instrDiv.textContent).toBe('user selected text here');
     });
 
+    it('restores conversation state and enables follow-up on history entry click', async () => {
+      global.getHistory = vi.fn(() => Promise.resolve([
+        {
+          text: 'user selected text here',
+          instruction: 'system prompt content',
+          response: 'AI response',
+          pageTitle: 'Test Page',
+          timestamp: Date.now(),
+        },
+      ]));
+
+      showBubble({ bottom: 100, left: 50, right: 250 }, [{ role: 'user', content: 'hi' }]);
+      const container = _getBubbleContainer();
+      const shadow = container.shadowRoot;
+
+      shadow.querySelector('.history-btn').click();
+      await new Promise((r) => setTimeout(r, 0));
+
+      // Click the history entry
+      shadow.querySelector('.history-entry').click();
+
+      // Follow-up input should be enabled
+      const followUpInput = shadow.querySelector('.follow-up-input');
+      expect(followUpInput.disabled).toBe(false);
+
+      // Response should be rendered
+      const responseText = shadow.querySelector('.response-text');
+      expect(responseText.innerHTML).toContain('AI response');
+    });
+
     it('falls back to instruction when text is empty', async () => {
       global.getHistory = vi.fn(() => Promise.resolve([
         {


### PR DESCRIPTION
## Summary
- Clicking a history entry now rebuilds `currentMessages` from stored data (system prompt + user text + response)
- Enables the follow-up input so users can continue the conversation
- Sets `responseText` for clipboard/history consistency

## Test plan
- [x] New test: history entry click restores conversation state and enables follow-up
- [x] All 393 tests pass
- [ ] Manual: open history, click an entry, type a follow-up question — should work

Note: GIF verification was attempted but Playwright CDP screenshots have timing issues with Shadow DOM updates triggered via `evalInExtension`. The fix is verified via unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)