### PR TITLE
fix: restore cursor element after loading history entry

### DIFF
--- a/bubble.js
+++ b/bubble.js
@@ -555,6 +555,9 @@ async function showHistoryPanel(shadow) {
       responseEl.className = 'response-text';
       responseEl.innerHTML = renderMarkdown(entry.response);
       body.appendChild(responseEl);
+      const cursor = document.createElement('span');
+      cursor.className = 'cursor hidden';
+      body.appendChild(cursor);
 
       // Show response section and hide presets
       const presetsSection = shadow.querySelector('.presets-section');

--- a/tests/bubble.test.js
+++ b/tests/bubble.test.js
@@ -207,6 +207,41 @@ describe('bubble.js', () => {
       expect(responseText.innerHTML).toContain('AI response');
     });
 
+    it('follow-up works after loading history entry', async () => {
+      global.getHistory = vi.fn(() => Promise.resolve([
+        {
+          text: 'user selected text here',
+          instruction: 'system prompt content',
+          response: 'AI response',
+          pageTitle: 'Test Page',
+          timestamp: Date.now(),
+        },
+      ]));
+
+      showBubble({ bottom: 100, left: 50, right: 250 }, [{ role: 'user', content: 'hi' }]);
+      const container = _getBubbleContainer();
+      const shadow = container.shadowRoot;
+
+      shadow.querySelector('.history-btn').click();
+      await new Promise((r) => setTimeout(r, 0));
+
+      // Click history entry to load it
+      shadow.querySelector('.history-entry').click();
+
+      // Cursor element must still exist for startStreaming
+      const cursor = shadow.querySelector('.cursor');
+      expect(cursor).not.toBeNull();
+
+      // Follow-up should work without crashing
+      const followUpInput = shadow.querySelector('.follow-up-input');
+      followUpInput.disabled = false;
+      followUpInput.value = 'tell me more';
+      followUpInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+
+      // requestChat should have been called (streaming started)
+      expect(global.requestChat).toHaveBeenCalled();
+    });
+
     it('falls back to instruction when text is empty', async () => {
       global.getHistory = vi.fn(() => Promise.resolve([
         {


### PR DESCRIPTION
## Summary

- Fix: follow-up messages crash silently after loading a history entry
- Root cause: history click handler clears `body.innerHTML` which destroys the `.cursor` span. `startStreaming` then gets `null` for `cursorEl` and throws on `cursorEl.classList.remove('hidden')`
- Fix: recreate the `.cursor` span (hidden) after restoring history content

## Test plan

- [x] New test: "follow-up works after loading history entry" — verifies cursor exists and `requestChat` is called
- [x] All 409 tests pass
- [ ] Manual: open bubble → get response → click history → click entry → type follow-up → verify AI responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)