### PR TITLE
[codex] Unify autosuggest token limits

### DIFF
--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -2,6 +2,7 @@
 import { validatePayload, verifyHmac } from './validate.js';
 import { checkRateLimit, incrementCounters } from './rate-limit.js';
 import { createChatStream } from './openai.js';
+import { AUTOSUGGEST_MAX_SUGGESTION_TOKENS } from '../../src/shared/autosuggest-limits.js';
 
 const MAX_BODY_SIZE = 2097152; // 2MB
 
@@ -97,7 +98,7 @@ export default {
 
     if (!devBypass) await incrementCounters(ip, env.RATE_LIMIT_KV, purpose);
 
-    const maxTokens = purpose === 'autosuggest' ? 200 : undefined;
+    const maxTokens = purpose === 'autosuggest' ? AUTOSUGGEST_MAX_SUGGESTION_TOKENS : undefined;
     const openaiResponse = await createChatStream(body.messages, env.OPENAI_API_KEY, undefined, maxTokens);
 
     if (!openaiResponse.ok) {

--- a/proxy/tests/index.test.js
+++ b/proxy/tests/index.test.js
@@ -1,5 +1,6 @@
 // proxy/tests/index.test.js
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AUTOSUGGEST_MAX_SUGGESTION_TOKENS } from '../../src/shared/autosuggest-limits.js';
 
 // Mock modules before importing handler
 vi.mock('../src/validate.js', () => ({
@@ -205,7 +206,7 @@ describe('POST /chat', () => {
     expect(incrementCounters).toHaveBeenCalledWith('1.2.3.4', expect.anything(), 'chat');
   });
 
-  it('passes maxTokens=200 to createChatStream for autosuggest', async () => {
+  it('passes the shared autosuggest token limit to createChatStream for autosuggest', async () => {
     const req = makeRequest('/chat', {
       method: 'POST',
       body: { messages: [{ role: 'user', content: 'hi' }], signature: 'x', timestamp: 1, purpose: 'autosuggest' },
@@ -216,7 +217,7 @@ describe('POST /chat', () => {
       expect.any(Array),
       'sk-test',
       undefined,
-      200
+      AUTOSUGGEST_MAX_SUGGESTION_TOKENS
     );
   });
 

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -1,6 +1,8 @@
 // src/background/index.js — Dobby AI API relay + streaming hub
 // All API calls from content scripts route through here (MV3 cross-origin constraint)
 
+import { AUTOSUGGEST_MAX_SUGGESTION_TOKENS } from '../shared/autosuggest-limits.js';
+
 const PROXY_URL = 'https://dobby-ai-proxy.zhongnansu.workers.dev/chat';
 // HMAC_SECRET is intentionally in extension source — it's light obfuscation per spec.
 // Real defense is IP rate limiting on the proxy.
@@ -218,7 +220,7 @@ chrome.runtime.onConnect.addListener((port) => {
             model: 'gpt-4.1-mini',
             messages,
             stream: true,
-            max_tokens: 50,
+            max_tokens: AUTOSUGGEST_MAX_SUGGESTION_TOKENS,
           }),
           signal: abortController.signal,
         });

--- a/src/content/shared/constants.js
+++ b/src/content/shared/constants.js
@@ -1,5 +1,7 @@
 // src/content/shared/constants.js — Shared constants for Dobby AI extension
 
+import { AUTOSUGGEST_MAX_SUGGESTION_TOKENS } from '../../shared/autosuggest-limits.js';
+
 export const Z_INDEX = {
   TRIGGER: 2147483647,
   SCREENSHOT_OVERLAY: 2147483646,
@@ -37,7 +39,7 @@ export const AUTOSUGGEST = {
   DEBOUNCE_MS: 500,
   MIN_CHARS: 10,
   MAX_CONTEXT_CHARS: 2000,
-  MAX_SUGGESTION_TOKENS: 50,
+  MAX_SUGGESTION_TOKENS: AUTOSUGGEST_MAX_SUGGESTION_TOKENS,
   GHOST_OPACITY: 0.4,
   GHOST_COLOR: '#9ca3af',
 };

--- a/src/shared/autosuggest-limits.js
+++ b/src/shared/autosuggest-limits.js
@@ -1,0 +1,3 @@
+// src/shared/autosuggest-limits.js — Autosuggest token limits shared by extension and proxy
+
+export const AUTOSUGGEST_MAX_SUGGESTION_TOKENS = 50;

--- a/tests/autosuggest-state.test.js
+++ b/tests/autosuggest-state.test.js
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect } from 'vitest';
+import { AUTOSUGGEST_MAX_SUGGESTION_TOKENS } from '../src/shared/autosuggest-limits.js';
 
 describe('autosuggest constants', () => {
   it('exports AUTOSUGGEST timing constants', async () => {
@@ -7,7 +8,7 @@ describe('autosuggest constants', () => {
     expect(AUTOSUGGEST.DEBOUNCE_MS).toBe(500);
     expect(AUTOSUGGEST.MIN_CHARS).toBe(10);
     expect(AUTOSUGGEST.MAX_CONTEXT_CHARS).toBe(2000);
-    expect(AUTOSUGGEST.MAX_SUGGESTION_TOKENS).toBe(50);
+    expect(AUTOSUGGEST.MAX_SUGGESTION_TOKENS).toBe(AUTOSUGGEST_MAX_SUGGESTION_TOKENS);
     expect(AUTOSUGGEST.GHOST_OPACITY).toBe(0.4);
     expect(AUTOSUGGEST.GHOST_COLOR).toBe('#9ca3af');
   });

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -1,5 +1,6 @@
 // tests/background.test.js
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AUTOSUGGEST_MAX_SUGGESTION_TOKENS } from '../src/shared/autosuggest-limits.js';
 
 const mockCreate = vi.fn();
 const mockSendMessage = vi.fn();
@@ -406,7 +407,7 @@ describe('autosuggest-stream port', () => {
     expect(port.onMessage.addListener).not.toHaveBeenCalled();
   });
 
-  it('uses max_tokens of 50 when calling OpenAI directly', async () => {
+  it('uses the shared autosuggest token limit when calling OpenAI directly', async () => {
     const { port, getHandler } = createAutosuggestPort();
     const autosuggestHandler = connectListeners[1];
     autosuggestHandler(port);
@@ -427,7 +428,7 @@ describe('autosuggest-stream port', () => {
     const calledUrl = fetch.mock.calls[0][0];
     expect(calledUrl).toContain('openai.com');
     const body = JSON.parse(fetch.mock.calls[0][1].body);
-    expect(body.max_tokens).toBe(50);
+    expect(body.max_tokens).toBe(AUTOSUGGEST_MAX_SUGGESTION_TOKENS);
   });
 
   it('passes purpose=autosuggest to proxy when no user key', async () => {


### PR DESCRIPTION
## Summary

- Add a shared autosuggest max-token constant set to 50.
- Use the same limit for direct OpenAI autosuggest requests and proxy autosuggest forwarding.
- Update extension and proxy tests to assert the shared limit.

Closes #136

## Validation

- `npm run build`
- `npm test -- tests/background.test.js tests/autosuggest-state.test.js`
- `cd proxy && npm test -- tests/index.test.js`
- `cd proxy && npx wrangler deploy --dry-run --outdir /tmp/dobby-proxy-dry-run-token-limit`