### PR TITLE
fix: show actual API error details instead of generic Request failed

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -154,7 +154,11 @@ chrome.runtime.onConnect.addListener((port) => {
       }
 
       if (!response.ok) {
-        try { port.postMessage({ type: 'error', code: response.status, message: 'Request failed' }); } catch (e) { console.warn('[Dobby AI] port.postMessage failed:', e.message); }
+        let errBody = '';
+        try { errBody = await response.text(); } catch (e) { /* ignore */ }
+        console.error('[Dobby AI] API error:', response.status, errBody);
+        const errMsg = errBody ? `Request failed (${response.status}): ${errBody.substring(0, 200)}` : 'Request failed';
+        try { port.postMessage({ type: 'error', code: response.status, message: errMsg }); } catch (e) { console.warn('[Dobby AI] port.postMessage failed:', e.message); }
         return;
       }
 


### PR DESCRIPTION
## Summary

- When the API returns a non-200 response, the error bubble now shows the status code and response body (truncated to 200 chars) instead of a generic "Request failed"
- Helps diagnose issues like payload size limits (413), auth errors (401), or bad requests (400)

## Test plan

- [x] All tests pass
- [x] Manual: verified error message shows actual API response when screenshot payload hits proxy size limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)