### PR TITLE
feat: add three-way theme toggle to popup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dobby-ai",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dobby-ai",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "devDependencies": {
         "@playwright/test": "^1.58.2",
         "@vitest/coverage-v8": "^3.2.4",

--- a/popup.html
+++ b/popup.html
@@ -145,9 +145,9 @@
   <div class="theme-row">
     <span class="status">Theme</span>
     <div class="theme-segment" id="theme-segment" role="group" aria-label="Theme">
-      <button class="theme-option active" data-theme="auto">Auto</button>
-      <button class="theme-option" data-theme="light">Light</button>
-      <button class="theme-option" data-theme="dark">Dark</button>
+      <button class="theme-option active" data-theme="auto" aria-pressed="true">Auto</button>
+      <button class="theme-option" data-theme="light" aria-pressed="false">Light</button>
+      <button class="theme-option" data-theme="dark" aria-pressed="false">Dark</button>
     </div>
   </div>
   <a class="settings-link" id="settings">Settings</a>

--- a/popup.html
+++ b/popup.html
@@ -16,6 +16,41 @@
     .toggle-row { border-bottom-color: rgba(255,255,255,0.08); }
     .status { color: #a1a1aa; }
     .settings-link { color: #a78bfa; }
+    .theme-segment { background: #2a2a3a; border-color: rgba(255,255,255,0.08); }
+    .theme-option { color: #a1a1aa; }
+    .theme-option:hover { color: #e4e4e7; }
+    .theme-option.active { background: #7c3aed; color: #fff; }
+  }
+  .theme-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding-bottom: 10px;
+    margin-bottom: 10px;
+    border-bottom: 1px solid rgba(0,0,0,0.06);
+  }
+  .theme-segment {
+    display: flex;
+    border: 1px solid rgba(0,0,0,0.10);
+    border-radius: 6px;
+    overflow: hidden;
+    background: #f4f4f5;
+  }
+  .theme-option {
+    padding: 3px 8px;
+    font-size: 11px;
+    cursor: pointer;
+    border: none;
+    background: transparent;
+    color: #52525b;
+    font-family: inherit;
+    transition: background 0.15s, color 0.15s;
+  }
+  .theme-option:hover { color: #18181b; }
+  .theme-option.active {
+    background: #7c3aed;
+    color: #fff;
+    border-radius: 4px;
   }
   .header {
     display: flex;
@@ -106,6 +141,14 @@
       <input type="checkbox" id="autosuggest-enabled" aria-label="Enable or disable auto-suggest">
       <span class="slider"></span>
     </label>
+  </div>
+  <div class="theme-row">
+    <span class="status">Theme</span>
+    <div class="theme-segment" id="theme-segment" role="group" aria-label="Theme">
+      <button class="theme-option active" data-theme="auto">Auto</button>
+      <button class="theme-option" data-theme="light">Light</button>
+      <button class="theme-option" data-theme="dark">Dark</button>
+    </div>
   </div>
   <a class="settings-link" id="settings">Settings</a>
   <script src="popup.js"></script>

--- a/popup.html
+++ b/popup.html
@@ -13,7 +13,7 @@
   }
   @media (prefers-color-scheme: dark) {
     body { background: #1e1e28; color: #e4e4e7; }
-    .toggle-row { border-bottom-color: rgba(255,255,255,0.08); }
+    .toggle-row, .theme-row { border-bottom-color: rgba(255,255,255,0.08); }
     .status { color: #a1a1aa; }
     .settings-link { color: #a78bfa; }
     .theme-segment { background: #2a2a3a; border-color: rgba(255,255,255,0.08); }

--- a/src/content/bubble/core.js
+++ b/src/content/bubble/core.js
@@ -18,11 +18,22 @@ import { getSuggestedPresetsForType } from '../presets.js';
 import { buildChatMessages } from '../prompt.js';
 import { recordPresetUsage, buildTypeKey } from '../shared/preset-usage.js';
 
-export function detectTheme() {
-  if (typeof window !== 'undefined' && window.matchMedia) {
-    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-  }
-  return 'light';
+export async function detectTheme() {
+  return new Promise((resolve) => {
+    chrome.storage.local.get('theme', (data) => {
+      const stored = data.theme;
+      if (stored === 'light' || stored === 'dark') {
+        resolve(stored);
+        return;
+      }
+      // 'auto' or absent — fall back to OS preference
+      if (typeof window !== 'undefined' && window.matchMedia) {
+        resolve(window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+      } else {
+        resolve('light');
+      }
+    });
+  });
 }
 
 function truncatePreview(text, maxLen = 120) {
@@ -48,6 +59,19 @@ function createBubbleHost(selectionRect) {
   });
   host._escHandler = (e) => { if (e.key === 'Escape') hideBubble(); };
   document.addEventListener('keydown', host._escHandler);
+
+  // Live-update theme when storage changes
+  host._storageChangeHandler = (changes) => {
+    if (!changes.theme) return;
+    const newTheme = changes.theme.newValue || 'auto';
+    detectTheme().then((theme) => {
+      if (!bubbleHost || !bubbleHost.shadowRoot) return;
+      const styleEl = bubbleHost.shadowRoot.querySelector('style');
+      if (styleEl) styleEl.textContent = getStyles(theme);
+    });
+  };
+  chrome.storage.onChanged.addListener(host._storageChangeHandler);
+
   setBubbleHost(host);
   return host;
 }
@@ -239,7 +263,7 @@ function activateResponseSection(shadow, messages) {
   startStreaming(shadow, messages);
 }
 
-function initBubble(selectionRect, selectedText, previewLabel, showPresets, images) {
+async function initBubble(selectionRect, selectedText, previewLabel, showPresets, images) {
   hideBubble();
   setResponseText('');
 
@@ -248,7 +272,7 @@ function initBubble(selectionRect, selectedText, previewLabel, showPresets, imag
   const shadow = bubbleHost.attachShadow({ mode: 'open' });
 
   const style = document.createElement('style');
-  style.textContent = getStyles(detectTheme());
+  style.textContent = getStyles(await detectTheme());
   shadow.appendChild(style);
 
   const bubble = document.createElement('div');
@@ -273,11 +297,11 @@ function launchFromPreset(shadow, selectedText, instruction, images) {
 }
 
 // Show bubble with preset selection first, then expand to show response
-export function showBubbleWithPresets(selectionRect, selectedText, anchorNode, images) {
+export async function showBubbleWithPresets(selectionRect, selectedText, anchorNode, images) {
   const hasImages = images && images.length > 0;
   const isImageOnly = hasImages && !selectedText.trim();
   const previewLabel = isImageOnly ? 'Image' : 'Selected text';
-  const shadow = initBubble(selectionRect, selectedText, previewLabel, true, images);
+  const shadow = await initBubble(selectionRect, selectedText, previewLabel, true, images);
 
   // Detect content type and populate presets
   let detected;
@@ -330,9 +354,9 @@ export function showBubbleWithPresets(selectionRect, selectedText, anchorNode, i
 }
 
 // Direct bubble (used by context menu — no preset selection needed)
-export function showBubble(selectionRect, messages, selectedText, instruction, images) {
+export async function showBubble(selectionRect, messages, selectedText, instruction, images) {
   setCurrentMessages(messages);
-  const shadow = initBubble(selectionRect, selectedText, instruction || 'Selected text', false, images);
+  const shadow = await initBubble(selectionRect, selectedText, instruction || 'Selected text', false, images);
   activateResponseSection(shadow, messages);
 }
 
@@ -350,6 +374,9 @@ export function hideBubble() {
       bubbleHost._resizeCleanup();
     }
     if (bubbleHost._escHandler) document.removeEventListener('keydown', bubbleHost._escHandler);
+    if (bubbleHost._storageChangeHandler) {
+      chrome.storage.onChanged.removeListener(bubbleHost._storageChangeHandler);
+    }
     removeElement(bubbleHost);
   }
   setBubbleHost(null);

--- a/src/content/bubble/core.js
+++ b/src/content/bubble/core.js
@@ -63,12 +63,12 @@ function createBubbleHost(selectionRect) {
   // Live-update theme when storage changes
   host._storageChangeHandler = (changes) => {
     if (!changes.theme) return;
-    const newTheme = changes.theme.newValue || 'auto';
-    detectTheme().then((theme) => {
-      if (!bubbleHost || !bubbleHost.shadowRoot) return;
-      const styleEl = bubbleHost.shadowRoot.querySelector('style');
-      if (styleEl) styleEl.textContent = getStyles(theme);
-    });
+    const raw = changes.theme.newValue || 'auto';
+    const theme = (raw === 'light' || raw === 'dark') ? raw
+      : window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    if (!bubbleHost || !bubbleHost.shadowRoot) return;
+    const styleEl = bubbleHost.shadowRoot.querySelector('style');
+    if (styleEl) styleEl.textContent = getStyles(theme);
   };
   chrome.storage.onChanged.addListener(host._storageChangeHandler);
 

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -71,9 +71,9 @@ chrome.runtime.onMessage.addListener((msg) => {
         const captured = await captureImage(msg.image);
         if (captured) images = [captured];
         if (images.length > 0) {
-          showBubbleWithPresets(rect, '', null, images);
+          await showBubbleWithPresets(rect, '', null, images);
         } else {
-          showBubble(rect, [{ role: 'user', content: "Couldn't capture this image" }], '', 'Error');
+          await showBubble(rect, [{ role: 'user', content: "Couldn't capture this image" }], '', 'Error');
         }
       })();
       return;
@@ -81,7 +81,7 @@ chrome.runtime.onMessage.addListener((msg) => {
 
     const instruction = 'Explain the following';
     const messages = buildChatMessages(msg.text, instruction, true);
-    showBubble(rect, messages, msg.text, instruction);
+    (async () => { await showBubble(rect, messages, msg.text, instruction); })();
   }
 });
 

--- a/src/content/trigger/button.js
+++ b/src/content/trigger/button.js
@@ -433,10 +433,16 @@ function exitInputMode(shadow, pencilBtn, inputField, sendBtn, host) {
 
 // --- Public API ---
 
+let toolbarCreating = null;
+
 export async function showTrigger(x, y, selectionData = {}) {
   let host = document.getElementById('dobby-ai-toolbar-host');
   if (!host) {
-    host = await createToolbar();
+    if (!toolbarCreating) {
+      toolbarCreating = createToolbar();
+    }
+    host = await toolbarCreating;
+    toolbarCreating = null;
   }
 
   // Store selection data on host

--- a/src/content/trigger/button.js
+++ b/src/content/trigger/button.js
@@ -298,8 +298,8 @@ function morphIntoBubble(host, shadow, label, instruction) {
   const images = host._images || null;
   const messages = buildChatMessages(text, instruction, true, images);
 
-  // Crossfade: open bubble FIRST, then fade out toolbar on top
-  // This avoids the blink — toolbar stays visible while bubble appears underneath
+  // Crossfade: start bubble creation and toolbar fade simultaneously.
+  // showBubble is async (theme read) but the fade timer is independent of that.
   showBubble(selectionRect, messages, text, instruction, images);
 
   // Fade out toolbar smoothly over the same duration as bubble entry animation

--- a/src/content/trigger/button.js
+++ b/src/content/trigger/button.js
@@ -144,6 +144,16 @@ async function createToolbar() {
 
   shadow.appendChild(toolbar);
 
+  // Live-update theme when storage changes
+  host._storageChangeHandler = (changes) => {
+    if (!changes.theme) return;
+    const raw = changes.theme.newValue || 'auto';
+    const theme = (raw === 'light' || raw === 'dark') ? raw
+      : window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    style.textContent = getToolbarStyles(theme);
+  };
+  chrome.storage.onChanged.addListener(host._storageChangeHandler);
+
   // --- Event handlers ---
   toolbar.addEventListener('mouseenter', () => {
     clearAutoHide();
@@ -300,7 +310,8 @@ function morphIntoBubble(host, shadow, label, instruction) {
 
   // Crossfade: start bubble creation and toolbar fade simultaneously.
   // showBubble is async (theme read) but the fade timer is independent of that.
-  showBubble(selectionRect, messages, text, instruction, images);
+  showBubble(selectionRect, messages, text, instruction, images)
+    .catch((err) => console.error('[Dobby AI] Bubble creation failed:', err));
 
   // Fade out toolbar smoothly over the same duration as bubble entry animation
   toolbar.style.transition = 'opacity 0.2s ease-out, transform 0.2s ease-out';
@@ -454,6 +465,9 @@ export function hideTrigger() {
   }
   const host = document.getElementById('dobby-ai-toolbar-host');
   if (host) {
+    if (host._storageChangeHandler) {
+      chrome.storage.onChanged.removeListener(host._storageChangeHandler);
+    }
     host.remove();
   }
   setToolbarHost(null);

--- a/src/content/trigger/button.js
+++ b/src/content/trigger/button.js
@@ -65,7 +65,7 @@ function clearAutoHide() {
 
 // --- Toolbar creation ---
 
-function createToolbar() {
+async function createToolbar() {
   const host = document.createElement('div');
   host.id = 'dobby-ai-toolbar-host';
   Object.assign(host.style, {
@@ -79,7 +79,7 @@ function createToolbar() {
 
   // Inject styles
   const style = document.createElement('style');
-  style.textContent = getToolbarStyles(detectTheme());
+  style.textContent = getToolbarStyles(await detectTheme());
   shadow.appendChild(style);
 
   // Build toolbar DOM
@@ -422,10 +422,10 @@ function exitInputMode(shadow, pencilBtn, inputField, sendBtn, host) {
 
 // --- Public API ---
 
-export function showTrigger(x, y, selectionData = {}) {
+export async function showTrigger(x, y, selectionData = {}) {
   let host = document.getElementById('dobby-ai-toolbar-host');
   if (!host) {
-    host = createToolbar();
+    host = await createToolbar();
   }
 
   // Store selection data on host
@@ -462,11 +462,11 @@ export function hideTrigger() {
 }
 
 // --- Legacy compatibility: createTriggerButton maps to showTrigger ---
-export function createTriggerButton() {
+export async function createTriggerButton() {
   // For backwards compat: create toolbar in hidden state
   let host = document.getElementById('dobby-ai-toolbar-host');
   if (!host) {
-    host = createToolbar();
+    host = await createToolbar();
   }
 }
 

--- a/src/content/trigger/screenshot.js
+++ b/src/content/trigger/screenshot.js
@@ -182,7 +182,7 @@ function _showConfirmToolbar(overlay, banner, rect) {
             right: rect.x + rect.width,
             top: rect.y,
           };
-          showBubbleWithPresets(bubbleRect, '', null, [captured]);
+          await showBubbleWithPresets(bubbleRect, '', null, [captured]);
         }
       }
     } catch (err) {

--- a/src/content/trigger/selection.js
+++ b/src/content/trigger/selection.js
@@ -61,7 +61,7 @@ export function registerListeners() {
       if (text.length >= 3 && dobbyEnabled) {
         const sel = window.getSelection();
         const anchorNode = sel.anchorNode || null;
-        showTrigger(cursorX, cursorY, { text, anchorNode });
+        showTrigger(cursorX, cursorY, { text, anchorNode }).catch(() => {});
       } else {
         hideTrigger();
       }
@@ -79,7 +79,7 @@ export function registerListeners() {
         if (!triggerButton || triggerButton.style.display === 'none') {
           const anchorNode = selection.anchorNode || null;
           const rect = getSelectionRect();
-          showTrigger(rect.right, rect.bottom, { text, anchorNode });
+          showTrigger(rect.right, rect.bottom, { text, anchorNode }).catch(() => {});
         }
       }
     }, TIMING.SELECTION_DEBOUNCE));
@@ -95,7 +95,7 @@ export function registerListeners() {
       if (text.length >= 3 && dobbyEnabled && selection.rangeCount > 0) {
         const anchorNode = selection.anchorNode || null;
         const rect = getSelectionRect();
-        showTrigger(rect.right, rect.top, { text, anchorNode });
+        showTrigger(rect.right, rect.top, { text, anchorNode }).catch(() => {});
       }
     }, TIMING.SCROLL_DEBOUNCE));
   }, true);

--- a/src/popup.js
+++ b/src/popup.js
@@ -66,7 +66,9 @@ const themeOptions = document.querySelectorAll('.theme-option');
 
 function setActiveThemeOption(value) {
   themeOptions.forEach((btn) => {
-    btn.classList.toggle('active', btn.dataset.theme === value);
+    const isActive = btn.dataset.theme === value;
+    btn.classList.toggle('active', isActive);
+    btn.setAttribute('aria-pressed', String(isActive));
   });
 }
 

--- a/src/popup.js
+++ b/src/popup.js
@@ -60,3 +60,25 @@ autosuggestToggle.addEventListener('change', () => {
     });
   });
 });
+
+// Theme segmented control
+const themeOptions = document.querySelectorAll('.theme-option');
+
+function setActiveThemeOption(value) {
+  themeOptions.forEach((btn) => {
+    btn.classList.toggle('active', btn.dataset.theme === value);
+  });
+}
+
+chrome.storage.local.get('theme', (data) => {
+  const theme = data.theme || 'auto';
+  setActiveThemeOption(theme);
+});
+
+themeOptions.forEach((btn) => {
+  btn.addEventListener('click', () => {
+    const value = btn.dataset.theme;
+    chrome.storage.local.set({ theme: value });
+    setActiveThemeOption(value);
+  });
+});

--- a/tests/bubble.test.js
+++ b/tests/bubble.test.js
@@ -64,28 +64,28 @@ describe('bubble.js', () => {
   });
 
   describe('showBubble', () => {
-    it('creates a shadow DOM container', () => {
-      showBubble({ bottom: 200, left: 100, right: 300 }, [{ role: 'user', content: 'hi' }]);
+    it('creates a shadow DOM container', async () => {
+      await showBubble({ bottom: 200, left: 100, right: 300 }, [{ role: 'user', content: 'hi' }]);
       const container = _getBubbleContainer();
       expect(container).not.toBeNull();
       expect(container.shadowRoot).not.toBeNull();
     });
 
-    it('positions below the selection rect', () => {
-      showBubble({ bottom: 150, left: 50, right: 250 }, []);
+    it('positions below the selection rect', async () => {
+      await showBubble({ bottom: 150, left: 50, right: 250 }, []);
       const container = _getBubbleContainer();
       expect(container.style.top).toBe('158px'); // bottom + 8px gap
     });
 
-    it('shows thinking status initially', () => {
-      showBubble({ bottom: 100, left: 50, right: 250 }, []);
+    it('shows thinking status initially', async () => {
+      await showBubble({ bottom: 100, left: 50, right: 250 }, []);
       const container = _getBubbleContainer();
       const status = container.shadowRoot.querySelector('.bubble-status');
       expect(status.textContent).toBe('thinking...');
     });
 
-    it('has Dobby AI branding in header', () => {
-      showBubble({ bottom: 100, left: 50, right: 250 }, []);
+    it('has Dobby AI branding in header', async () => {
+      await showBubble({ bottom: 100, left: 50, right: 250 }, []);
       const container = _getBubbleContainer();
       const header = container.shadowRoot.querySelector('.bubble-header');
       expect(header.textContent).toContain('Dobby AI');
@@ -93,8 +93,8 @@ describe('bubble.js', () => {
   });
 
   describe('appendToken', () => {
-    it('appends text to response area', () => {
-      showBubble({ bottom: 100, left: 50, right: 250 }, []);
+    it('appends text to response area', async () => {
+      await showBubble({ bottom: 100, left: 50, right: 250 }, []);
       appendToken('Hello');
       appendToken(' world');
       const container = _getBubbleContainer();
@@ -104,8 +104,8 @@ describe('bubble.js', () => {
   });
 
   describe('setBubbleStatus', () => {
-    it('updates status text', () => {
-      showBubble({ bottom: 100, left: 50, right: 250 }, []);
+    it('updates status text', async () => {
+      await showBubble({ bottom: 100, left: 50, right: 250 }, []);
       setBubbleStatus('typing...');
       const container = _getBubbleContainer();
       const status = container.shadowRoot.querySelector('.bubble-status');
@@ -114,68 +114,68 @@ describe('bubble.js', () => {
   });
 
   describe('hideBubble', () => {
-    it('removes bubble from DOM', () => {
-      showBubble({ bottom: 100, left: 50, right: 250 }, []);
+    it('removes bubble from DOM', async () => {
+      await showBubble({ bottom: 100, left: 50, right: 250 }, []);
       expect(_getBubbleContainer()).not.toBeNull();
       hideBubble();
       expect(_getBubbleContainer()).toBeNull();
     });
 
-    it('is safe to call when no bubble exists', () => {
+    it('is safe to call when no bubble exists', async () => {
       expect(() => hideBubble()).not.toThrow();
     });
   });
 
   describe('renderMarkdown', () => {
-    it('renders bold text', () => {
+    it('renders bold text', async () => {
       expect(renderMarkdown('**bold**')).toContain('<strong>bold</strong>');
     });
 
-    it('renders inline code', () => {
+    it('renders inline code', async () => {
       expect(renderMarkdown('`code`')).toContain('<code>code</code>');
     });
 
-    it('renders code blocks', () => {
+    it('renders code blocks', async () => {
       const result = renderMarkdown('```\nconst x = 1;\n```');
       expect(result).toContain('<pre><code>');
       expect(result).toContain('const x = 1;');
     });
 
-    it('renders newlines as <br>', () => {
+    it('renders newlines as <br>', async () => {
       expect(renderMarkdown('line1\nline2')).toContain('<br>');
     });
 
-    it('handles plain text without modification', () => {
+    it('handles plain text without modification', async () => {
       const result = renderMarkdown('just plain text');
       expect(result).toContain('just plain text');
     });
   });
 
   describe('detectTheme', () => {
-    it('returns light when OS prefers light', () => {
+    it('returns light when OS prefers light', async () => {
       window.matchMedia = vi.fn(() => ({ matches: false }));
-      expect(detectTheme()).toBe('light');
+      expect(await detectTheme()).toBe('light');
       expect(window.matchMedia).toHaveBeenCalledWith('(prefers-color-scheme: dark)');
     });
 
-    it('returns dark when OS prefers dark', () => {
+    it('returns dark when OS prefers dark', async () => {
       window.matchMedia = vi.fn(() => ({ matches: true }));
-      expect(detectTheme()).toBe('dark');
+      expect(await detectTheme()).toBe('dark');
       expect(window.matchMedia).toHaveBeenCalledWith('(prefers-color-scheme: dark)');
     });
 
-    it('defaults to light when matchMedia unavailable', () => {
+    it('defaults to light when matchMedia unavailable', async () => {
       const original = window.matchMedia;
       window.matchMedia = undefined;
-      expect(detectTheme()).toBe('light');
+      expect(await detectTheme()).toBe('light');
       window.matchMedia = original;
     });
   });
 
   // Errata item 8: additional tests
   describe('follow-up input', () => {
-    it('calls buildFollowUp and requestChat on Enter', () => {
-      showBubble({ bottom: 100, left: 50, right: 250 }, [{ role: 'user', content: 'hi' }]);
+    it('calls buildFollowUp and requestChat on Enter', async () => {
+      await showBubble({ bottom: 100, left: 50, right: 250 }, [{ role: 'user', content: 'hi' }]);
       const container = _getBubbleContainer();
       const input = container.shadowRoot.querySelector('.follow-up-input');
       input.disabled = false;
@@ -197,7 +197,7 @@ describe('bubble.js', () => {
         },
       ]);
 
-      showBubble({ bottom: 100, left: 50, right: 250 }, [{ role: 'user', content: 'hi' }]);
+      await showBubble({ bottom: 100, left: 50, right: 250 }, [{ role: 'user', content: 'hi' }]);
       const container = _getBubbleContainer();
       const shadow = container.shadowRoot;
 
@@ -222,7 +222,7 @@ describe('bubble.js', () => {
         },
       ]);
 
-      showBubble({ bottom: 100, left: 50, right: 250 }, [{ role: 'user', content: 'hi' }]);
+      await showBubble({ bottom: 100, left: 50, right: 250 }, [{ role: 'user', content: 'hi' }]);
       const container = _getBubbleContainer();
       const shadow = container.shadowRoot;
 
@@ -252,7 +252,7 @@ describe('bubble.js', () => {
         },
       ]);
 
-      showBubble({ bottom: 100, left: 50, right: 250 }, [{ role: 'user', content: 'hi' }]);
+      await showBubble({ bottom: 100, left: 50, right: 250 }, [{ role: 'user', content: 'hi' }]);
       const container = _getBubbleContainer();
       const shadow = container.shadowRoot;
 
@@ -287,7 +287,7 @@ describe('bubble.js', () => {
         },
       ]);
 
-      showBubble({ bottom: 100, left: 50, right: 250 }, [{ role: 'user', content: 'hi' }]);
+      await showBubble({ bottom: 100, left: 50, right: 250 }, [{ role: 'user', content: 'hi' }]);
       const container = _getBubbleContainer();
       const shadow = container.shadowRoot;
 
@@ -300,8 +300,8 @@ describe('bubble.js', () => {
   });
 
   describe('keyboard shortcuts', () => {
-    it('closes bubble on Escape key', () => {
-      showBubble({ bottom: 100, left: 50, right: 250 }, []);
+    it('closes bubble on Escape key', async () => {
+      await showBubble({ bottom: 100, left: 50, right: 250 }, []);
       expect(_getBubbleContainer()).not.toBeNull();
       document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
       expect(_getBubbleContainer()).toBeNull();
@@ -309,7 +309,7 @@ describe('bubble.js', () => {
   });
 
   describe('renderMarkdown XSS', () => {
-    it('escapes HTML tags in input', () => {
+    it('escapes HTML tags in input', async () => {
       const result = renderMarkdown('<script>alert("xss")</script>');
       expect(result).not.toContain('<script>');
       expect(result).toContain('&lt;script&gt;');
@@ -317,74 +317,74 @@ describe('bubble.js', () => {
   });
 
   describe('renderMarkdown lists', () => {
-    it('renders list items', () => {
+    it('renders list items', async () => {
       const result = renderMarkdown('- item one\n- item two');
       expect(result).toContain('<li>item one</li>');
     });
   });
 
   describe('renderMarkdown images', () => {
-    it('renders https image markdown as img tag', () => {
+    it('renders https image markdown as img tag', async () => {
       const result = renderMarkdown('![diagram](https://example.com/img.png)');
       expect(result).toContain('<img class="response-img"');
       expect(result).toContain('src="https://example.com/img.png"');
       expect(result).toContain('alt="diagram"');
     });
 
-    it('rejects non-https image URLs', () => {
+    it('rejects non-https image URLs', async () => {
       const result = renderMarkdown('![pic](http://example.com/img.png)');
       expect(result).not.toContain('<img');
       expect(result).toContain('![pic]');
     });
 
-    it('rejects javascript: URLs', () => {
+    it('rejects javascript: URLs', async () => {
       const result = renderMarkdown('![xss](javascript:alert(1))');
       expect(result).not.toContain('<img');
     });
 
-    it('rejects data: URLs', () => {
+    it('rejects data: URLs', async () => {
       const result = renderMarkdown('![xss](data:text/html,<script>alert(1)</script>)');
       expect(result).not.toContain('<img');
     });
 
-    it('escapes alt text to prevent XSS', () => {
+    it('escapes alt text to prevent XSS', async () => {
       const result = renderMarkdown('![<script>xss</script>](https://example.com/img.png)');
       expect(result).toContain('&lt;script&gt;');
       expect(result).not.toContain('alt="<script>');
     });
 
-    it('escapes double quotes in alt text', () => {
+    it('escapes double quotes in alt text', async () => {
       const result = renderMarkdown('![x" onerror="alert(1)](https://example.com/img.png)');
       // Quotes escaped — onerror stays inside the alt value, not a separate attribute
       expect(result).toContain('&quot;');
       expect(result).not.toMatch(/alt="[^"]*"\s+onerror="/);
     });
 
-    it('escapes double quotes in URLs', () => {
+    it('escapes double quotes in URLs', async () => {
       const result = renderMarkdown('![x](https://evil.com/x" onerror="alert(1))');
       // Quotes escaped — onerror stays inside the src value, not a separate attribute
       expect(result).toContain('&quot;');
       expect(result).not.toMatch(/src="[^"]*"\s+onerror="/);
     });
 
-    it('does not render images inside code blocks', () => {
+    it('does not render images inside code blocks', async () => {
       const result = renderMarkdown('```\n![alt](https://example.com/img.png)\n```');
       expect(result).not.toContain('<img');
       expect(result).toContain('<pre><code>');
     });
 
-    it('handles placeholder pattern in raw text without crashing', () => {
+    it('handles placeholder pattern in raw text without crashing', async () => {
       const result = renderMarkdown('The pattern %%IMAGE_0%% is used internally');
       expect(result).toBeDefined();
     });
 
-    it('renders multiple images', () => {
+    it('renders multiple images', async () => {
       const text = '![a](https://example.com/1.png)\n![b](https://example.com/2.png)';
       const result = renderMarkdown(text);
       expect((result.match(/<img/g) || []).length).toBe(2);
     });
 
-    it('mixes images with other markdown', () => {
+    it('mixes images with other markdown', async () => {
       const text = '**bold** and ![img](https://example.com/pic.png) and `code`';
       const result = renderMarkdown(text);
       expect(result).toContain('<strong>bold</strong>');
@@ -394,15 +394,15 @@ describe('bubble.js', () => {
   });
 
   describe('resize handle', () => {
-    it('renders a resize handle in the bubble', () => {
-      showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
+    it('renders a resize handle in the bubble', async () => {
+      await showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
       const shadow = document.querySelector('#dobby-ai-bubble').shadowRoot;
       const handle = shadow.querySelector('.resize-handle');
       expect(handle).not.toBeNull();
     });
 
-    it('resizes bubble on mousedown + mousemove on handle', () => {
-      showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
+    it('resizes bubble on mousedown + mousemove on handle', async () => {
+      await showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
       const shadow = document.querySelector('#dobby-ai-bubble').shadowRoot;
       const handle = shadow.querySelector('.resize-handle');
       const bubble = shadow.querySelector('.bubble');
@@ -417,8 +417,8 @@ describe('bubble.js', () => {
       expect(parseInt(bubble.style.height)).toBe(300);
     });
 
-    it('enforces minimum size of 300x200', () => {
-      showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
+    it('enforces minimum size of 300x200', async () => {
+      await showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
       const shadow = document.querySelector('#dobby-ai-bubble').shadowRoot;
       const handle = shadow.querySelector('.resize-handle');
       const bubble = shadow.querySelector('.bubble');
@@ -432,8 +432,8 @@ describe('bubble.js', () => {
       expect(parseInt(bubble.style.height)).toBeGreaterThanOrEqual(200);
     });
 
-    it('stops resizing after mouseup', () => {
-      showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
+    it('stops resizing after mouseup', async () => {
+      await showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
       const shadow = document.querySelector('#dobby-ai-bubble').shadowRoot;
       const handle = shadow.querySelector('.resize-handle');
       const bubble = shadow.querySelector('.bubble');
@@ -448,8 +448,8 @@ describe('bubble.js', () => {
       expect(bubble.style.width).toBe(widthAfterRelease);
     });
 
-    it('close button still works after resize', () => {
-      showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
+    it('close button still works after resize', async () => {
+      await showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
       const shadow = document.querySelector('#dobby-ai-bubble').shadowRoot;
       const handle = shadow.querySelector('.resize-handle');
       const bubble = shadow.querySelector('.bubble');
@@ -464,8 +464,8 @@ describe('bubble.js', () => {
       expect(document.querySelector('#dobby-ai-bubble')).toBeNull();
     });
 
-    it('cleans up resize listeners when bubble is hidden during resize', () => {
-      showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
+    it('cleans up resize listeners when bubble is hidden during resize', async () => {
+      await showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
       const shadow = document.querySelector('#dobby-ai-bubble').shadowRoot;
       const handle = shadow.querySelector('.resize-handle');
 
@@ -479,16 +479,16 @@ describe('bubble.js', () => {
   });
 
   describe('pin button', () => {
-    it('renders a pin button in the bubble header', () => {
-      showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
+    it('renders a pin button in the bubble header', async () => {
+      await showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
       const shadow = document.querySelector('#dobby-ai-bubble').shadowRoot;
       const pinBtn = shadow.querySelector('.pin-btn');
       expect(pinBtn).not.toBeNull();
       expect(pinBtn.title).toBe('Pin');
     });
 
-    it('toggles pinned state on click', () => {
-      showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
+    it('toggles pinned state on click', async () => {
+      await showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
       const host = document.querySelector('#dobby-ai-bubble');
       const shadow = host.shadowRoot;
       const pinBtn = shadow.querySelector('.pin-btn');
@@ -507,8 +507,8 @@ describe('bubble.js', () => {
       expect(pinBtn.title).toBe('Pin');
     });
 
-    it('close button still works when pinned', () => {
-      showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
+    it('close button still works when pinned', async () => {
+      await showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
       const host = document.querySelector('#dobby-ai-bubble');
       const shadow = host.shadowRoot;
       shadow.querySelector('.pin-btn').click(); // pin it
@@ -517,8 +517,8 @@ describe('bubble.js', () => {
       expect(document.querySelector('#dobby-ai-bubble')).toBeNull();
     });
 
-    it('Escape key closes bubble when pinned', () => {
-      showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
+    it('Escape key closes bubble when pinned', async () => {
+      await showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
       const host = document.querySelector('#dobby-ai-bubble');
       const shadow = host.shadowRoot;
       shadow.querySelector('.pin-btn').click(); // pin it
@@ -527,21 +527,21 @@ describe('bubble.js', () => {
       expect(document.querySelector('#dobby-ai-bubble')).toBeNull();
     });
 
-    it('pin resets to unpinned on new bubble open', () => {
-      showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
+    it('pin resets to unpinned on new bubble open', async () => {
+      await showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
       const host1 = document.querySelector('#dobby-ai-bubble');
       host1.shadowRoot.querySelector('.pin-btn').click(); // pin it
       expect(host1._isPinned).toBe(true);
       // Open new bubble (replaces the old one)
-      showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test2');
+      await showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test2');
       const host2 = document.querySelector('#dobby-ai-bubble');
       expect(host2._isPinned).toBe(false);
     });
   });
 
   describe('draggable when pinned', () => {
-    it('header has draggable class when pinned', () => {
-      showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
+    it('header has draggable class when pinned', async () => {
+      await showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
       const host = document.querySelector('#dobby-ai-bubble');
       const shadow = host.shadowRoot;
       const header = shadow.querySelector('.bubble-header');
@@ -554,8 +554,8 @@ describe('bubble.js', () => {
       expect(header.classList.contains('draggable')).toBe(false);
     });
 
-    it('header is not draggable when unpinned', () => {
-      showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
+    it('header is not draggable when unpinned', async () => {
+      await showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
       const shadow = document.querySelector('#dobby-ai-bubble').shadowRoot;
       const header = shadow.querySelector('.bubble-header');
 
@@ -570,8 +570,8 @@ describe('bubble.js', () => {
       expect(host.style.left).toBe(initialLeft);
     });
 
-    it('moves bubble when dragging header while pinned', () => {
-      showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
+    it('moves bubble when dragging header while pinned', async () => {
+      await showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
       const host = document.querySelector('#dobby-ai-bubble');
       const shadow = host.shadowRoot;
       const pinBtn = shadow.querySelector('.pin-btn');
@@ -590,8 +590,8 @@ describe('bubble.js', () => {
       expect(parseInt(host.style.top)).toBe(initialTop + 150);
     });
 
-    it('stops dragging on mouseup', () => {
-      showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
+    it('stops dragging on mouseup', async () => {
+      await showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
       const host = document.querySelector('#dobby-ai-bubble');
       const shadow = host.shadowRoot;
       shadow.querySelector('.pin-btn').click();
@@ -606,8 +606,8 @@ describe('bubble.js', () => {
       expect(host.style.left).toBe(leftAfterDrop);
     });
 
-    it('does not drag when clicking pin button', () => {
-      showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
+    it('does not drag when clicking pin button', async () => {
+      await showBubble({ top: 100, bottom: 120, left: 50, right: 200 }, 'test');
       const host = document.querySelector('#dobby-ai-bubble');
       const shadow = host.shadowRoot;
       const pinBtn = shadow.querySelector('.pin-btn');
@@ -624,8 +624,8 @@ describe('bubble.js', () => {
   });
 
   describe('image lightbox', () => {
-    it('opens lightbox overlay when image is clicked', () => {
-      showBubble({ bottom: 100, left: 50, right: 250 }, []);
+    it('opens lightbox overlay when image is clicked', async () => {
+      await showBubble({ bottom: 100, left: 50, right: 250 }, []);
       const container = _getBubbleContainer();
       const shadow = container.shadowRoot;
       const responseText = shadow.querySelector('.response-text');
@@ -639,8 +639,8 @@ describe('bubble.js', () => {
       expect(lightbox.querySelector('img').src).toBe('https://example.com/img.png');
     });
 
-    it('closes lightbox when overlay is clicked', () => {
-      showBubble({ bottom: 100, left: 50, right: 250 }, []);
+    it('closes lightbox when overlay is clicked', async () => {
+      await showBubble({ bottom: 100, left: 50, right: 250 }, []);
       const container = _getBubbleContainer();
       const shadow = container.shadowRoot;
       const responseText = shadow.querySelector('.response-text');

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -23,6 +23,10 @@ export function setupChromeMocks(overrides = {}) {
         get: vi.fn((keys, cb) => cb({})),
         set: vi.fn((data, cb) => { if (cb) cb(); }),
       },
+      onChanged: {
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+      },
       ...(overrides.storage || {}),
     },
     contextMenus: {

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -13,6 +13,11 @@ document.body.innerHTML = `
   <span id="screenshot-status">Screenshot mode</span>
   <input type="checkbox" id="autosuggest-enabled" />
   <span id="autosuggest-status" title="Works in standard text fields (textarea). Gmail, Docs, and Notion support coming soon.">Auto-suggest</span>
+  <div id="theme-segment">
+    <button class="theme-option active" data-theme="auto">Auto</button>
+    <button class="theme-option" data-theme="light">Light</button>
+    <button class="theme-option" data-theme="dark">Dark</button>
+  </div>
   <a id="settings" href="#">Settings</a>
 `;
 
@@ -147,6 +152,56 @@ describe('popup.js', () => {
       toggle.checked = false;
       toggle.dispatchEvent(new Event('change'));
       expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(1, { type: 'SCREENSHOT_TOGGLE', enabled: false });
+    });
+  });
+
+  describe('theme toggle', () => {
+    it('renders three theme option buttons', () => {
+      const options = document.querySelectorAll('.theme-option');
+      expect(options.length).toBe(3);
+      expect(options[0].dataset.theme).toBe('auto');
+      expect(options[1].dataset.theme).toBe('light');
+      expect(options[2].dataset.theme).toBe('dark');
+    });
+
+    it('defaults to Auto active when theme absent from storage', () => {
+      storageGetCallbacks['theme']({});
+      const options = document.querySelectorAll('.theme-option');
+      expect(options[0].classList.contains('active')).toBe(true);
+      expect(options[1].classList.contains('active')).toBe(false);
+      expect(options[2].classList.contains('active')).toBe(false);
+    });
+
+    it('loads light theme from storage and activates Light button', () => {
+      storageGetCallbacks['theme']({ theme: 'light' });
+      const options = document.querySelectorAll('.theme-option');
+      expect(options[0].classList.contains('active')).toBe(false);
+      expect(options[1].classList.contains('active')).toBe(true);
+      expect(options[2].classList.contains('active')).toBe(false);
+    });
+
+    it('loads dark theme from storage and activates Dark button', () => {
+      storageGetCallbacks['theme']({ theme: 'dark' });
+      const options = document.querySelectorAll('.theme-option');
+      expect(options[0].classList.contains('active')).toBe(false);
+      expect(options[1].classList.contains('active')).toBe(false);
+      expect(options[2].classList.contains('active')).toBe(true);
+    });
+
+    it('persists theme to chrome.storage on click', () => {
+      vi.clearAllMocks();
+      const darkBtn = document.querySelector('.theme-option[data-theme="dark"]');
+      darkBtn.click();
+      expect(chrome.storage.local.set).toHaveBeenCalledWith({ theme: 'dark' });
+    });
+
+    it('updates active class on click', () => {
+      const lightBtn = document.querySelector('.theme-option[data-theme="light"]');
+      lightBtn.click();
+      const options = document.querySelectorAll('.theme-option');
+      expect(options[1].classList.contains('active')).toBe(true);
+      expect(options[0].classList.contains('active')).toBe(false);
+      expect(options[2].classList.contains('active')).toBe(false);
     });
   });
 

--- a/tests/toolbar.test.js
+++ b/tests/toolbar.test.js
@@ -6,7 +6,7 @@ import { setupChromeMocks } from './helpers.js';
 
 // Mock bubble/core.js
 vi.mock('../src/content/bubble/core.js', () => ({
-  showBubble: vi.fn(),
+  showBubble: vi.fn(() => Promise.resolve()),
   hideBubble: vi.fn(),
   getBubbleContainer: vi.fn(() => null),
   detectTheme: vi.fn(() => Promise.resolve('light')),

--- a/tests/toolbar.test.js
+++ b/tests/toolbar.test.js
@@ -9,7 +9,7 @@ vi.mock('../src/content/bubble/core.js', () => ({
   showBubble: vi.fn(),
   hideBubble: vi.fn(),
   getBubbleContainer: vi.fn(() => null),
-  detectTheme: vi.fn(() => 'light'),
+  detectTheme: vi.fn(() => Promise.resolve('light')),
 }));
 
 // Mock image-capture
@@ -75,54 +75,54 @@ afterEach(() => {
 });
 
 describe('createToolbar / showTrigger', () => {
-  it('creates a Shadow DOM host element with id dobby-ai-toolbar-host', () => {
-    showTrigger(200, 100, { text: 'hello', anchorNode: null });
+  it('creates a Shadow DOM host element with id dobby-ai-toolbar-host', async () => {
+    await showTrigger(200, 100, { text: 'hello', anchorNode: null });
     const host = getToolbarHost();
     expect(host).not.toBeNull();
     expect(host.id).toBe('dobby-ai-toolbar-host');
     expect(host.shadowRoot).not.toBeNull();
   });
 
-  it('positions and shows the toolbar at given coordinates', () => {
-    showTrigger(200, 100, { text: 'hello', anchorNode: null });
+  it('positions and shows the toolbar at given coordinates', async () => {
+    await showTrigger(200, 100, { text: 'hello', anchorNode: null });
     const host = getToolbarHost();
     expect(host.style.display).not.toBe('none');
     expect(parseInt(host.style.left)).toBeGreaterThanOrEqual(8);
     expect(parseInt(host.style.top)).toBeGreaterThanOrEqual(4);
   });
 
-  it('stores selection data on the host element', () => {
+  it('stores selection data on the host element', async () => {
     const anchorNode = document.createElement('p');
-    showTrigger(200, 100, { text: 'test text', anchorNode });
+    await showTrigger(200, 100, { text: 'test text', anchorNode });
     const host = getToolbarHost();
     expect(host._selectedText).toBe('test text');
     expect(host._anchorNode).toBe(anchorNode);
   });
 
-  it('is idempotent - calling showTrigger twice does not duplicate', () => {
-    showTrigger(200, 100, { text: 'hello', anchorNode: null });
-    showTrigger(300, 200, { text: 'world', anchorNode: null });
+  it('is idempotent - calling showTrigger twice does not duplicate', async () => {
+    await showTrigger(200, 100, { text: 'hello', anchorNode: null });
+    await showTrigger(300, 200, { text: 'world', anchorNode: null });
     const hosts = document.querySelectorAll('#dobby-ai-toolbar-host');
     expect(hosts.length).toBe(1);
   });
 
-  it('has a toolbar element inside shadow DOM', () => {
-    showTrigger(200, 100, { text: 'hello', anchorNode: null });
+  it('has a toolbar element inside shadow DOM', async () => {
+    await showTrigger(200, 100, { text: 'hello', anchorNode: null });
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
     expect(toolbar).not.toBeNull();
   });
 
-  it('contains the Dobby icon in collapsed state', () => {
-    showTrigger(200, 100, { text: 'hello', anchorNode: null });
+  it('contains the Dobby icon in collapsed state', async () => {
+    await showTrigger(200, 100, { text: 'hello', anchorNode: null });
     const shadow = getShadow();
     const icon = shadow.querySelector('.toolbar-icon img');
     expect(icon).not.toBeNull();
     expect(icon.alt).toBe('Dobby AI');
   });
 
-  it('works with default selectionData parameter', () => {
-    showTrigger(200, 100);
+  it('works with default selectionData parameter', async () => {
+    await showTrigger(200, 100);
     const host = getToolbarHost();
     expect(host).not.toBeNull();
     expect(host._selectedText).toBe('');
@@ -131,19 +131,19 @@ describe('createToolbar / showTrigger', () => {
 });
 
 describe('hideTrigger', () => {
-  it('removes the toolbar host from DOM', () => {
-    showTrigger(200, 100, { text: 'hello', anchorNode: null });
+  it('removes the toolbar host from DOM', async () => {
+    await showTrigger(200, 100, { text: 'hello', anchorNode: null });
     expect(getToolbarHost()).not.toBeNull();
     hideTrigger();
     expect(getToolbarHost()).toBeNull();
   });
 
-  it('is safe to call when no toolbar exists', () => {
+  it('is safe to call when no toolbar exists', async () => {
     expect(() => hideTrigger()).not.toThrow();
   });
 
   it('resets toolbar state', async () => {
-    showTrigger(200, 100, { text: 'hello', anchorNode: null });
+    await showTrigger(200, 100, { text: 'hello', anchorNode: null });
     hideTrigger();
     // Verify the host is gone from state module too
     const { toolbarHost } = await import('../src/content/shared/state.js');
@@ -152,8 +152,8 @@ describe('hideTrigger', () => {
 });
 
 describe('hover expand/collapse', () => {
-  it('expands toolbar on mouseenter, showing preset buttons', () => {
-    showTrigger(200, 100, { text: 'test text', anchorNode: null });
+  it('expands toolbar on mouseenter, showing preset buttons', async () => {
+    await showTrigger(200, 100, { text: 'test text', anchorNode: null });
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
@@ -164,8 +164,8 @@ describe('hover expand/collapse', () => {
     expect(actions.length).toBe(2);
   });
 
-  it('calls detectContentType and getSuggestedPresetsForType on hover', () => {
-    showTrigger(200, 100, { text: 'test text', anchorNode: document.body });
+  it('calls detectContentType and getSuggestedPresetsForType on hover', async () => {
+    await showTrigger(200, 100, { text: 'test text', anchorNode: document.body });
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
@@ -175,8 +175,8 @@ describe('hover expand/collapse', () => {
     expect(getSuggestedPresetsForType).toHaveBeenCalled();
   });
 
-  it('collapses toolbar on mouseleave', () => {
-    showTrigger(200, 100, { text: 'test text', anchorNode: null });
+  it('collapses toolbar on mouseleave', async () => {
+    await showTrigger(200, 100, { text: 'test text', anchorNode: null });
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
@@ -187,8 +187,8 @@ describe('hover expand/collapse', () => {
     expect(toolbar.classList.contains('expanded')).toBe(false);
   });
 
-  it('does not collapse when in input mode', () => {
-    showTrigger(200, 100, { text: 'test text', anchorNode: null });
+  it('does not collapse when in input mode', async () => {
+    await showTrigger(200, 100, { text: 'test text', anchorNode: null });
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
@@ -204,18 +204,18 @@ describe('hover expand/collapse', () => {
 });
 
 describe('auto-hide timer', () => {
-  it('auto-hides after 3 seconds when collapsed', () => {
+  it('auto-hides after 3 seconds when collapsed', async () => {
     vi.useFakeTimers();
-    showTrigger(200, 100, { text: 'test text', anchorNode: null });
+    await showTrigger(200, 100, { text: 'test text', anchorNode: null });
     expect(getToolbarHost()).not.toBeNull();
 
     vi.advanceTimersByTime(3100);
     expect(getToolbarHost()).toBeNull();
   });
 
-  it('hover pauses auto-hide timer', () => {
+  it('hover pauses auto-hide timer', async () => {
     vi.useFakeTimers();
-    showTrigger(200, 100, { text: 'test text', anchorNode: null });
+    await showTrigger(200, 100, { text: 'test text', anchorNode: null });
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
@@ -228,9 +228,9 @@ describe('auto-hide timer', () => {
     expect(getToolbarHost()).not.toBeNull();
   });
 
-  it('resumes auto-hide after mouseleave from expanded state', () => {
+  it('resumes auto-hide after mouseleave from expanded state', async () => {
     vi.useFakeTimers();
-    showTrigger(200, 100, { text: 'test text', anchorNode: null });
+    await showTrigger(200, 100, { text: 'test text', anchorNode: null });
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
@@ -245,8 +245,8 @@ describe('auto-hide timer', () => {
 });
 
 describe('input mode', () => {
-  it('shows pencil button in expanded toolbar', () => {
-    showTrigger(200, 100, { text: 'test text', anchorNode: null });
+  it('shows pencil button in expanded toolbar', async () => {
+    await showTrigger(200, 100, { text: 'test text', anchorNode: null });
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
@@ -257,8 +257,8 @@ describe('input mode', () => {
     expect(pencilBtn.title).toBe('Custom prompt');
   });
 
-  it('enters input mode on pencil click — shows input, hides presets', () => {
-    showTrigger(200, 100, { text: 'test text', anchorNode: null });
+  it('enters input mode on pencil click — shows input, hides presets', async () => {
+    await showTrigger(200, 100, { text: 'test text', anchorNode: null });
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
@@ -272,8 +272,8 @@ describe('input mode', () => {
     expect(actionsDiv.style.opacity).toBe('0');
   });
 
-  it('pencil becomes close icon in input mode', () => {
-    showTrigger(200, 100, { text: 'test text', anchorNode: null });
+  it('pencil becomes close icon in input mode', async () => {
+    await showTrigger(200, 100, { text: 'test text', anchorNode: null });
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
@@ -285,8 +285,8 @@ describe('input mode', () => {
     expect(pencilBtn.title).toBe('Cancel');
   });
 
-  it('exits input mode on close button click — restores presets', () => {
-    showTrigger(200, 100, { text: 'test text', anchorNode: null });
+  it('exits input mode on close button click — restores presets', async () => {
+    await showTrigger(200, 100, { text: 'test text', anchorNode: null });
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
@@ -302,8 +302,8 @@ describe('input mode', () => {
     expect(actionsDiv.style.opacity).not.toBe('0');
   });
 
-  it('exits input mode on Escape key', () => {
-    showTrigger(200, 100, { text: 'test text', anchorNode: null });
+  it('exits input mode on Escape key', async () => {
+    await showTrigger(200, 100, { text: 'test text', anchorNode: null });
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
@@ -317,8 +317,8 @@ describe('input mode', () => {
     expect(inputSection.classList.contains('visible')).toBe(false);
   });
 
-  it('send button is disabled when input is empty', () => {
-    showTrigger(200, 100, { text: 'test text', anchorNode: null });
+  it('send button is disabled when input is empty', async () => {
+    await showTrigger(200, 100, { text: 'test text', anchorNode: null });
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
@@ -329,8 +329,8 @@ describe('input mode', () => {
     expect(sendBtn.classList.contains('disabled')).toBe(true);
   });
 
-  it('send button enables when input has text', () => {
-    showTrigger(200, 100, { text: 'test text', anchorNode: null });
+  it('send button enables when input has text', async () => {
+    await showTrigger(200, 100, { text: 'test text', anchorNode: null });
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
@@ -345,8 +345,8 @@ describe('input mode', () => {
     expect(sendBtn.classList.contains('disabled')).toBe(false);
   });
 
-  it('Enter with empty input does not call showBubble', () => {
-    showTrigger(200, 100, { text: 'test text', anchorNode: null });
+  it('Enter with empty input does not call showBubble', async () => {
+    await showTrigger(200, 100, { text: 'test text', anchorNode: null });
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
@@ -359,8 +359,8 @@ describe('input mode', () => {
     expect(showBubble).not.toHaveBeenCalled();
   });
 
-  it('Enter with text calls showBubble via morphIntoBubble', () => {
-    showTrigger(200, 100, { text: 'test text', anchorNode: null });
+  it('Enter with text calls showBubble via morphIntoBubble', async () => {
+    await showTrigger(200, 100, { text: 'test text', anchorNode: null });
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
@@ -375,8 +375,8 @@ describe('input mode', () => {
     expect(buildChatMessages).toHaveBeenCalledWith('test text', 'What does this mean?', true, null);
   });
 
-  it('send button click with text calls showBubble', () => {
-    showTrigger(200, 100, { text: 'test text', anchorNode: null });
+  it('send button click with text calls showBubble', async () => {
+    await showTrigger(200, 100, { text: 'test text', anchorNode: null });
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
@@ -392,9 +392,9 @@ describe('input mode', () => {
     expect(showBubble).toHaveBeenCalledTimes(1);
   });
 
-  it('auto-hide is suppressed during input mode', () => {
+  it('auto-hide is suppressed during input mode', async () => {
     vi.useFakeTimers();
-    showTrigger(200, 100, { text: 'test text', anchorNode: null });
+    await showTrigger(200, 100, { text: 'test text', anchorNode: null });
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
@@ -405,8 +405,8 @@ describe('input mode', () => {
     expect(getToolbarHost()).not.toBeNull();
   });
 
-  it('mouseleave does not collapse during input mode', () => {
-    showTrigger(200, 100, { text: 'test text', anchorNode: null });
+  it('mouseleave does not collapse during input mode', async () => {
+    await showTrigger(200, 100, { text: 'test text', anchorNode: null });
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
@@ -417,9 +417,9 @@ describe('input mode', () => {
     expect(toolbar.classList.contains('expanded')).toBe(true);
   });
 
-  it('click outside toolbar exits input mode', () => {
+  it('click outside toolbar exits input mode', async () => {
     vi.useFakeTimers();
-    showTrigger(200, 100, { text: 'test text', anchorNode: null });
+    await showTrigger(200, 100, { text: 'test text', anchorNode: null });
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
@@ -434,8 +434,8 @@ describe('input mode', () => {
     expect(inputSection.classList.contains('visible')).toBe(false);
   });
 
-  it('send button click with empty input does not call showBubble', () => {
-    showTrigger(200, 100, { text: 'test text', anchorNode: null });
+  it('send button click with empty input does not call showBubble', async () => {
+    await showTrigger(200, 100, { text: 'test text', anchorNode: null });
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
@@ -448,9 +448,9 @@ describe('input mode', () => {
     expect(showBubble).not.toHaveBeenCalled();
   });
 
-  it('auto-hide resumes after exiting input mode', () => {
+  it('auto-hide resumes after exiting input mode', async () => {
     vi.useFakeTimers();
-    showTrigger(200, 100, { text: 'test text', anchorNode: null });
+    await showTrigger(200, 100, { text: 'test text', anchorNode: null });
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
@@ -465,8 +465,8 @@ describe('input mode', () => {
 });
 
 describe('preset click opens bubble', () => {
-  it('calls showBubble with correct arguments on preset button click', () => {
-    showTrigger(200, 100, { text: 'test text', anchorNode: null });
+  it('calls showBubble with correct arguments on preset button click', async () => {
+    await showTrigger(200, 100, { text: 'test text', anchorNode: null });
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
@@ -489,8 +489,8 @@ describe('preset click opens bubble', () => {
     expect(args[3]).toBe('Summarize the following');
   });
 
-  it('calls buildChatMessages with text, instruction, and true', () => {
-    showTrigger(200, 100, { text: 'test text', anchorNode: null });
+  it('calls buildChatMessages with text, instruction, and true', async () => {
+    await showTrigger(200, 100, { text: 'test text', anchorNode: null });
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
@@ -500,9 +500,9 @@ describe('preset click opens bubble', () => {
     expect(buildChatMessages).toHaveBeenCalledWith('test text', 'Summarize the following', true, null);
   });
 
-  it('removes toolbar after preset click', () => {
+  it('removes toolbar after preset click', async () => {
     vi.useFakeTimers();
-    showTrigger(200, 100, { text: 'test text', anchorNode: null });
+    await showTrigger(200, 100, { text: 'test text', anchorNode: null });
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
@@ -532,9 +532,9 @@ describe('extractImagesFromSelection', () => {
 });
 
 describe('fallback presets', () => {
-  it('falls back to Summarize/Explain when 0 suggested presets', () => {
+  it('falls back to Summarize/Explain when 0 suggested presets', async () => {
     getSuggestedPresetsForType.mockReturnValueOnce([]);
-    showTrigger(200, 100, { text: 'test text', anchorNode: null });
+    await showTrigger(200, 100, { text: 'test text', anchorNode: null });
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
@@ -545,11 +545,11 @@ describe('fallback presets', () => {
     expect(actions[1].textContent).toBe('Explain');
   });
 
-  it('shows only 1 button + more when 1 suggested preset', () => {
+  it('shows only 1 button + more when 1 suggested preset', async () => {
     getSuggestedPresetsForType.mockReturnValueOnce([
       { label: 'Explain code', instruction: 'Explain the following code' },
     ]);
-    showTrigger(200, 100, { text: 'test text', anchorNode: null });
+    await showTrigger(200, 100, { text: 'test text', anchorNode: null });
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 

--- a/tests/toolbar.test.js
+++ b/tests/toolbar.test.js
@@ -509,8 +509,8 @@ describe('preset click opens bubble', () => {
     toolbar.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
     shadow.querySelector('.toolbar-action').click();
 
-    // Toolbar is removed after 220ms crossfade
-    vi.advanceTimersByTime(250);
+    // Flush async microtasks (showBubble is now async)
+    await vi.advanceTimersByTimeAsync(250);
     expect(getToolbarHost()).toBeNull();
   });
 });

--- a/tests/trigger.test.js
+++ b/tests/trigger.test.js
@@ -10,7 +10,7 @@ vi.mock('../src/content/bubble/core.js', () => ({
   showBubble: vi.fn(),
   hideBubble: vi.fn(),
   getBubbleContainer: vi.fn(() => null),
-  detectTheme: vi.fn(() => 'light'),
+  detectTheme: vi.fn(() => Promise.resolve('light')),
 }));
 
 // Mock image-capture (path must match what the source modules use)
@@ -73,8 +73,8 @@ beforeEach(() => {
 });
 
 describe('createTriggerButton', () => {
-  it('creates toolbar host with cockapoo icon in shadow DOM', () => {
-    createTriggerButton();
+  it('creates toolbar host with cockapoo icon in shadow DOM', async () => {
+    await createTriggerButton();
     const host = getHost();
     expect(host).not.toBeNull();
     const shadow = host.shadowRoot;
@@ -83,14 +83,14 @@ describe('createTriggerButton', () => {
     expect(img.alt).toBe('Dobby AI');
   });
 
-  it('is idempotent', () => {
-    createTriggerButton();
-    createTriggerButton();
+  it('is idempotent', async () => {
+    await createTriggerButton();
+    await createTriggerButton();
     expect(document.querySelectorAll('#dobby-ai-toolbar-host').length).toBe(1);
   });
 
-  it('has correct host styling', () => {
-    createTriggerButton();
+  it('has correct host styling', async () => {
+    await createTriggerButton();
     const host = getHost();
     expect(host.style.position).toBe('fixed');
     expect(host.style.zIndex).toBe('2147483647');
@@ -99,40 +99,40 @@ describe('createTriggerButton', () => {
 });
 
 describe('showTrigger', () => {
-  it('makes toolbar visible and positions it near cursor', () => {
-    showTrigger(200, 100);
+  it('makes toolbar visible and positions it near cursor', async () => {
+    await showTrigger(200, 100);
     const host = getHost();
     expect(host.style.display).toBe('block');
   });
 
-  it('positions below-right of cursor', () => {
-    showTrigger(200, 100);
+  it('positions below-right of cursor', async () => {
+    await showTrigger(200, 100);
     const host = getHost();
     expect(host.style.left).toBe('212px'); // x + 12
     expect(host.style.top).toBe('110px'); // y + 10
   });
 
-  it('clamps left position to prevent off-screen rendering', () => {
-    showTrigger(1020, 100);
+  it('clamps left position to prevent off-screen rendering', async () => {
+    await showTrigger(1020, 100);
     const host = getHost();
     expect(parseInt(host.style.left)).toBeLessThanOrEqual(980);
   });
 
-  it('clamps top position to viewport bottom', () => {
-    showTrigger(100, 800);
+  it('clamps top position to viewport bottom', async () => {
+    await showTrigger(100, 800);
     const host = getHost();
     expect(parseInt(host.style.top)).toBeLessThanOrEqual(732);
   });
 });
 
 describe('hideTrigger', () => {
-  it('removes toolbar host from DOM', () => {
-    showTrigger(100, 100);
+  it('removes toolbar host from DOM', async () => {
+    await showTrigger(100, 100);
     hideTrigger();
     expect(getHost()).toBeNull();
   });
 
-  it('is safe to call when no button exists', () => {
+  it('is safe to call when no button exists', async () => {
     expect(() => hideTrigger()).not.toThrow();
   });
 });
@@ -142,12 +142,16 @@ describe('event-driven behavior', () => {
     sharedMockSelection(text);
   }
 
-  it('mouseup with selection >= 3 chars shows trigger', () => {
+  it('mouseup with selection >= 3 chars shows trigger', async () => {
     vi.useFakeTimers();
     mockSelection('hello world');
 
     document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
     vi.advanceTimersByTime(20);
+    // flush microtask queue multiple times so async showTrigger/createToolbar resolve
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
 
     const host = getHost();
     expect(host).not.toBeNull();
@@ -155,10 +159,10 @@ describe('event-driven behavior', () => {
     vi.useRealTimers();
   });
 
-  it('mouseup with selection < 3 chars hides trigger', () => {
+  it('mouseup with selection < 3 chars hides trigger', async () => {
     vi.useFakeTimers();
     // First show it
-    showTrigger(100, 100);
+    await showTrigger(100, 100);
     mockSelection('ab');
 
     document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
@@ -168,7 +172,7 @@ describe('event-driven behavior', () => {
     vi.useRealTimers();
   });
 
-  it('mouseup does not show trigger when dobbyEnabled is false', () => {
+  it('mouseup does not show trigger when dobbyEnabled is false', async () => {
     vi.useFakeTimers();
     _setDobbyEnabled(false);
     mockSelection('hello world');
@@ -186,25 +190,25 @@ describe('event-driven behavior', () => {
     vi.useRealTimers();
   });
 
-  it('click-away hides trigger', () => {
-    showTrigger(200, 100);
+  it('click-away hides trigger', async () => {
+    await showTrigger(200, 100);
     expect(getHost()).not.toBeNull();
 
     document.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
     expect(getHost()).toBeNull();
   });
 
-  it('uses img element with data URI (no innerHTML)', () => {
-    createTriggerButton();
+  it('uses img element with data URI (no innerHTML)', async () => {
+    await createTriggerButton();
     const host = getHost();
     const shadow = host.shadowRoot;
     const img = shadow.querySelector('.toolbar-icon img');
     expect(img.src).toContain('data:image/svg+xml');
   });
 
-  it('showTrigger passes selection data when provided', () => {
+  it('showTrigger passes selection data when provided', async () => {
     const anchorNode = document.createElement('p');
-    showTrigger(200, 100, { text: 'test text', anchorNode });
+    await showTrigger(200, 100, { text: 'test text', anchorNode });
     const host = getHost();
     expect(host._selectedText).toBe('test text');
     expect(host._anchorNode).toBe(anchorNode);
@@ -216,7 +220,7 @@ describe('screenshot mode', () => {
     cancelScreenshotMode();
   });
 
-  it('startScreenshotMode creates overlay with banner', () => {
+  it('startScreenshotMode creates overlay with banner', async () => {
     startScreenshotMode();
     const overlays = document.querySelectorAll('div[style*="crosshair"]');
     expect(overlays.length).toBe(1);
@@ -224,21 +228,21 @@ describe('screenshot mode', () => {
     cancelScreenshotMode();
   });
 
-  it('cancelScreenshotMode removes the overlay', () => {
+  it('cancelScreenshotMode removes the overlay', async () => {
     startScreenshotMode();
     expect(document.querySelectorAll('div[style*="crosshair"]').length).toBe(1);
     cancelScreenshotMode();
     expect(document.querySelectorAll('div[style*="crosshair"]').length).toBe(0);
   });
 
-  it('ESC key cancels screenshot mode', () => {
+  it('ESC key cancels screenshot mode', async () => {
     startScreenshotMode();
     expect(document.querySelectorAll('div[style*="crosshair"]').length).toBe(1);
     document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
     expect(document.querySelectorAll('div[style*="crosshair"]').length).toBe(0);
   });
 
-  it('mouseup without prior mousedown on overlay does not dismiss it', () => {
+  it('mouseup without prior mousedown on overlay does not dismiss it', async () => {
     startScreenshotMode();
     const overlay = document.querySelector('div[style*="crosshair"]');
     // Simulate the mouseup from long-press release (no mousedown on overlay)
@@ -248,7 +252,7 @@ describe('screenshot mode', () => {
     cancelScreenshotMode();
   });
 
-  it('click-without-drag resets selection instead of dismissing overlay', () => {
+  it('click-without-drag resets selection instead of dismissing overlay', async () => {
     startScreenshotMode();
     const overlay = document.querySelector('div[style*="crosshair"]');
     // mousedown then mouseup at same position (no drag)
@@ -259,7 +263,7 @@ describe('screenshot mode', () => {
     cancelScreenshotMode();
   });
 
-  it('cancelScreenshotMode is safe to call when not in screenshot mode', () => {
+  it('cancelScreenshotMode is safe to call when not in screenshot mode', async () => {
     expect(() => cancelScreenshotMode()).not.toThrow();
   });
 
@@ -268,7 +272,7 @@ describe('screenshot mode', () => {
     overlay.dispatchEvent(new MouseEvent('mouseup', { clientX: endX, clientY: endY, bubbles: true }));
   }
 
-  it('shows confirmation toolbar after valid drag selection', () => {
+  it('shows confirmation toolbar after valid drag selection', async () => {
     startScreenshotMode();
     const overlay = document.querySelector('div[style*="crosshair"]');
     simulateDrag(overlay, 50, 50, 200, 200);
@@ -280,7 +284,7 @@ describe('screenshot mode', () => {
     cancelScreenshotMode();
   });
 
-  it('updates banner text after selection', () => {
+  it('updates banner text after selection', async () => {
     startScreenshotMode();
     const overlay = document.querySelector('div[style*="crosshair"]');
     simulateDrag(overlay, 50, 50, 200, 200);
@@ -288,7 +292,7 @@ describe('screenshot mode', () => {
     cancelScreenshotMode();
   });
 
-  it('reselect button resets selection and restores banner', () => {
+  it('reselect button resets selection and restores banner', async () => {
     startScreenshotMode();
     const overlay = document.querySelector('div[style*="crosshair"]');
     simulateDrag(overlay, 50, 50, 200, 200);
@@ -304,7 +308,7 @@ describe('screenshot mode', () => {
     cancelScreenshotMode();
   });
 
-  it('cancel button in toolbar removes overlay', () => {
+  it('cancel button in toolbar removes overlay', async () => {
     startScreenshotMode();
     const overlay = document.querySelector('div[style*="crosshair"]');
     simulateDrag(overlay, 50, 50, 200, 200);
@@ -328,7 +332,7 @@ describe('screenshot mode', () => {
     expect(document.querySelectorAll('div[style*="crosshair"]').length).toBe(0);
   });
 
-  it('does not show toolbar for too-small drag', () => {
+  it('does not show toolbar for too-small drag', async () => {
     startScreenshotMode();
     const overlay = document.querySelector('div[style*="crosshair"]');
     simulateDrag(overlay, 50, 50, 55, 55); // 5x5 < 10x10 threshold
@@ -336,7 +340,7 @@ describe('screenshot mode', () => {
     cancelScreenshotMode();
   });
 
-  it('re-drag on overlay clears existing toolbar', () => {
+  it('re-drag on overlay clears existing toolbar', async () => {
     startScreenshotMode();
     const overlay = document.querySelector('div[style*="crosshair"]');
     simulateDrag(overlay, 50, 50, 200, 200);
@@ -347,7 +351,7 @@ describe('screenshot mode', () => {
     cancelScreenshotMode();
   });
 
-  it('mousemove after selection does not resize rectangle', () => {
+  it('mousemove after selection does not resize rectangle', async () => {
     startScreenshotMode();
     const overlay = document.querySelector('div[style*="crosshair"]');
     simulateDrag(overlay, 50, 50, 200, 200);
@@ -363,7 +367,7 @@ describe('screenshot mode', () => {
   });
 
 
-  it('re-drag after reselect shows new toolbar', () => {
+  it('re-drag after reselect shows new toolbar', async () => {
     startScreenshotMode();
     const overlay = document.querySelector('div[style*="crosshair"]');
     // First drag
@@ -377,7 +381,7 @@ describe('screenshot mode', () => {
     cancelScreenshotMode();
   });
 
-  it('does not start screenshot mode when clicking on scrollbar area', () => {
+  it('does not start screenshot mode when clicking on scrollbar area', async () => {
     vi.useFakeTimers();
     _setDobbyEnabled(true);
     Object.defineProperty(document.documentElement, 'clientWidth', { value: 1024, configurable: true });
@@ -389,7 +393,7 @@ describe('screenshot mode', () => {
     vi.useRealTimers();
   });
 
-  it('does not start screenshot mode when clicking on element-level scrollbar', () => {
+  it('does not start screenshot mode when clicking on element-level scrollbar', async () => {
     vi.useFakeTimers();
     _setDobbyEnabled(true);
     const scrollable = document.createElement('div');
@@ -409,7 +413,7 @@ describe('screenshot mode', () => {
     vi.useRealTimers();
   });
 
-  it('does not start screenshot mode when clicking on interactive elements', () => {
+  it('does not start screenshot mode when clicking on interactive elements', async () => {
     vi.useFakeTimers();
     _setDobbyEnabled(true);
     const button = document.createElement('button');
@@ -423,7 +427,7 @@ describe('screenshot mode', () => {
     vi.useRealTimers();
   });
 
-  it('does not start screenshot mode when clicking on a link', () => {
+  it('does not start screenshot mode when clicking on a link', async () => {
     vi.useFakeTimers();
     _setDobbyEnabled(true);
     const link = document.createElement('a');
@@ -438,7 +442,7 @@ describe('screenshot mode', () => {
     vi.useRealTimers();
   });
 
-  it('does not start screenshot mode when clicking inside a role=button element', () => {
+  it('does not start screenshot mode when clicking inside a role=button element', async () => {
     vi.useFakeTimers();
     _setDobbyEnabled(true);
     const div = document.createElement('div');
@@ -463,7 +467,7 @@ describe('progress ring', () => {
     document.getElementById('dobby-progress-ring-styles')?.remove();
   });
 
-  it('_showProgressRing creates an SVG element at given coordinates', () => {
+  it('_showProgressRing creates an SVG element at given coordinates', async () => {
     _showProgressRing(200, 150);
     const ring = document.querySelector('[data-dobby-progress-ring]');
     expect(ring).not.toBeNull();
@@ -473,7 +477,7 @@ describe('progress ring', () => {
     _removeProgressRing();
   });
 
-  it('_showProgressRing centers the 28px ring on the coordinates', () => {
+  it('_showProgressRing centers the 28px ring on the coordinates', async () => {
     _showProgressRing(200, 150);
     const ring = document.querySelector('[data-dobby-progress-ring]');
     expect(ring.style.left).toBe('186px'); // 200 - 14
@@ -481,14 +485,14 @@ describe('progress ring', () => {
     _removeProgressRing();
   });
 
-  it('_showProgressRing injects CSS style tag on first call', () => {
+  it('_showProgressRing injects CSS style tag on first call', async () => {
     expect(document.getElementById('dobby-progress-ring-styles')).toBeNull();
     _showProgressRing(100, 100);
     expect(document.getElementById('dobby-progress-ring-styles')).not.toBeNull();
     _removeProgressRing();
   });
 
-  it('_showProgressRing does not duplicate style tag on second call', () => {
+  it('_showProgressRing does not duplicate style tag on second call', async () => {
     _showProgressRing(100, 100);
     _removeProgressRing();
     _showProgressRing(200, 200);
@@ -496,18 +500,18 @@ describe('progress ring', () => {
     _removeProgressRing();
   });
 
-  it('_removeProgressRing removes the ring element', () => {
+  it('_removeProgressRing removes the ring element', async () => {
     _showProgressRing(100, 100);
     expect(document.querySelector('[data-dobby-progress-ring]')).not.toBeNull();
     _removeProgressRing();
     expect(document.querySelector('[data-dobby-progress-ring]')).toBeNull();
   });
 
-  it('_removeProgressRing is safe to call when no ring exists', () => {
+  it('_removeProgressRing is safe to call when no ring exists', async () => {
     expect(() => _removeProgressRing()).not.toThrow();
   });
 
-  it('_showProgressRing removes existing ring before creating new one', () => {
+  it('_showProgressRing removes existing ring before creating new one', async () => {
     _showProgressRing(100, 100);
     _showProgressRing(200, 200);
     expect(document.querySelectorAll('[data-dobby-progress-ring]').length).toBe(1);
@@ -516,7 +520,7 @@ describe('progress ring', () => {
     _removeProgressRing();
   });
 
-  it('ring contains SVG with camera icon', () => {
+  it('ring contains SVG with camera icon', async () => {
     _showProgressRing(100, 100);
     const ring = document.querySelector('[data-dobby-progress-ring]');
     const svg = ring.querySelector('svg');
@@ -526,7 +530,7 @@ describe('progress ring', () => {
     _removeProgressRing();
   });
 
-  it('ring does not appear when dobbyEnabled is false', () => {
+  it('ring does not appear when dobbyEnabled is false', async () => {
     vi.useFakeTimers();
     _setDobbyEnabled(false);
     document.dispatchEvent(new MouseEvent('mousedown', {
@@ -536,9 +540,9 @@ describe('progress ring', () => {
     vi.useRealTimers();
   });
 
-  it('ring is removed when startScreenshotMode fires', () => {
+  it('ring is removed when startScreenshotMode fires', async () => {
     vi.useFakeTimers();
-    createTriggerButton();
+    await createTriggerButton();
     Object.defineProperty(document.documentElement, 'clientWidth', { value: 1024, configurable: true });
     Object.defineProperty(document.documentElement, 'clientHeight', { value: 768, configurable: true });
     document.dispatchEvent(new MouseEvent('mousedown', {
@@ -558,9 +562,9 @@ describe('progress ring', () => {
     vi.useRealTimers();
   });
 
-  it('ring is removed on early mouseup', () => {
+  it('ring is removed on early mouseup', async () => {
     vi.useFakeTimers();
-    createTriggerButton();
+    await createTriggerButton();
     Object.defineProperty(document.documentElement, 'clientWidth', { value: 1024, configurable: true });
     Object.defineProperty(document.documentElement, 'clientHeight', { value: 768, configurable: true });
     document.dispatchEvent(new MouseEvent('mousedown', {
@@ -577,9 +581,9 @@ describe('progress ring', () => {
     vi.useRealTimers();
   });
 
-  it('ring is removed when mouse moves beyond threshold', () => {
+  it('ring is removed when mouse moves beyond threshold', async () => {
     vi.useFakeTimers();
-    createTriggerButton();
+    await createTriggerButton();
     Object.defineProperty(document.documentElement, 'clientWidth', { value: 1024, configurable: true });
     Object.defineProperty(document.documentElement, 'clientHeight', { value: 768, configurable: true });
     document.dispatchEvent(new MouseEvent('mousedown', {
@@ -598,14 +602,14 @@ describe('progress ring', () => {
 });
 
 describe('toolbar replaces old trigger tooltip', () => {
-  it('toolbar host exists after createTriggerButton', () => {
-    createTriggerButton();
+  it('toolbar host exists after createTriggerButton', async () => {
+    await createTriggerButton();
     const host = getHost();
     expect(host).not.toBeNull();
   });
 
-  it('toolbar shadow DOM contains icon element', () => {
-    createTriggerButton();
+  it('toolbar shadow DOM contains icon element', async () => {
+    await createTriggerButton();
     const host = getHost();
     const shadow = host.shadowRoot;
     const icon = shadow.querySelector('.toolbar-icon');


### PR DESCRIPTION
## Summary

- Adds a three-way theme toggle (Auto / Light / Dark) to the extension popup
- Stores preference in `chrome.storage.local` — defaults to Auto (OS preference)
- `detectTheme()` is now async: checks storage first, falls back to OS preference
- Open bubbles live-update when theme preference changes via `chrome.storage.onChanged`
- All callers updated to `await` the async functions

## Files Changed

- `popup.html` — segmented control UI with dark mode support
- `src/popup.js` — read/write theme preference
- `src/content/bubble/core.js` — async `detectTheme()`, live theme listener + cleanup
- `src/content/trigger/button.js` — async `createToolbar`/`showTrigger`/`launchAction`
- `src/content/index.js` — `await` on `showBubble`/`showBubbleWithPresets` calls
- `src/content/trigger/screenshot.js` — `await` on `showBubbleWithPresets`
- `tests/` — 6 new tests, all existing tests updated for async (577 total, 0 failures)

## Test plan

- [ ] Build succeeds (`npm run build`)
- [ ] All 577 tests pass (`npx vitest run`)
- [ ] Toggle in popup persists across sessions
- [ ] Auto mode follows OS preference
- [ ] Light/Dark override OS preference
- [ ] Open bubble live-updates when toggle changes
- [ ] Accessible: `aria-pressed` on toggle buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)