### PR TITLE
feat: add esbuild watch mode for development

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -2,57 +2,49 @@ const esbuild = require('esbuild');
 const fs = require('fs');
 
 const DIST = 'dist';
+const isWatch = process.argv.includes('--watch');
 
-async function build() {
-  fs.rmSync(DIST, { recursive: true, force: true });
-  fs.mkdirSync(DIST, { recursive: true });
-
-  // Bundle content script
-  await esbuild.build({
-    entryPoints: ['src/content/index.js'],
-    bundle: true,
-    outfile: `${DIST}/content.js`,
-    format: 'iife',
-    target: 'chrome115',
-    minify: false,
-  });
-
-  // Bundle background service worker
-  await esbuild.build({
-    entryPoints: ['src/background/index.js'],
-    bundle: true,
-    outfile: `${DIST}/background.js`,
-    format: 'iife',
-    target: 'chrome115',
-    minify: false,
-  });
-
-  // Bundle popup and options
-  await esbuild.build({
-    entryPoints: ['src/popup.js', 'src/options.js'],
-    bundle: true,
-    outdir: DIST,
-    format: 'iife',
-    target: 'chrome115',
-    minify: false,
-  });
-
-  // Copy static assets
+function copyStaticAssets() {
   fs.copyFileSync('popup.html', `${DIST}/popup.html`);
   fs.copyFileSync('options.html', `${DIST}/options.html`);
 
-  // Copy manifest with bundled file paths
   const manifest = JSON.parse(fs.readFileSync('manifest.json', 'utf8'));
   manifest.content_scripts[0].js = ['content.js'];
   manifest.background.service_worker = 'background.js';
   fs.writeFileSync(`${DIST}/manifest.json`, JSON.stringify(manifest, null, 2));
 
-  // Copy icons
   if (fs.existsSync('icons')) {
     fs.cpSync('icons', `${DIST}/icons`, { recursive: true });
   }
+}
 
-  console.log('Build complete → dist/');
+const sharedConfig = {
+  bundle: true,
+  format: 'iife',
+  target: 'chrome115',
+  minify: false,
+};
+
+async function build() {
+  fs.rmSync(DIST, { recursive: true, force: true });
+  fs.mkdirSync(DIST, { recursive: true });
+
+  if (isWatch) {
+    const contexts = await Promise.all([
+      esbuild.context({ ...sharedConfig, entryPoints: ['src/content/index.js'], outfile: `${DIST}/content.js` }),
+      esbuild.context({ ...sharedConfig, entryPoints: ['src/background/index.js'], outfile: `${DIST}/background.js` }),
+      esbuild.context({ ...sharedConfig, entryPoints: ['src/popup.js', 'src/options.js'], outdir: DIST }),
+    ]);
+    copyStaticAssets();
+    await Promise.all(contexts.map(ctx => ctx.watch()));
+    console.log('Watching for changes...');
+  } else {
+    await esbuild.build({ ...sharedConfig, entryPoints: ['src/content/index.js'], outfile: `${DIST}/content.js` });
+    await esbuild.build({ ...sharedConfig, entryPoints: ['src/background/index.js'], outfile: `${DIST}/background.js` });
+    await esbuild.build({ ...sharedConfig, entryPoints: ['src/popup.js', 'src/options.js'], outdir: DIST });
+    copyStaticAssets();
+    console.log('Build complete → dist/');
+  }
 }
 
 build().catch((err) => {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Chrome extension to select text and send it to ChatGPT or Claude",
   "scripts": {
     "build": "node esbuild.config.js",
+    "dev": "node esbuild.config.js --watch",
     "test": "vitest run",
     "test:watch": "vitest"
   },


### PR DESCRIPTION
## Summary

- Add `npm run dev` — runs esbuild in watch mode, auto-rebuilds `dist/` on file changes
- Refactor esbuild.config.js to share config between build and watch modes

## Dev workflow

```bash
npm run dev          # start watching
# edit src/ files... dist/ rebuilds automatically
# reload extension in Chrome to pick up changes
```

## Test plan

- [x] `npm run build` still works
- [x] All 408 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)