### PR TITLE
refactor: address code review findings from PR #88

### DIFF
--- a/bubble.js
+++ b/bubble.js
@@ -85,7 +85,7 @@ function createBubbleHost(selectionRect) {
     : preferredTop;
   Object.assign(bubbleHost.style, {
     position: 'fixed',
-    zIndex: '2147483647',
+    zIndex: String(Z_INDEX.BUBBLE),
     left: `${Math.max(8, (selectionRect.left + selectionRect.right) / 2 - 190)}px`,
     top: `${top}px`,
   });
@@ -423,7 +423,7 @@ function startStreaming(shadow, messages) {
           aiMsg.innerHTML = renderMarkdown(responseText);
           const body = shadow.querySelector('.bubble-body');
           body.scrollTop = body.scrollHeight;
-        }, 50);
+        }, TIMING.RENDER_DEBOUNCE);
       }
     },
     (usageInfo) => {
@@ -637,7 +637,7 @@ function hideBubble() {
       bubbleHost._resizeCleanup();
     }
     if (bubbleHost._escHandler) document.removeEventListener('keydown', bubbleHost._escHandler);
-    if (bubbleHost.parentNode) bubbleHost.parentNode.removeChild(bubbleHost);
+    removeElement(bubbleHost);
   }
   bubbleHost = null;
   currentMessages = [];

