### PR TITLE
fix: use correct version tag for repo-tokens action

### DIFF
--- a/.github/workflows/token-count.yml
+++ b/.github/workflows/token-count.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - uses: qwibitai/nanoclaw/repo-tokens@v1
+      - uses: qwibitai/nanoclaw/repo-tokens@v1.2.0
         id: tokens
         with:
           include: 'src/**/*.js'


### PR DESCRIPTION
Fix: `qwibitai/nanoclaw@v1` tag doesn't exist. Use `@v1.2.0` instead.