### PR TITLE
[codex] Add keyboard shortcut commands

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -23,6 +23,22 @@
       "48": "icons/icon48.png"
     }
   },
+  "commands": {
+    "toggle-dobby": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+D",
+        "mac": "Command+Shift+D"
+      },
+      "description": "Toggle Dobby AI"
+    },
+    "toggle-screenshot-mode": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+S",
+        "mac": "Command+Shift+S"
+      },
+      "description": "Toggle screenshot mode"
+    }
+  },
   "options_ui": {
     "page": "options.html",
     "open_in_tab": true

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -67,7 +67,8 @@ function notifyActiveTab(message) {
 
 function toggleStoredSetting(storageKey, messageType) {
   chrome.storage.local.get(storageKey, (data) => {
-    const enabled = data[storageKey] === false;
+    const current = data[storageKey] !== false;
+    const enabled = !current;
     chrome.storage.local.set({ [storageKey]: enabled }, () => {
       notifyActiveTab({ type: messageType, enabled });
     });

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -48,6 +48,41 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
   });
 });
 
+// --- Keyboard Commands ---
+
+function notifyActiveTab(message) {
+  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    const tabId = tabs?.[0]?.id;
+    if (!tabId) return;
+    chrome.tabs.sendMessage(tabId, message).catch(() => {
+      chrome.notifications.create({
+        type: 'basic',
+        iconUrl: 'icons/icon48.png',
+        title: 'Dobby AI',
+        message: 'Cannot run on this page. Try a regular webpage.',
+      });
+    });
+  });
+}
+
+function toggleStoredSetting(storageKey, messageType) {
+  chrome.storage.local.get(storageKey, (data) => {
+    const enabled = data[storageKey] === false;
+    chrome.storage.local.set({ [storageKey]: enabled }, () => {
+      notifyActiveTab({ type: messageType, enabled });
+    });
+  });
+}
+
+chrome.commands.onCommand.addListener((command) => {
+  if (command === 'toggle-dobby') {
+    toggleStoredSetting('dobbyEnabled', 'DOBBY_TOGGLE');
+  }
+  if (command === 'toggle-screenshot-mode') {
+    toggleStoredSetting('screenshotEnabled', 'SCREENSHOT_TOGGLE');
+  }
+});
+
 // --- HMAC Signing ---
 
 export async function generateSignature(messages, timestamp, secret) {

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -5,8 +5,10 @@ const mockCreate = vi.fn();
 const mockSendMessage = vi.fn();
 const mockStorageGet = vi.fn();
 const mockStorageSet = vi.fn();
+const mockTabsQuery = vi.fn();
 const connectListeners = [];
 const messageListeners = [];
+const commandListeners = [];
 
 global.chrome = {
   runtime: {
@@ -15,11 +17,15 @@ global.chrome = {
     onConnect: { addListener: vi.fn((fn) => connectListeners.push(fn)) },
     lastError: null,
   },
+  commands: {
+    onCommand: { addListener: vi.fn((fn) => commandListeners.push(fn)) },
+  },
   contextMenus: {
     create: mockCreate,
     onClicked: { addListener: vi.fn() },
   },
   tabs: {
+    query: mockTabsQuery,
     sendMessage: mockSendMessage,
   },
   storage: {
@@ -40,6 +46,7 @@ const mod = await import('../src/background/index.js');
 const { parseSSEStream, generateSignature } = mod;
 
 const clickHandler = chrome.contextMenus.onClicked.addListener.mock.calls[0][0];
+const commandHandler = commandListeners[0];
 
 describe('context menu registration', () => {
   it('registers onInstalled listener', () => {
@@ -84,6 +91,65 @@ describe('context menu click handler', () => {
 
   it('ignores whitespace-only selectionText', () => {
     clickHandler({ menuItemId: 'dobby-ai', selectionText: '   ' }, { id: 1 });
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('keyboard commands', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTabsQuery.mockImplementation((query, cb) => cb([{ id: 1 }]));
+    mockStorageSet.mockImplementation((data, cb) => { if (cb) cb(); });
+    mockSendMessage.mockResolvedValue(undefined);
+  });
+
+  it('registers command listener', () => {
+    expect(commandListeners).toHaveLength(1);
+  });
+
+  it('toggles Dobby AI off when currently enabled', () => {
+    mockStorageGet.mockImplementation((key, cb) => cb({ dobbyEnabled: true }));
+
+    commandHandler('toggle-dobby');
+
+    expect(mockStorageSet).toHaveBeenCalledWith({ dobbyEnabled: false }, expect.any(Function));
+    expect(mockTabsQuery).toHaveBeenCalledWith({ active: true, currentWindow: true }, expect.any(Function));
+    expect(mockSendMessage).toHaveBeenCalledWith(1, {
+      type: 'DOBBY_TOGGLE',
+      enabled: false,
+    });
+  });
+
+  it('toggles Dobby AI on when currently disabled', () => {
+    mockStorageGet.mockImplementation((key, cb) => cb({ dobbyEnabled: false }));
+
+    commandHandler('toggle-dobby');
+
+    expect(mockStorageSet).toHaveBeenCalledWith({ dobbyEnabled: true }, expect.any(Function));
+    expect(mockSendMessage).toHaveBeenCalledWith(1, {
+      type: 'DOBBY_TOGGLE',
+      enabled: true,
+    });
+  });
+
+  it('toggles screenshot mode and notifies the active tab', () => {
+    mockStorageGet.mockImplementation((key, cb) => cb({ screenshotEnabled: true }));
+
+    commandHandler('toggle-screenshot-mode');
+
+    expect(mockStorageSet).toHaveBeenCalledWith({ screenshotEnabled: false }, expect.any(Function));
+    expect(mockSendMessage).toHaveBeenCalledWith(1, {
+      type: 'SCREENSHOT_TOGGLE',
+      enabled: false,
+    });
+  });
+
+  it('does not notify when there is no active tab', () => {
+    mockStorageGet.mockImplementation((key, cb) => cb({ dobbyEnabled: true }));
+    mockTabsQuery.mockImplementation((query, cb) => cb([]));
+
+    commandHandler('toggle-dobby');
+
     expect(mockSendMessage).not.toHaveBeenCalled();
   });
 });

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -132,8 +132,32 @@ describe('keyboard commands', () => {
     });
   });
 
+  it('toggles Dobby AI off when the setting is unset', () => {
+    mockStorageGet.mockImplementation((key, cb) => cb({}));
+
+    commandHandler('toggle-dobby');
+
+    expect(mockStorageSet).toHaveBeenCalledWith({ dobbyEnabled: false }, expect.any(Function));
+    expect(mockSendMessage).toHaveBeenCalledWith(1, {
+      type: 'DOBBY_TOGGLE',
+      enabled: false,
+    });
+  });
+
   it('toggles screenshot mode and notifies the active tab', () => {
     mockStorageGet.mockImplementation((key, cb) => cb({ screenshotEnabled: true }));
+
+    commandHandler('toggle-screenshot-mode');
+
+    expect(mockStorageSet).toHaveBeenCalledWith({ screenshotEnabled: false }, expect.any(Function));
+    expect(mockSendMessage).toHaveBeenCalledWith(1, {
+      type: 'SCREENSHOT_TOGGLE',
+      enabled: false,
+    });
+  });
+
+  it('toggles screenshot mode off when the setting is unset', () => {
+    mockStorageGet.mockImplementation((key, cb) => cb({}));
 
     commandHandler('toggle-screenshot-mode');
 


### PR DESCRIPTION
## Summary

Adds Chrome extension commands for the existing Dobby AI and screenshot mode toggles:

- `toggle-dobby` defaults to `Ctrl+Shift+D` / `Command+Shift+D`
- `toggle-screenshot-mode` defaults to `Ctrl+Shift+S` / `Command+Shift+S`
- Background command handling updates `chrome.storage.local` and notifies the active content script with the same messages used by the popup toggles

## Why

Issue #110 asks for keyboard shortcuts for common actions. This PR implements the smallest low-risk slice by wiring shortcut commands to existing toggle state and message flows.

## Validation

- `npm test -- tests/background.test.js`
- `npm test`
- `npm run build`

Refs #110