--- a/styles.js
+++ b/styles.js
@@ -2,12 +2,15 @@
 
 function getStyles(theme) {
   const isDark = theme === 'dark';
+  const accent = typeof THEME !== 'undefined' ? THEME.ACCENT : '#7c3aed';
+  const accentLight = typeof THEME !== 'undefined' ? THEME.ACCENT_LIGHT : '#a78bfa';
+  const fontStack = typeof THEME !== 'undefined' ? THEME.FONT_STACK : '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
   return `
     :host { all: initial; }
     * { box-sizing: border-box; margin: 0; padding: 0; }
     .bubble {
       position: relative;
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      font-family: ${fontStack};
       width: 380px;
       max-height: 420px;
       border-radius: 16px;
@@ -36,7 +39,7 @@ function getStyles(theme) {
     .bubble-logo {
       font-weight: 700;
       font-size: 14px;
-      color: ${isDark ? '#a78bfa' : '#7c3aed'};
+      color: ${isDark ? accentLight : accent};
     }
     .bubble-status {
       font-size: 12px;
@@ -65,7 +68,7 @@ function getStyles(theme) {
     }
     .pin-btn:hover { background: ${isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.06)'}; }
     .pin-btn.pinned {
-      color: #7c3aed;
+      color: ${accent};
       transform: rotate(0deg);
     }
     .selected-text-preview {
@@ -82,7 +85,7 @@ function getStyles(theme) {
       font-size: 11px;
       text-transform: uppercase;
       letter-spacing: 0.5px;
-      color: ${isDark ? '#a78bfa' : '#7c3aed'};
+      color: ${isDark ? accentLight : accent};
       margin-bottom: 2px;
     }
     .selected-text-preview .text {
@@ -105,7 +108,7 @@ function getStyles(theme) {
     }
     .message-user {
       align-self: flex-end;
-      background: #7c3aed;
+      background: ${accent};
       color: #fff;
       padding: 6px 12px;
       border-radius: 12px 12px 2px 12px;
@@ -180,7 +183,7 @@ function getStyles(theme) {
       display: inline-block;
       width: 2px;
       height: 14px;
-      background: ${isDark ? '#a78bfa' : '#7c3aed'};
+      background: ${isDark ? accentLight : accent};
       margin-left: 2px;
       vertical-align: text-bottom;
     }
@@ -206,7 +209,7 @@ function getStyles(theme) {
       font-family: inherit;
     }
     .follow-up-input:focus {
-      border-color: ${isDark ? '#a78bfa' : '#7c3aed'};
+      border-color: ${isDark ? accentLight : accent};
     }
     .follow-up-input::placeholder {
       color: ${isDark ? '#71717a' : '#a1a1aa'};
@@ -226,7 +229,7 @@ function getStyles(theme) {
       padding: 8px 0;
     }
     .retry-btn {
-      background: ${isDark ? '#a78bfa' : '#7c3aed'};
+      background: ${isDark ? accentLight : accent};
       color: white;
       border: none;
       padding: 4px 12px;
@@ -242,7 +245,7 @@ function getStyles(theme) {
     .rate-limit-msg .cta {
       display: inline-block;
       margin-top: 8px;
-      color: ${isDark ? '#a78bfa' : '#7c3aed'};
+      color: ${isDark ? accentLight : accent};
       cursor: pointer;
       text-decoration: underline;
     }
@@ -280,11 +283,11 @@ function getStyles(theme) {
       color: ${isDark ? '#e4e4e7' : '#18181b'};
       font-family: inherit;
     }
-    .preset-input:focus { border-color: ${isDark ? '#a78bfa' : '#7c3aed'}; }
+    .preset-input:focus { border-color: ${isDark ? accentLight : accent}; }
     .preset-input::placeholder { color: ${isDark ? '#71717a' : '#a1a1aa'}; }
     .detection-badge {
       font-size: 10px;
-      color: ${isDark ? '#a78bfa' : '#7c3aed'};
+      color: ${isDark ? accentLight : accent};
       font-weight: 500;
       padding: 0 0 4px;
     }

--- a/tests/trigger.test.js
+++ b/tests/trigger.test.js
@@ -2,31 +2,14 @@
 // @vitest-environment jsdom
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setupContentScriptMocks, mockSelection as sharedMockSelection } from './helpers.js';
 
 // Load shared constants and DOM utilities as globals (trigger.js expects them in global scope)
-const { Z_INDEX, THEME, TIMING } = await import('../constants.js');
-const { removeElement, isClickInsideUI } = await import('../dom-utils.js');
-global.Z_INDEX = Z_INDEX;
-global.THEME = THEME;
-global.TIMING = TIMING;
-global.removeElement = removeElement;
-global.isClickInsideUI = isClickInsideUI;
+Object.assign(globalThis, await import('../constants.js'));
+Object.assign(globalThis, await import('../dom-utils.js'));
 
 // Mock dependencies
-global.detectContentType = vi.fn(() => ({ type: 'general', subType: null, confidence: 'high' }));
-global.detectContent = vi.fn(() => ({ type: 'general', subType: null, confidence: 'high' }));
-global.getSuggestedPresetsForType = vi.fn(() => [
-  { id: 'explain', label: 'Explain this', instruction: 'Explain the following' },
-  { id: 'summarize', label: 'Summarize', instruction: 'Summarize the following' },
-]);
-global.buildChatMessages = vi.fn((text, instruction) => [
-  { role: 'system', content: instruction },
-  { role: 'user', content: text },
-]);
-global.showBubble = vi.fn();
-global.showBubbleWithPresets = vi.fn();
-global.hideBubble = vi.fn();
-global._getBubbleContainer = vi.fn(() => null);
+setupContentScriptMocks();
 
 const {
   createTriggerButton,
@@ -116,13 +99,7 @@ describe('hideTrigger', () => {
 
 describe('event-driven behavior', () => {
   function mockSelection(text) {
-    const range = { getBoundingClientRect: () => ({ top: 100, right: 200, bottom: 120, left: 100 }) };
-    window.getSelection = vi.fn(() => ({
-      toString: () => text,
-      anchorNode: document.body,
-      rangeCount: 1,
-      getRangeAt: () => range,
-    }));
+    sharedMockSelection(text);
   }
 
   it('mouseup with selection >= 3 chars shows trigger', () => {

--- a/trigger.js
+++ b/trigger.js
@@ -182,8 +182,7 @@ document.addEventListener('mouseup', (e) => {
   const cursorX = e.clientX;
   const cursorY = e.clientY;
   setTimeout(() => {
-    const selection = window.getSelection();
-    const text = selection.toString().trim();
+    const text = getSelectedText();
 
     if (text.length >= 3 && dobbyEnabled) {
       showTrigger(cursorX, cursorY);
@@ -198,13 +197,12 @@ let selectionChangeTimer = null;
 document.addEventListener('selectionchange', () => {
   clearTimeout(selectionChangeTimer);
   selectionChangeTimer = setTimeout(() => {
+    const text = getSelectedText();
     const selection = window.getSelection();
-    const text = selection.toString().trim();
     if (text.length >= 3 && dobbyEnabled && selection.rangeCount > 0) {
       // Only show if trigger isn't already visible
       if (!triggerButton || triggerButton.style.display === 'none') {
-        const range = selection.getRangeAt(0);
-        const rect = range.getBoundingClientRect();
+        const rect = getSelectionRect();
         showTrigger(rect.right, rect.bottom);
       }
     }
@@ -217,11 +215,10 @@ window.addEventListener('scroll', () => {
   hideTrigger();
   clearTimeout(scrollTimer);
   scrollTimer = setTimeout(() => {
+    const text = getSelectedText();
     const selection = window.getSelection();
-    const text = selection.toString().trim();
     if (text.length >= 3 && dobbyEnabled && selection.rangeCount > 0) {
-      const range = selection.getRangeAt(0);
-      const rect = range.getBoundingClientRect();
+      const rect = getSelectionRect();
       showTrigger(rect.right, rect.top);
     }
   }, TIMING.SCROLL_DEBOUNCE);
@@ -530,7 +527,7 @@ function startScreenshotMode() {
     padding: '10px 24px',
     borderRadius: '8px',
     fontSize: '14px',
-    fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+    fontFamily: THEME.FONT_STACK,
     fontWeight: '500',
     zIndex: String(Z_INDEX.TRIGGER),
     pointerEvents: 'none',
@@ -652,7 +649,7 @@ function _showConfirmToolbar(overlay, banner, rect) {
     borderRadius: '6px',
     padding: '8px 16px',
     fontSize: '13px',
-    fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+    fontFamily: THEME.FONT_STACK,
     fontWeight: '500',
     cursor: 'pointer',
     boxShadow: '0 2px 8px rgba(0,0,0,0.25)',
@@ -748,8 +745,12 @@ function _resetTriggerForTesting() {
   removeElement(triggerButton);
   triggerButton = null;
   dobbyEnabled = true;
+  if (longPressState.timer) { clearTimeout(longPressState.timer); longPressState.timer = null; }
   if (longPressState.ringTimer) { clearTimeout(longPressState.ringTimer); longPressState.ringTimer = null; }
+  longPressState.startX = 0;
+  longPressState.startY = 0;
   _removeProgressRing();
+  cancelScreenshotMode();
 }
 
 function _setDobbyEnabled(val) { dobbyEnabled = val; }


### PR DESCRIPTION
## Summary

Follow-up to #88 addressing all 5 important issues and 4 suggestions from code review.

- **bubble.js**: Wire `Z_INDEX.BUBBLE`, `TIMING.RENDER_DEBOUNCE`, and `removeElement()` — 3 missed spots
- **trigger.js**: Wire `getSelectedText()` and `getSelectionRect()` from dom-utils (previously dead code), use `THEME.FONT_STACK` in 2 places, complete `_resetTriggerForTesting` to reset all state
- **styles.js**: Use `THEME.ACCENT`, `THEME.ACCENT_LIGHT`, `THEME.FONT_STACK` via local variables with safe fallbacks
- **tests/trigger.test.js**: Migrate to shared `setupContentScriptMocks()` and `mockSelection()` from `tests/helpers.js`

## Test plan

- [x] All 408 tests pass across 18 test files
- [x] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)