### PR TITLE
fix: show response section when loading history entry

### DIFF
--- a/bubble.js
+++ b/bubble.js
@@ -891,6 +891,12 @@ async function showHistoryPanel(shadow) {
       responseEl.innerHTML = renderMarkdown(entry.response);
       body.appendChild(responseEl);
 
+      // Show response section and hide presets
+      const presetsSection = shadow.querySelector('.presets-section');
+      if (presetsSection) presetsSection.classList.add('collapsed');
+      const responseSection = shadow.querySelector('.response-section');
+      if (responseSection) responseSection.classList.add('active');
+
       // Restore conversation state so follow-up works
       currentMessages = [];
       if (entry.instruction) currentMessages.push({ role: 'system', content: entry.instruction });


### PR DESCRIPTION
## Summary
- `.response-section` was `display: none` by default — needed `.active` class to become visible
- Clicking a history entry now adds `.active` to response section and collapses presets
- Root cause of "can't continue conversation from history" — the UI was there but hidden

## Test plan
- [x] All 393 tests pass
- [ ] Manual: open history, click entry — response shows and follow-up input is usable

🤖 Generated with [Claude Code](https://claude.com/claude-code)