### PR TITLE
[codex] Make autosuggest init idempotent

### DIFF
--- a/src/content/autosuggest/index.js
+++ b/src/content/autosuggest/index.js
@@ -16,6 +16,7 @@ let focusoutHandler = null;
 
 export function initAutosuggest() {
   if (!autosuggestEnabled) return;
+  if (focusinHandler || focusoutHandler) return;
 
   focusinHandler = (e) => {
     if (e.target.tagName === 'TEXTAREA') attachToTextarea(e.target);

--- a/tests/autosuggest-index.test.js
+++ b/tests/autosuggest-index.test.js
@@ -54,11 +54,38 @@ describe('autosuggest lifecycle', () => {
     vi.restoreAllMocks();
   });
 
-  it('attaches focusin listener when initAutosuggest() called', () => {
+  it('attaches focus listeners when initAutosuggest() called', () => {
     const spy = vi.spyOn(document, 'addEventListener');
     initAutosuggest();
     const focusinCall = spy.mock.calls.find((c) => c[0] === 'focusin');
+    const focusoutCall = spy.mock.calls.find((c) => c[0] === 'focusout');
     expect(focusinCall).toBeDefined();
+    expect(focusoutCall).toBeDefined();
+  });
+
+  it('does not register duplicate document listeners on repeated initAutosuggest() calls', () => {
+    const spy = vi.spyOn(document, 'addEventListener');
+
+    initAutosuggest();
+    initAutosuggest();
+    initAutosuggest();
+
+    expect(spy.mock.calls.filter((c) => c[0] === 'focusin')).toHaveLength(1);
+    expect(spy.mock.calls.filter((c) => c[0] === 'focusout')).toHaveLength(1);
+  });
+
+  it('does not attach duplicate textarea listeners after repeated initAutosuggest() calls', () => {
+    const addSpy = vi.spyOn(textarea, 'addEventListener');
+    const removeSpy = vi.spyOn(textarea, 'removeEventListener');
+
+    initAutosuggest();
+    initAutosuggest();
+    textarea.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+
+    expect(addSpy.mock.calls.filter((c) => c[0] === 'input')).toHaveLength(1);
+    expect(addSpy.mock.calls.filter((c) => c[0] === 'keydown')).toHaveLength(1);
+    expect(removeSpy.mock.calls.filter((c) => c[0] === 'input')).toHaveLength(0);
+    expect(removeSpy.mock.calls.filter((c) => c[0] === 'keydown')).toHaveLength(0);
   });
 
   it('starts monitoring textarea on focus', () => {
@@ -103,7 +130,20 @@ describe('autosuggest lifecycle', () => {
     initAutosuggest();
     destroyAutosuggest();
     const focusinRemove = removeSpy.mock.calls.find((c) => c[0] === 'focusin');
+    const focusoutRemove = removeSpy.mock.calls.find((c) => c[0] === 'focusout');
     expect(focusinRemove).toBeDefined();
+    expect(focusoutRemove).toBeDefined();
+  });
+
+  it('destroyAutosuggest removes listeners after repeated initAutosuggest() calls', () => {
+    const removeSpy = vi.spyOn(document, 'removeEventListener');
+
+    initAutosuggest();
+    initAutosuggest();
+    destroyAutosuggest();
+
+    expect(removeSpy.mock.calls.filter((c) => c[0] === 'focusin')).toHaveLength(1);
+    expect(removeSpy.mock.calls.filter((c) => c[0] === 'focusout')).toHaveLength(1);
   });
 
   it('cleans up on textarea blur', () => {


### PR DESCRIPTION
## Summary

- Guard `initAutosuggest()` so repeated calls while enabled do not register duplicate document listeners.
- Add focused lifecycle tests for repeated init, textarea attachment, and destroy cleanup.

Closes #135

## Validation

- `npm run build`
- `npm test -- tests/autosuggest-index.test.js`