### PR TITLE
[codex] Include selected images and respect prompt budget

### DIFF
--- a/src/content/prompt.js
+++ b/src/content/prompt.js
@@ -1,5 +1,30 @@
 // prompt.js — OpenAI chat message format
 export const MAX_TEXT_LENGTH = 6000;
+export const MAX_INSTRUCTION_LENGTH = 500;
+export const MAX_SOURCE_CONTEXT_LENGTH = 500;
+
+const TRUNCATION_MARKER = '...[truncated]';
+const SYSTEM_PROMPT = 'You are Dobby AI, a helpful assistant. The user has selected text on a webpage and the full selected text is provided below. Do NOT attempt to access, fetch, or visit any URLs — the text content is already included in the message. A source URL may be provided as metadata only. Be concise and clear. Always respond in the same language as the selected text.';
+
+function truncateToBudget(text, maxLength) {
+  if (!text || maxLength <= 0) return '';
+  if (text.length <= maxLength) return text;
+  if (maxLength <= TRUNCATION_MARKER.length) {
+    return TRUNCATION_MARKER.slice(0, maxLength);
+  }
+  return text.substring(0, maxLength - TRUNCATION_MARKER.length) + TRUNCATION_MARKER;
+}
+
+function buildSourceSuffix(includePageContext) {
+  if (!includePageContext) return '';
+
+  const title = typeof document !== 'undefined' ? document.title : '';
+  const url = typeof window !== 'undefined' ? window.location.href : '';
+  return truncateToBudget(
+    `\n\n(Source: "${title}" — ${url})`,
+    MAX_SOURCE_CONTEXT_LENGTH
+  );
+}
 
 /**
  * Build OpenAI chat messages array from selected text and instruction.
@@ -10,30 +35,25 @@ export const MAX_TEXT_LENGTH = 6000;
  * @returns {Array<{role: string, content: string|Array}>}
  */
 export function buildChatMessages(selectedText, instruction, includePageContext, images) {
-  let text = selectedText;
-  if (text.length > MAX_TEXT_LENGTH) {
-    text = text.substring(0, MAX_TEXT_LENGTH) + '...[truncated]';
-  }
+  const safeInstruction = instruction
+    ? truncateToBudget(String(instruction), MAX_INSTRUCTION_LENGTH)
+    : '';
+  const sourceSuffix = buildSourceSuffix(includePageContext);
+  const instructionPrefix = safeInstruction ? `${safeInstruction}:\n\n` : '';
+  const textBudget = MAX_TEXT_LENGTH - SYSTEM_PROMPT.length - instructionPrefix.length - sourceSuffix.length;
+  const text = truncateToBudget(selectedText || '', textBudget);
 
   const messages = [];
 
   // System message sets the assistant's role
   messages.push({
     role: 'system',
-    content: 'You are Dobby AI, a helpful assistant. The user has selected text on a webpage and the full selected text is provided below. Do NOT attempt to access, fetch, or visit any URLs — the text content is already included in the message. A source URL may be provided as metadata only. Be concise and clear. Always respond in the same language as the selected text.',
+    content: SYSTEM_PROMPT,
   });
 
   // Combine instruction + selected text in the user message so the model
   // clearly knows what task to perform on which text
-  let userText = instruction
-    ? `${instruction}:\n\n${text}`
-    : text;
-
-  if (includePageContext) {
-    const title = typeof document !== 'undefined' ? document.title : '';
-    const url = typeof window !== 'undefined' ? window.location.href : '';
-    userText += `\n\n(Source: "${title}" — ${url})`;
-  }
+  const userText = `${instructionPrefix}${text}${sourceSuffix}`;
 
   // When images are present, build multimodal content array
   if (images && images.length > 0) {
@@ -45,7 +65,7 @@ export function buildChatMessages(selectedText, instruction, includePageContext,
     } else {
       // Image-only: images first, then instruction as text
       images.forEach(img => contentParts.push(img));
-      const instructionText = instruction || 'Explain this image';
+      const instructionText = safeInstruction || 'Explain this image';
       contentParts.push({ type: 'text', text: instructionText });
     }
     messages.push({ role: 'user', content: contentParts });

--- a/src/content/trigger/button.js
+++ b/src/content/trigger/button.js
@@ -43,6 +43,7 @@ const iconDataUri = 'data:image/svg+xml,' + encodeURIComponent(cockapooSvg);
 const pencilSvg = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/><path d="m15 5 4 4"/></svg>`;
 const closeSvg = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>`;
 const sendSvg = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>`;
+const SELECTION_IMAGE_WAIT_MS = 1000;
 
 // --- Auto-hide timer ---
 let autoHideTimer = null;
@@ -282,44 +283,115 @@ function collapseToolbar(shadow) {
 
 // --- Morph into chat ---
 
+function normalizeImages(images) {
+  return Array.isArray(images) && images.length > 0 ? images : null;
+}
+
+function cloneSelectionForImageExtraction(selection) {
+  try {
+    if (!selection?.rangeCount) return null;
+    const range = selection.getRangeAt(0);
+    if (!range) return null;
+    const clonedRange = typeof range.cloneRange === 'function' ? range.cloneRange() : range;
+    return {
+      rangeCount: 1,
+      getRangeAt: () => clonedRange,
+    };
+  } catch (err) {
+    console.warn('[Dobby AI] Could not preserve selection for image extraction:', err.message);
+    return null;
+  }
+}
+
+function startSelectionImageExtraction(host, selectionRequestId) {
+  if (host._images || host._imagesPromise || !host._selectionForImages) {
+    return host._imagesPromise;
+  }
+
+  host._imagesPromise = extractImagesFromSelection(host._selectionForImages)
+    .then((images) => {
+      const normalized = normalizeImages(images);
+      if (host._selectionRequestId === selectionRequestId) {
+        host._images = normalized;
+      }
+      return normalized;
+    })
+    .catch((err) => {
+      console.warn('[Dobby AI] Selection image extraction failed:', err.message);
+      return null;
+    });
+
+  return host._imagesPromise;
+}
+
+function resolveSelectionImages(host, selectionRequestId, onResolved) {
+  const finish = (images) => {
+    if (!host.isConnected || host._selectionRequestId !== selectionRequestId) return;
+    onResolved(normalizeImages(images));
+  };
+
+  const imagesPromise = startSelectionImageExtraction(host, selectionRequestId);
+
+  if (imagesPromise) {
+    let settled = false;
+    let timeoutId = null;
+    const finishOnce = (images) => {
+      if (settled) return;
+      settled = true;
+      if (timeoutId) clearTimeout(timeoutId);
+      finish(images);
+    };
+
+    timeoutId = setTimeout(() => finishOnce(host._images), SELECTION_IMAGE_WAIT_MS);
+    imagesPromise.then(finishOnce).catch(() => finishOnce(null));
+  } else {
+    finish(host._images);
+  }
+}
+
 function morphIntoBubble(host, shadow, label, instruction) {
+  if (host._isMorphing) return;
+  host._isMorphing = true;
+
   const toolbar = shadow.querySelector('.toolbar');
+  const selectionRequestId = host._selectionRequestId;
 
   clearAutoHide();
   removeSelectionHighlight();
 
-  // Get toolbar position — bubble will appear growing from here
-  const hostRect = host.getBoundingClientRect();
+  resolveSelectionImages(host, selectionRequestId, (images) => {
+    // Get toolbar position — bubble will appear growing from here
+    const hostRect = host.getBoundingClientRect();
 
-  // Pass a rect that positions the bubble at the toolbar's origin.
-  // createBubbleHost places bubble at selectionRect.bottom + 8,
-  // so we set bottom = toolbar.top - 8 so the bubble top = toolbar.top.
-  const selectionRect = {
-    top: hostRect.top - 16,
-    right: hostRect.right,
-    bottom: hostRect.top - 8,
-    left: hostRect.left,
-    width: hostRect.width,
-    height: hostRect.height,
-  };
+    // Pass a rect that positions the bubble at the toolbar's origin.
+    // createBubbleHost places bubble at selectionRect.bottom + 8,
+    // so we set bottom = toolbar.top - 8 so the bubble top = toolbar.top.
+    const selectionRect = {
+      top: hostRect.top - 16,
+      right: hostRect.right,
+      bottom: hostRect.top - 8,
+      left: hostRect.left,
+      width: hostRect.width,
+      height: hostRect.height,
+    };
 
-  // Build messages
-  const text = host._selectedText || '';
-  const images = host._images || null;
-  const messages = buildChatMessages(text, instruction, true, images);
+    // Build messages
+    const text = host._selectedText || '';
+    const messages = buildChatMessages(text, instruction, true, images);
 
-  // Crossfade: start bubble creation and toolbar fade simultaneously.
-  // showBubble is async (theme read) but the fade timer is independent of that.
-  showBubble(selectionRect, messages, text, instruction, images)
-    .catch((err) => console.error('[Dobby AI] Bubble creation failed:', err));
+    // Crossfade: start bubble creation and toolbar fade simultaneously.
+    // showBubble is async (theme read) but the fade timer is independent of that.
+    showBubble(selectionRect, messages, text, instruction, images)
+      .catch((err) => console.error('[Dobby AI] Bubble creation failed:', err));
 
-  // Fade out toolbar smoothly over the same duration as bubble entry animation
-  toolbar.style.transition = 'opacity 0.2s ease-out, transform 0.2s ease-out';
-  toolbar.style.opacity = '0';
-  toolbar.style.transform = 'scale(0.9)';
+    // Fade out toolbar smoothly over the same duration as bubble entry animation
+    toolbar.style.transition = 'opacity 0.2s ease-out, transform 0.2s ease-out';
+    toolbar.style.opacity = '0';
+    toolbar.style.transform = 'scale(0.9)';
 
-  // Remove toolbar after fade completes
-  setTimeout(() => hideTrigger(), 220);
+    // Remove toolbar after fade completes
+    setTimeout(() => hideTrigger(), 220);
+  });
 }
 
 // --- Selection highlight overlay ---
@@ -446,8 +518,14 @@ export async function showTrigger(x, y, selectionData = {}) {
   }
 
   // Store selection data on host
+  const selectionRequestId = (host._selectionRequestId || 0) + 1;
+  host._selectionRequestId = selectionRequestId;
+  host._isMorphing = false;
   host._selectedText = selectionData.text || '';
   host._anchorNode = selectionData.anchorNode || null;
+  host._images = normalizeImages(selectionData.images);
+  host._imagesPromise = null;
+  host._selectionForImages = host._images ? null : cloneSelectionForImageExtraction(selectionData.selection);
 
   // Position
   host.style.display = 'block';
@@ -494,9 +572,13 @@ export async function createTriggerButton() {
 
 export async function extractImagesFromSelection(selection, maxImages = 2) {
   const images = [];
-  if (!selection.rangeCount) return images;
+  if (!selection || !selection.rangeCount) return images;
 
   const range = selection.getRangeAt(0);
+  if (!range?.commonAncestorContainer || typeof range.intersectsNode !== 'function') {
+    return images;
+  }
+
   const container = range.commonAncestorContainer;
   const imgElements = container.nodeType === Node.ELEMENT_NODE
     ? container.querySelectorAll('img')

--- a/src/content/trigger/selection.js
+++ b/src/content/trigger/selection.js
@@ -61,7 +61,7 @@ export function registerListeners() {
       if (text.length >= 3 && dobbyEnabled) {
         const sel = window.getSelection();
         const anchorNode = sel.anchorNode || null;
-        showTrigger(cursorX, cursorY, { text, anchorNode }).catch(() => {});
+        showTrigger(cursorX, cursorY, { text, anchorNode, selection: sel }).catch(() => {});
       } else {
         hideTrigger();
       }
@@ -79,7 +79,7 @@ export function registerListeners() {
         if (!triggerButton || triggerButton.style.display === 'none') {
           const anchorNode = selection.anchorNode || null;
           const rect = getSelectionRect();
-          showTrigger(rect.right, rect.bottom, { text, anchorNode }).catch(() => {});
+          showTrigger(rect.right, rect.bottom, { text, anchorNode, selection }).catch(() => {});
         }
       }
     }, TIMING.SELECTION_DEBOUNCE));
@@ -95,7 +95,7 @@ export function registerListeners() {
       if (text.length >= 3 && dobbyEnabled && selection.rangeCount > 0) {
         const anchorNode = selection.anchorNode || null;
         const rect = getSelectionRect();
-        showTrigger(rect.right, rect.top, { text, anchorNode }).catch(() => {});
+        showTrigger(rect.right, rect.top, { text, anchorNode, selection }).catch(() => {});
       }
     }, TIMING.SCROLL_DEBOUNCE));
   }, true);

--- a/tests/prompt.test.js
+++ b/tests/prompt.test.js
@@ -7,12 +7,26 @@ const SYSTEM_MSG = {
 };
 
 describe('MAX_TEXT_LENGTH', () => {
-  it('is 6000', () => {
+  it('matches the proxy total text budget', () => {
     expect(MAX_TEXT_LENGTH).toBe(6000);
   });
 });
 
 describe('buildChatMessages', () => {
+  function totalTextChars(messages) {
+    return messages.reduce((total, message) => {
+      if (typeof message.content === 'string') {
+        return total + message.content.length;
+      }
+      if (Array.isArray(message.content)) {
+        return total + message.content
+          .filter((item) => item.type === 'text')
+          .reduce((sum, item) => sum + item.text.length, 0);
+      }
+      return total;
+    }, 0);
+  }
+
   it('always includes system message', () => {
     const result = buildChatMessages('hello world', '', false);
     expect(result[0]).toEqual(SYSTEM_MSG);
@@ -37,16 +51,16 @@ describe('buildChatMessages', () => {
     expect(result[1].content).toBe('text');
   });
 
-  it('truncates text longer than MAX_TEXT_LENGTH', () => {
+  it('truncates selected text so total text payload fits the proxy limit', () => {
     const longText = 'a'.repeat(MAX_TEXT_LENGTH + 500);
-    const result = buildChatMessages(longText, '', false);
+    const result = buildChatMessages(longText, 'Summarize the following', true);
     const userContent = result[1].content;
-    expect(userContent.length).toBe(MAX_TEXT_LENGTH + '...[truncated]'.length);
+    expect(totalTextChars(result)).toBeLessThanOrEqual(MAX_TEXT_LENGTH);
     expect(userContent).toContain('...[truncated]');
   });
 
-  it('does not truncate text at MAX_TEXT_LENGTH exactly', () => {
-    const text = 'a'.repeat(MAX_TEXT_LENGTH);
+  it('does not truncate when the total text payload fits the budget', () => {
+    const text = 'a'.repeat(1000);
     const result = buildChatMessages(text, '', false);
     expect(result[1].content).toBe(text);
   });

--- a/tests/toolbar.test.js
+++ b/tests/toolbar.test.js
@@ -51,6 +51,7 @@ const { showBubble } = await import('../src/content/bubble/core.js');
 const { detectContentType } = await import('../src/content/detection.js');
 const { getSuggestedPresetsForType } = await import('../src/content/presets.js');
 const { buildChatMessages } = await import('../src/content/prompt.js');
+const { captureImage } = await import('../src/content/image-capture.js');
 const { setToolbarHost, setToolbarState } = await import('../src/content/shared/state.js');
 
 function getToolbarHost() {
@@ -498,6 +499,40 @@ describe('preset click opens bubble', () => {
     shadow.querySelector('.toolbar-action').click();
 
     expect(buildChatMessages).toHaveBeenCalledWith('test text', 'Summarize the following', true, null);
+  });
+
+  it('includes images intersecting the text selection when opening the bubble', async () => {
+    const image = { type: 'image_url', image_url: { url: 'data:image/jpeg;base64,abc' } };
+    captureImage.mockResolvedValueOnce(image);
+
+    const container = document.createElement('div');
+    const img = document.createElement('img');
+    img.src = 'https://example.com/image.png';
+    container.appendChild(document.createTextNode('test text'));
+    container.appendChild(img);
+    document.body.appendChild(container);
+
+    const range = {
+      commonAncestorContainer: container,
+      intersectsNode: (node) => node === img,
+    };
+    const selection = {
+      rangeCount: 1,
+      getRangeAt: () => range,
+    };
+
+    await showTrigger(200, 100, { text: 'test text', anchorNode: null, selection });
+    const shadow = getShadow();
+    const toolbar = shadow.querySelector('.toolbar');
+
+    toolbar.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    shadow.querySelector('.toolbar-action').click();
+    await getToolbarHost()._imagesPromise;
+    await Promise.resolve();
+
+    expect(captureImage).toHaveBeenCalledWith(img);
+    expect(buildChatMessages).toHaveBeenCalledWith('test text', 'Summarize the following', true, [image]);
+    expect(showBubble.mock.calls.at(-1)[4]).toEqual([image]);
   });
 
   it('removes toolbar after preset click', async () => {


### PR DESCRIPTION
## Summary

- Wire selected text/image selections into the toolbar request path so intersecting images are captured and sent with the selected text.
- Add a bounded wait for selection image extraction so slow image capture falls back to text instead of blocking the toolbar action.
- Make prompt truncation account for the system prompt, instruction, and source metadata so proxy-bound requests stay under the 6000-character validation limit.
- Cover the selected-image flow and proxy-safe prompt budget with unit tests.

Closes #133

## Why

The README promises that selected text containing images sends both text and images, but the production toolbar path never populated `host._images`. Near-limit text selections could also exceed the proxy validator after adding prompt overhead, causing requests to be rejected even though the selected text was capped.

## Local UX validation

Validated locally in Chromium with the unpacked `dist/` extension. The AI stream endpoint was mocked so the run exercised the real content script, selection toolbar, image extraction, bubble preview, and prompt construction without consuming an API key.

![PR 132 local UX validation](https://raw.githubusercontent.com/Duobi-AI/dobby-ai/refs/heads/docs/pr-demo-gifs/pr-132/pr-132-validation.gif)

Selected image bubble preview:

![Selected image bubble preview](https://raw.githubusercontent.com/Duobi-AI/dobby-ai/refs/heads/docs/pr-demo-gifs/pr-132/03-selected-image-bubble-preview.png)

Request-level checks from `validation.json`:

- selected text + image request: `hasImage: true`, `imagePreviewCount: 1`
- long selection request: `totalTextChars: 6000`, `hasTruncationMarker: true`
- raw validation artifact: https://raw.githubusercontent.com/Duobi-AI/dobby-ai/refs/heads/docs/pr-demo-gifs/pr-132/validation.json

## Validation

- `npm run build`
- `npm test`
- GitHub CI: all checks passing on `d5f491f`