### PR TITLE
release: v1.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ jobs:
           cache: 'npm'
 
       - run: npm ci
-      - run: npm test
 
       - name: Validate version matches tag
         run: |
@@ -36,24 +35,19 @@ jobs:
           fi
           echo "Version $TAG_VERSION validated"
 
+      - name: Build extension
+        run: npm run build
+
+      - run: npm test
+
       - name: Package extension
         run: |
-          mkdir -p dist
-          zip -r dist/dobby-ai-${GITHUB_REF#refs/tags/}.zip \
-            manifest.json \
-            background.js \
-            content.js \
-            detection.js \
-            presets.js \
-            prompt.js \
-            trigger.js \
-            popup.js \
-            icons/
+          cd dist && zip -r ../dobby-ai-${GITHUB_REF#refs/tags/}.zip .
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/dobby-ai-*.zip
+          files: dobby-ai-*.zip
           generate_release_notes: true
 
       - name: Publish to Chrome Web Store
@@ -72,16 +66,16 @@ jobs:
             -d "grant_type=refresh_token" | node -e "process.stdin.on('data',d=>console.log(JSON.parse(d).access_token))")
 
           # Upload zip
-          curl -s -X PUT \
+          UPLOAD_RESULT=$(curl -s -X PUT \
             "https://www.googleapis.com/upload/chromewebstore/v1.1/items/$CHROME_EXTENSION_ID" \
             -H "Authorization: Bearer $ACCESS_TOKEN" \
             -H "x-goog-api-version: 2" \
-            -T dist/dobby-ai-${GITHUB_REF#refs/tags/}.zip
+            -T dobby-ai-${GITHUB_REF#refs/tags/}.zip)
+          echo "Upload result: $UPLOAD_RESULT"
 
           # Publish
-          curl -s -X POST \
+          PUBLISH_RESULT=$(curl -s -X POST \
             "https://www.googleapis.com/chromewebstore/v1.1/items/$CHROME_EXTENSION_ID/publish" \
             -H "Authorization: Bearer $ACCESS_TOKEN" \
-            -H "x-goog-api-version: 2"
-
-          echo "Published to Chrome Web Store"
+            -H "x-goog-api-version: 2")
+          echo "Publish result: $PUBLISH_RESULT"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/zhongnansu/dobby-ai/actions/workflows/ci.yml"><img src="https://github.com/zhongnansu/dobby-ai/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://github.com/zhongnansu/dobby-ai/actions/workflows/security.yml"><img src="https://github.com/zhongnansu/dobby-ai/actions/workflows/security.yml/badge.svg" alt="Security"></a>
   <a href="https://github.com/zhongnansu/dobby-ai/actions/workflows/coverage.yml"><img src="https://github.com/zhongnansu/dobby-ai/actions/workflows/coverage.yml/badge.svg" alt="Coverage"></a>
-  <img src="https://img.shields.io/badge/version-2.1.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-1.0.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/manifest-v3-green" alt="Manifest V3">
   <a href="https://github.com/zhongnansu/dobby-ai/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-yellow" alt="License"></a>
   <img src="https://img.shields.io/badge/chrome-web%20store-orange?logo=googlechrome&logoColor=white" alt="Chrome Web Store">

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dobby AI",
-  "version": "2.1.0",
+  "version": "1.0.0",
   "description": "Select text and get instant AI explanations inline on any page",
   "permissions": ["contextMenus", "activeTab", "storage", "notifications"],
   "host_permissions": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dobby-ai",
-  "version": "2.1.0",
+  "version": "1.0.0",
   "private": true,
   "description": "Select text or screenshot any region on the web — get instant AI answers right where you are",
   "scripts": {


### PR DESCRIPTION
## Summary

- Reset version to 1.0.0 — fresh start with new name and esbuild modular architecture
- Fix release workflow: `npm run build` before packaging, zip from `dist/`
- Deleted old releases (v1.0.0, v1.1.0, v2.1.0) and tags

After merge, tag `v1.0.0` to trigger the release workflow which will:
1. Build + test
2. Create GitHub Release with zip
3. Upload + publish to Chrome Web Store

🤖 Generated with [Claude Code](https://claude.com/claude-code)