### PR TITLE
feat: add repo token count badge to README

### DIFF
--- a/.github/workflows/token-count.yml
+++ b/.github/workflows/token-count.yml
@@ -1,0 +1,32 @@
+name: Update token count
+
+on:
+  push:
+    branches: [main]
+    paths: ['src/**']
+
+permissions:
+  contents: write
+
+jobs:
+  update-tokens:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: qwibitai/nanoclaw/repo-tokens@v1
+        id: tokens
+        with:
+          include: 'src/**/*.js'
+          exclude: 'src/**/*.test.js'
+          badge-path: '.github/badges/tokens.svg'
+      - name: Commit if changed
+        run: |
+          git add README.md .github/badges/tokens.svg
+          git diff --cached --quiet && exit 0
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -m "docs: update token count to ${{ steps.tokens.outputs.badge }}"
+          git push

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
   <a href="https://github.com/zhongnansu/dobby-ai/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-yellow" alt="License"></a>
   <img src="https://img.shields.io/badge/chrome-web%20store-orange?logo=googlechrome&logoColor=white" alt="Chrome Web Store">
   <img src="https://img.shields.io/badge/PRs-welcome-brightgreen" alt="PRs Welcome">
+  <!-- token-count --><!-- /token-count -->
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

Adds a token count badge to the README using [qwibitai/nanoclaw/repo-tokens](https://github.com/qwibitai/nanoclaw/tree/main/repo-tokens). The badge shows how many tokens the codebase is and what percentage of an LLM context window it fills (green <30%, yellow 50-70%, red 70%+).

- Counts all `src/**/*.js` files (excludes tests)
- Updates automatically on push to main when `src/` changes
- Badge SVG stored at `.github/badges/tokens.svg`

🤖 Generated with [Claude Code](https://claude.com/claude-code)