### PR TITLE
[codex] improve popup controls

### DIFF
--- a/e2e/extension.spec.js
+++ b/e2e/extension.spec.js
@@ -43,11 +43,11 @@ test('popup page loads and toggle works', async () => {
   // Click to toggle off
   await toggleLabel.click();
   const status = popupPage.locator('#status');
-  await expect(status).toHaveText('Disabled');
+  await expect(status).toHaveText('Off');
 
   // Click to toggle back on (toggleLabel already references .first())
   await toggleLabel.click();
-  await expect(status).toHaveText('Enabled');
+  await expect(status).toHaveText('On');
 
   await popupPage.close();
 });

--- a/options.html
+++ b/options.html
@@ -147,7 +147,7 @@
       <img src="icons/icon48.png" alt="Dobby AI">
       <div>
         <h1>Dobby AI</h1>
-        <div class="version">v2.0.0</div>
+        <div class="version" id="extension-version">v1.1.0</div>
       </div>
     </div>
 

--- a/popup.html
+++ b/popup.html
@@ -4,22 +4,12 @@
 <style>
   * { margin: 0; padding: 0; box-sizing: border-box; }
   body {
-    width: 200px;
+    width: 268px;
     padding: 12px;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
     font-size: 13px;
     color: #18181b;
     background: #fff;
-  }
-  @media (prefers-color-scheme: dark) {
-    body { background: #1e1e28; color: #e4e4e7; }
-    .toggle-row, .theme-row { border-bottom-color: rgba(255,255,255,0.08); }
-    .status { color: #a1a1aa; }
-    .settings-link { color: #a78bfa; }
-    .theme-segment { background: #2a2a3a; border-color: rgba(255,255,255,0.08); }
-    .theme-option { color: #a1a1aa; }
-    .theme-option:hover { color: #e4e4e7; }
-    .theme-option.active { background: #7c3aed; color: #fff; }
   }
   .theme-row {
     display: flex;
@@ -56,9 +46,32 @@
     display: flex;
     align-items: center;
     gap: 6px;
-    margin-bottom: 10px;
+    margin-bottom: 8px;
     font-weight: 600;
     font-size: 14px;
+  }
+  .header-text { flex: 1; min-width: 0; }
+  .version { font-size: 11px; color: #71717a; font-weight: 400; }
+  .usage-card {
+    border: 1px solid rgba(0,0,0,0.08);
+    border-radius: 8px;
+    padding: 10px;
+    margin-bottom: 10px;
+    background: #fafafa;
+  }
+  .usage-card.ok { border-color: rgba(22,163,74,0.18); }
+  .usage-card.warning { border-color: rgba(245,158,11,0.28); background: #fffbeb; }
+  .usage-card.danger { border-color: rgba(239,68,68,0.28); background: #fef2f2; }
+  .usage-primary {
+    font-size: 13px;
+    font-weight: 600;
+    line-height: 1.35;
+  }
+  .usage-secondary {
+    margin-top: 4px;
+    color: #71717a;
+    font-size: 11px;
+    line-height: 1.4;
   }
   .toggle-row {
     display: flex;
@@ -68,7 +81,20 @@
     margin-bottom: 10px;
     border-bottom: 1px solid rgba(0,0,0,0.06);
   }
+  .toggle-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
   .status { font-size: 12px; color: #71717a; }
+  .toggle-label { font-size: 12px; color: inherit; }
+  .state-badge {
+    font-size: 11px;
+    color: #71717a;
+  }
+  .state-badge.on { color: #15803d; }
+  .state-badge.off { color: #b91c1c; }
   .toggle {
     position: relative;
     width: 36px;
@@ -117,31 +143,103 @@
     text-decoration: none;
     cursor: pointer;
   }
+  .quick-actions {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 6px;
+    padding-bottom: 10px;
+    margin-bottom: 10px;
+    border-bottom: 1px solid rgba(0,0,0,0.06);
+  }
+  .quick-action {
+    border: 1px solid rgba(0,0,0,0.08);
+    border-radius: 7px;
+    background: #fff;
+    color: #18181b;
+    cursor: pointer;
+    font: inherit;
+    font-size: 11px;
+    min-height: 30px;
+    padding: 5px 6px;
+  }
+  .quick-action:hover { background: #f4f4f5; }
+  .quick-action:disabled { cursor: not-allowed; opacity: 0.55; }
+  .action-feedback {
+    min-height: 14px;
+    margin-top: -4px;
+    margin-bottom: 8px;
+    font-size: 11px;
+    color: #71717a;
+    text-align: center;
+  }
+  @media (prefers-color-scheme: dark) {
+    body { background: #1e1e28; color: #e4e4e7; }
+    .toggle-row, .theme-row, .usage-card, .quick-actions { border-color: rgba(255,255,255,0.08); }
+    .status, .usage-secondary, .action-feedback, .state-badge, .version { color: #a1a1aa; }
+    .settings-link { color: #a78bfa; }
+    .usage-card { background: #242432; }
+    .usage-card.warning { background: #3a3018; border-color: rgba(245,158,11,0.3); }
+    .usage-card.danger { background: #3a1f24; border-color: rgba(239,68,68,0.3); }
+    .state-badge.on { color: #86efac; }
+    .state-badge.off { color: #fca5a5; }
+    .quick-action { background: #2a2a3a; color: #e4e4e7; border-color: rgba(255,255,255,0.08); }
+    .quick-action:hover { background: #333348; }
+    .quick-action:disabled { color: #71717a; }
+    .theme-segment { background: #2a2a3a; border-color: rgba(255,255,255,0.08); }
+    .theme-option { color: #a1a1aa; }
+    .theme-option:hover { color: #e4e4e7; }
+    .theme-option.active { background: #7c3aed; color: #fff; }
+  }
 </style>
 </head>
 <body>
-  <div class="header">&#10022; Dobby AI</div>
+  <div class="header">
+    <span>&#10022;</span>
+    <div class="header-text">
+      <div>Dobby AI</div>
+      <div class="version" id="version"></div>
+    </div>
+  </div>
+  <div class="usage-card" id="usage-card">
+    <div class="usage-primary" id="usage-primary">Loading usage...</div>
+    <div class="usage-secondary" id="usage-secondary"></div>
+  </div>
   <div class="toggle-row">
-    <span class="status" id="status">Enabled</span>
+    <div class="toggle-copy">
+      <span class="toggle-label">Dobby on this browser</span>
+      <span class="state-badge" id="status">On</span>
+    </div>
     <label class="toggle">
       <input type="checkbox" id="enabled" checked aria-label="Enable or disable Dobby AI">
       <span class="slider"></span>
     </label>
   </div>
   <div class="toggle-row">
-    <span class="status" id="screenshot-status" title="Long-press anywhere to screenshot a region and ask AI about it.">Screenshot mode</span>
+    <div class="toggle-copy">
+      <span class="toggle-label" title="Long-press anywhere to screenshot a region and ask AI about it.">Long-press screenshots</span>
+      <span class="state-badge" id="screenshot-status">On</span>
+    </div>
     <label class="toggle">
       <input type="checkbox" id="screenshot-enabled" checked aria-label="Enable or disable screenshot mode">
       <span class="slider"></span>
     </label>
   </div>
   <div class="toggle-row">
-    <span class="status" id="autosuggest-status" title="Works in standard text fields (textarea). Gmail, Docs, and Notion support coming soon.">Auto-suggest</span>
+    <div class="toggle-copy">
+      <span class="toggle-label" title="Works in standard text fields (textarea). Gmail, Docs, and Notion support coming soon.">Text auto-suggest</span>
+      <span class="state-badge" id="autosuggest-status">Off</span>
+    </div>
     <label class="toggle">
       <input type="checkbox" id="autosuggest-enabled" aria-label="Enable or disable auto-suggest">
       <span class="slider"></span>
     </label>
   </div>
+  <div class="quick-actions">
+    <button class="quick-action" id="history">History</button>
+    <button class="quick-action" id="clear-history">Clear</button>
+    <button class="quick-action" id="settings">Settings</button>
+  </div>
+  <div class="action-feedback" id="action-feedback"></div>
   <div class="theme-row">
     <span class="status">Theme</span>
     <div class="theme-segment" id="theme-segment" role="group" aria-label="Theme">
@@ -150,7 +248,6 @@
       <button class="theme-option" data-theme="dark" aria-pressed="false">Dark</button>
     </div>
   </div>
-  <a class="settings-link" id="settings">Settings</a>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -4,11 +4,57 @@
 import { AUTOSUGGEST_MAX_SUGGESTION_TOKENS } from '../shared/autosuggest-limits.js';
 
 const PROXY_URL = 'https://dobby-ai-proxy.zhongnansu.workers.dev/chat';
+const USAGE_STORAGE_KEY = 'dobbyUsage';
 // HMAC_SECRET is intentionally in extension source — it's light obfuscation per spec.
 // Real defense is IP rate limiting on the proxy.
 const HMAC_SECRET = 'dobby-ai-v2-hmac-key-change-in-production';
 // Set to your dev token to bypass rate limits during development; leave empty for normal user behavior
 const DEV_BYPASS_TOKEN = '';
+
+function getUtcDay() {
+  return new Date().toISOString().split('T')[0];
+}
+
+function createEmptyUsage() {
+  return {
+    day: getUtcDay(),
+    chatRequests: 0,
+    autosuggestRequests: 0,
+    screenshotRequests: 0,
+    freeChatRemaining: null,
+    usingOwnKey: false,
+    lastUpdated: Date.now(),
+  };
+}
+
+async function recordUsage(kind, details = {}) {
+  try {
+    const stored = await chrome.storage.local.get(USAGE_STORAGE_KEY);
+    const current = stored[USAGE_STORAGE_KEY];
+    const usage = current && current.day === getUtcDay() ? { ...current } : createEmptyUsage();
+
+    if (!details.rateLimited) {
+      if (kind === 'chat') usage.chatRequests = (usage.chatRequests || 0) + 1;
+      if (kind === 'autosuggest') usage.autosuggestRequests = (usage.autosuggestRequests || 0) + 1;
+      if (kind === 'screenshot') usage.screenshotRequests = (usage.screenshotRequests || 0) + 1;
+    }
+
+    if (kind === 'chat' && details.remaining != null && !details.usingOwnKey) {
+      usage.freeChatRemaining = details.remaining;
+    }
+    if (details.remaining === 0 && !details.usingOwnKey) {
+      usage.freeChatRemaining = 0;
+    }
+    if (details.usingOwnKey != null) {
+      usage.usingOwnKey = details.usingOwnKey;
+    }
+    usage.lastUpdated = Date.now();
+
+    await chrome.storage.local.set({ [USAGE_STORAGE_KEY]: usage });
+  } catch (e) {
+    console.warn('[Dobby AI] Failed to record usage:', e.message);
+  }
+}
 
 // --- Context Menu ---
 
@@ -187,6 +233,7 @@ chrome.runtime.onConnect.addListener((port) => {
       if (response.status === 429) {
         let data;
         try { data = await response.json(); } catch (e) { console.warn('[Dobby AI] Failed to parse rate limit response'); data = { remaining: 0 }; }
+        await recordUsage('chat', { remaining: data.remaining ?? 0, usingOwnKey: false, rateLimited: true });
         try { port.postMessage({ type: 'rate_limited', remaining: data.remaining ?? 0, resetAt: data.resetAt }); } catch (e) { console.warn('[Dobby AI] port.postMessage failed:', e.message); }
         return;
       }
@@ -207,6 +254,7 @@ chrome.runtime.onConnect.addListener((port) => {
       for await (const token of parseSSEStream(reader)) {
         try { port.postMessage({ type: 'token', text: token }); } catch (e) { console.warn('[Dobby AI] port.postMessage failed:', e.message); break; }
       }
+      await recordUsage('chat', { remaining, usingOwnKey });
       try { port.postMessage({ type: 'done', remaining, usingOwnKey }); } catch (e) { console.warn('[Dobby AI] port.postMessage failed:', e.message); }
     } catch (err) {
       if (err.name === 'AbortError') {
@@ -277,6 +325,7 @@ chrome.runtime.onConnect.addListener((port) => {
       if (response.status === 429) {
         let data;
         try { data = await response.json(); } catch (e) { data = { remaining: 0 }; }
+        await recordUsage('autosuggest', { usingOwnKey: false, rateLimited: true });
         try { port.postMessage({ type: 'rate_limited', remaining: data.remaining ?? 0 }); } catch (e) { /* port closed */ }
         return;
       }
@@ -293,6 +342,7 @@ chrome.runtime.onConnect.addListener((port) => {
       for await (const token of parseSSEStream(reader)) {
         try { port.postMessage({ type: 'token', text: token }); } catch (e) { break; }
       }
+      await recordUsage('autosuggest', { usingOwnKey: !!stored.userApiKey });
       try { port.postMessage({ type: 'done' }); } catch (e) { /* port closed */ }
     } catch (err) {
       if (err.name !== 'AbortError') {
@@ -316,6 +366,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       if (chrome.runtime.lastError || !dataUrl) {
         sendResponse({ error: 'Screenshot failed' });
       } else {
+        recordUsage('screenshot');
         sendResponse({ dataUrl });
       }
     });

--- a/src/content/bubble/core.js
+++ b/src/content/bubble/core.js
@@ -360,6 +360,15 @@ export async function showBubble(selectionRect, messages, selectedText, instruct
   activateResponseSection(shadow, messages);
 }
 
+export async function showHistoryBubble(selectionRect) {
+  const shadow = await initBubble(selectionRect, '', 'History', false, null);
+  const responseSection = shadow.querySelector('.response-section');
+  if (responseSection) responseSection.classList.add('active');
+  const status = shadow.querySelector('.bubble-status');
+  if (status) status.textContent = 'history';
+  await showHistoryPanel(shadow);
+}
+
 export function hideBubble() {
   if (renderTimer) { clearTimeout(renderTimer); setRenderTimer(null); }
   if (currentRequest) {

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -5,7 +5,7 @@ import { setDobbyEnabled, setAutosuggestEnabled, setScreenshotEnabled } from './
 import { initAutosuggest, destroyAutosuggest } from './autosuggest/index.js';
 import { registerListeners } from './trigger/selection.js';
 import { hideTrigger } from './trigger/button.js';
-import { showBubbleWithPresets, showBubble, hideBubble, getBubbleContainer } from './bubble/core.js';
+import { showBubbleWithPresets, showBubble, showHistoryBubble, hideBubble, getBubbleContainer } from './bubble/core.js';
 import { buildChatMessages } from './prompt.js';
 import { captureImage } from './image-capture.js';
 import { isClickInsideUI } from './shared/dom-utils.js';
@@ -55,8 +55,19 @@ chrome.runtime.onMessage.addListener((msg) => {
   }
 });
 
-// Context menu message handler
+// Context menu and popup action message handler
 chrome.runtime.onMessage.addListener((msg) => {
+  if (msg.type === 'SHOW_HISTORY') {
+    const rect = {
+      top: window.innerHeight / 3 - 8,
+      bottom: window.innerHeight / 3,
+      left: window.innerWidth / 4,
+      right: window.innerWidth * 3 / 4,
+    };
+    (async () => { await showHistoryBubble(rect); })();
+    return;
+  }
+
   if (msg.type === 'SHOW_BUBBLE') {
     const rect = {
       top: window.innerHeight / 3 - 8,

--- a/src/content/trigger/button.js
+++ b/src/content/trigger/button.js
@@ -543,6 +543,7 @@ export async function showTrigger(x, y, selectionData = {}) {
 export function hideTrigger() {
   clearAutoHide();
   removeSelectionHighlight();
+  if (typeof document === 'undefined') return;
   if (outsideClickHandler) {
     document.removeEventListener('mousedown', outsideClickHandler, true);
     outsideClickHandler = null;

--- a/src/options.js
+++ b/src/options.js
@@ -7,6 +7,11 @@ const keyStatus = document.getElementById('key-status');
 const hasKeySection = document.getElementById('has-key');
 const noKeySection = document.getElementById('no-key');
 const keyDisplay = document.getElementById('key-display');
+const versionEl = document.getElementById('extension-version');
+
+if (versionEl && chrome.runtime.getManifest) {
+  versionEl.textContent = `v${chrome.runtime.getManifest().version}`;
+}
 
 function maskKey(key) {
   if (!key || key.length < 12) return '••••••••';

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,68 +1,116 @@
+const FREE_CHAT_LIMIT = 30;
+const LOW_QUOTA_THRESHOLD = 5;
+
 const toggle = document.getElementById('enabled');
 const status = document.getElementById('status');
-const settingsLink = document.getElementById('settings');
-
-chrome.storage.local.get('dobbyEnabled', (data) => {
-  const enabled = data.dobbyEnabled !== false; // default: enabled
-  toggle.checked = enabled;
-  status.textContent = enabled ? 'Enabled' : 'Disabled';
-});
-
-toggle.addEventListener('change', () => {
-  const enabled = toggle.checked;
-  chrome.storage.local.set({ dobbyEnabled: enabled });
-  status.textContent = enabled ? 'Enabled' : 'Disabled';
-  // Notify content-script tabs (filter to http/https to avoid chrome:// errors)
-  chrome.tabs.query({ url: ['http://*/*', 'https://*/*'] }, (tabs) => {
-    tabs.forEach((tab) => {
-      chrome.tabs.sendMessage(tab.id, { type: 'DOBBY_TOGGLE', enabled }).catch(() => {});
-    });
-  });
-});
-
-settingsLink.addEventListener('click', () => {
-  chrome.runtime.openOptionsPage();
-});
-
-// Screenshot mode toggle
 const screenshotToggle = document.getElementById('screenshot-enabled');
-
-chrome.storage.local.get('screenshotEnabled', (data) => {
-  const enabled = data.screenshotEnabled !== false; // default: enabled
-  screenshotToggle.checked = enabled;
-});
-
-screenshotToggle.addEventListener('change', () => {
-  const enabled = screenshotToggle.checked;
-  chrome.storage.local.set({ screenshotEnabled: enabled });
-  chrome.tabs.query({ url: ['http://*/*', 'https://*/*'] }, (tabs) => {
-    tabs.forEach((tab) => {
-      chrome.tabs.sendMessage(tab.id, { type: 'SCREENSHOT_TOGGLE', enabled }).catch(() => {});
-    });
-  });
-});
-
-// Autosuggest toggle
+const screenshotStatus = document.getElementById('screenshot-status');
 const autosuggestToggle = document.getElementById('autosuggest-enabled');
 const autosuggestStatus = document.getElementById('autosuggest-status');
+const settingsBtn = document.getElementById('settings');
+const historyBtn = document.getElementById('history');
+const clearHistoryBtn = document.getElementById('clear-history');
+const feedback = document.getElementById('action-feedback');
+const usageCard = document.getElementById('usage-card');
+const usagePrimary = document.getElementById('usage-primary');
+const usageSecondary = document.getElementById('usage-secondary');
+const versionEl = document.getElementById('version');
+const themeOptions = document.querySelectorAll('.theme-option');
 
-chrome.storage.local.get('autosuggestEnabled', (data) => {
-  const enabled = data.autosuggestEnabled === true; // default: disabled
-  autosuggestToggle.checked = enabled;
-});
+function getUtcDay() {
+  return new Date().toISOString().split('T')[0];
+}
 
-autosuggestToggle.addEventListener('change', () => {
-  const enabled = autosuggestToggle.checked;
-  chrome.storage.local.set({ autosuggestEnabled: enabled });
+function getResetTimeLabel() {
+  const reset = new Date();
+  reset.setUTCHours(24, 0, 0, 0);
+  return reset.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+}
+
+function setSwitchState(input, stateEl, enabled) {
+  input.checked = enabled;
+  stateEl.textContent = enabled ? 'On' : 'Off';
+  stateEl.classList.toggle('on', enabled);
+  stateEl.classList.toggle('off', !enabled);
+}
+
+function setFeedback(message) {
+  feedback.textContent = message || '';
+}
+
+function todayUsage(rawUsage) {
+  if (!rawUsage || rawUsage.day !== getUtcDay()) {
+    return {
+      chatRequests: 0,
+      autosuggestRequests: 0,
+      screenshotRequests: 0,
+      freeChatRemaining: null,
+    };
+  }
+  return rawUsage;
+}
+
+function renderUsage({ userApiKey, dobbyUsage }) {
+  const usage = todayUsage(dobbyUsage);
+  usageCard.classList.remove('ok', 'warning', 'danger');
+
+  if (userApiKey) {
+    usageCard.classList.add('ok');
+    usagePrimary.textContent = 'Using your API key';
+    usageSecondary.textContent = `Provider billing applies. Today: ${usage.chatRequests || 0} chats, ${usage.autosuggestRequests || 0} suggestions, ${usage.screenshotRequests || 0} screenshots.`;
+    return;
+  }
+
+  const remaining = Number.isFinite(usage.freeChatRemaining) ? usage.freeChatRemaining : null;
+  if (remaining == null) {
+    usagePrimary.textContent = `${FREE_CHAT_LIMIT} free questions/day`;
+    usageSecondary.textContent = 'Ask once to sync remaining quota. Add an API key for unlimited use.';
+    return;
+  }
+
+  if (remaining <= 0) {
+    usageCard.classList.add('danger');
+    usagePrimary.textContent = 'Free quota used';
+  } else {
+    usageCard.classList.add(remaining <= LOW_QUOTA_THRESHOLD ? 'warning' : 'ok');
+    usagePrimary.textContent = `${remaining}/${FREE_CHAT_LIMIT} free left`;
+  }
+
+  usageSecondary.textContent = `Resets around ${getResetTimeLabel()}. Today: ${usage.chatRequests || 0} chats, ${usage.autosuggestRequests || 0} suggestions, ${usage.screenshotRequests || 0} screenshots.`;
+}
+
+function setHistoryState(history) {
+  const hasHistory = Array.isArray(history) && history.length > 0;
+  historyBtn.disabled = !hasHistory;
+  clearHistoryBtn.disabled = !hasHistory;
+}
+
+function loadPopupState() {
+  chrome.storage.local.get([
+    'dobbyEnabled',
+    'screenshotEnabled',
+    'autosuggestEnabled',
+    'theme',
+    'userApiKey',
+    'dobbyUsage',
+    'chatHistory',
+  ], (data) => {
+    setSwitchState(toggle, status, data.dobbyEnabled !== false);
+    setSwitchState(screenshotToggle, screenshotStatus, data.screenshotEnabled !== false);
+    setSwitchState(autosuggestToggle, autosuggestStatus, data.autosuggestEnabled === true);
+    setActiveThemeOption(data.theme || 'auto');
+    renderUsage({ userApiKey: data.userApiKey, dobbyUsage: data.dobbyUsage });
+    setHistoryState(data.chatHistory || []);
+  });
+}
+
+function broadcastToContent(message) {
   chrome.tabs.query({ url: ['http://*/*', 'https://*/*'] }, (tabs) => {
     tabs.forEach((tab) => {
-      chrome.tabs.sendMessage(tab.id, { type: 'AUTOSUGGEST_TOGGLE', enabled }).catch(() => {});
+      chrome.tabs.sendMessage(tab.id, message).catch(() => {});
     });
   });
-});
-
-// Theme segmented control
-const themeOptions = document.querySelectorAll('.theme-option');
+}
 
 function setActiveThemeOption(value) {
   themeOptions.forEach((btn) => {
@@ -72,9 +120,56 @@ function setActiveThemeOption(value) {
   });
 }
 
-chrome.storage.local.get('theme', (data) => {
-  const theme = data.theme || 'auto';
-  setActiveThemeOption(theme);
+if (versionEl && chrome.runtime.getManifest) {
+  versionEl.textContent = `v${chrome.runtime.getManifest().version}`;
+}
+
+loadPopupState();
+
+toggle.addEventListener('change', () => {
+  const enabled = toggle.checked;
+  chrome.storage.local.set({ dobbyEnabled: enabled });
+  setSwitchState(toggle, status, enabled);
+  broadcastToContent({ type: 'DOBBY_TOGGLE', enabled });
+});
+
+screenshotToggle.addEventListener('change', () => {
+  const enabled = screenshotToggle.checked;
+  chrome.storage.local.set({ screenshotEnabled: enabled });
+  setSwitchState(screenshotToggle, screenshotStatus, enabled);
+  broadcastToContent({ type: 'SCREENSHOT_TOGGLE', enabled });
+});
+
+autosuggestToggle.addEventListener('change', () => {
+  const enabled = autosuggestToggle.checked;
+  chrome.storage.local.set({ autosuggestEnabled: enabled });
+  setSwitchState(autosuggestToggle, autosuggestStatus, enabled);
+  broadcastToContent({ type: 'AUTOSUGGEST_TOGGLE', enabled });
+});
+
+settingsBtn.addEventListener('click', () => {
+  chrome.runtime.openOptionsPage();
+});
+
+historyBtn.addEventListener('click', () => {
+  setFeedback('');
+  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    const tabId = tabs && tabs[0] && tabs[0].id;
+    if (!tabId) {
+      setFeedback('Open a regular webpage to show history.');
+      return;
+    }
+    chrome.tabs.sendMessage(tabId, { type: 'SHOW_HISTORY' })
+      .then(() => setFeedback('History opened on this page.'))
+      .catch(() => setFeedback('Open a regular webpage to show history.'));
+  });
+});
+
+clearHistoryBtn.addEventListener('click', () => {
+  chrome.storage.local.set({ chatHistory: [] }, () => {
+    setHistoryState([]);
+    setFeedback('History cleared.');
+  });
 });
 
 themeOptions.forEach((btn) => {

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -412,6 +412,30 @@ describe('chat-stream integration', () => {
     expect(calledUrl).toContain('workers.dev');
   });
 
+  it('records chat usage with remaining free quota', async () => {
+    const { port, getHandler } = createStreamPort();
+    const connectHandler = connectListeners[0];
+    connectHandler(port);
+
+    fetch.mockResolvedValue(makeSSEResponse([
+      'data: {"choices":[{"delta":{"content":"Hi"}}]}\n\n',
+      'data: [DONE]\n\n',
+    ]));
+
+    const handler = getHandler();
+    await handler({ type: 'CHAT_REQUEST', messages: [{ role: 'user', content: 'test' }] });
+
+    await vi.waitFor(() => {
+      expect(mockStorageSet).toHaveBeenCalledWith({
+        dobbyUsage: expect.objectContaining({
+          chatRequests: 1,
+          freeChatRemaining: 25,
+          usingOwnKey: false,
+        }),
+      });
+    });
+  });
+
   it('calls OpenAI directly when user has API key', async () => {
     const { port, getHandler } = createStreamPort();
     const connectHandler = connectListeners[0];
@@ -593,6 +617,29 @@ describe('autosuggest-stream port', () => {
       expect(port.postMessage).toHaveBeenCalledWith({ type: 'token', text: 'Hello' });
       expect(port.postMessage).toHaveBeenCalledWith({ type: 'token', text: ' world' });
       expect(port.postMessage).toHaveBeenCalledWith({ type: 'done' });
+    });
+  });
+
+  it('records autosuggest usage', async () => {
+    const { port, getHandler } = createAutosuggestPort();
+    const autosuggestHandler = connectListeners[1];
+    autosuggestHandler(port);
+
+    fetch.mockResolvedValue(makeSSEResponse([
+      'data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n',
+      'data: [DONE]\n\n',
+    ]));
+
+    const handler = getHandler();
+    await handler({ type: 'AUTOSUGGEST_REQUEST', messages: [{ role: 'user', content: 'test' }] });
+
+    await vi.waitFor(() => {
+      expect(mockStorageSet).toHaveBeenCalledWith({
+        dobbyUsage: expect.objectContaining({
+          autosuggestRequests: 1,
+          usingOwnKey: false,
+        }),
+      });
     });
   });
 

--- a/tests/content.test.js
+++ b/tests/content.test.js
@@ -33,6 +33,7 @@ global.chrome = {
 vi.mock('../src/content/bubble/core.js', () => ({
   showBubble: vi.fn(),
   showBubbleWithPresets: vi.fn(),
+  showHistoryBubble: vi.fn(),
   hideBubble: vi.fn(),
   getBubbleContainer: vi.fn(),
 }));
@@ -83,7 +84,7 @@ vi.mock('../src/content/shared/dom-utils.js', () => ({
   }),
 }));
 
-const { showBubble, showBubbleWithPresets, hideBubble, getBubbleContainer } = await import('../src/content/bubble/core.js');
+const { showBubble, showBubbleWithPresets, showHistoryBubble, hideBubble, getBubbleContainer } = await import('../src/content/bubble/core.js');
 const { buildChatMessages } = await import('../src/content/prompt.js');
 const { captureImage } = await import('../src/content/image-capture.js');
 
@@ -164,6 +165,17 @@ describe('content/index.js', () => {
       expect(showBubble).not.toHaveBeenCalled();
       expect(showBubbleWithPresets).not.toHaveBeenCalled();
       expect(buildChatMessages).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('SHOW_HISTORY from popup', () => {
+    it('opens the history bubble', () => {
+      const listener = messageListeners[3];
+      listener({ type: 'SHOW_HISTORY' });
+
+      expect(showHistoryBubble).toHaveBeenCalledWith(
+        expect.objectContaining({ bottom: expect.any(Number), left: expect.any(Number), right: expect.any(Number) }),
+      );
     });
   });
 

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -3,234 +3,290 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-const storageGetCallbacks = {};
+let mockStorage;
+let mockTabs;
 
-// Set up DOM elements before importing popup.js
-document.body.innerHTML = `
-  <input type="checkbox" id="enabled" />
-  <span id="status"></span>
-  <input type="checkbox" id="screenshot-enabled" checked />
-  <span id="screenshot-status">Screenshot mode</span>
-  <input type="checkbox" id="autosuggest-enabled" />
-  <span id="autosuggest-status" title="Works in standard text fields (textarea). Gmail, Docs, and Notion support coming soon.">Auto-suggest</span>
-  <div id="theme-segment">
-    <button class="theme-option active" data-theme="auto">Auto</button>
-    <button class="theme-option" data-theme="light">Light</button>
-    <button class="theme-option" data-theme="dark">Dark</button>
-  </div>
-  <a id="settings" href="#">Settings</a>
-`;
+function currentUtcDay() {
+  return new Date().toISOString().split('T')[0];
+}
 
-global.chrome = {
-  storage: {
-    local: {
-      get: vi.fn((key, cb) => { storageGetCallbacks[key] = cb; }),
-      set: vi.fn(),
+function setupDom() {
+  document.body.innerHTML = `
+    <div id="version"></div>
+    <div id="usage-card" class="usage-card">
+      <div id="usage-primary"></div>
+      <div id="usage-secondary"></div>
+    </div>
+    <input type="checkbox" id="enabled" />
+    <span id="status"></span>
+    <input type="checkbox" id="screenshot-enabled" checked />
+    <span id="screenshot-status"></span>
+    <input type="checkbox" id="autosuggest-enabled" />
+    <span id="autosuggest-status"></span>
+    <button id="history">History</button>
+    <button id="clear-history">Clear</button>
+    <button id="settings">Settings</button>
+    <div id="action-feedback"></div>
+    <div id="theme-segment">
+      <button class="theme-option active" data-theme="auto">Auto</button>
+      <button class="theme-option" data-theme="light">Light</button>
+      <button class="theme-option" data-theme="dark">Dark</button>
+    </div>
+  `;
+}
+
+function getStorageResult(keys) {
+  if (Array.isArray(keys)) {
+    return keys.reduce((acc, key) => {
+      if (Object.prototype.hasOwnProperty.call(mockStorage, key)) acc[key] = mockStorage[key];
+      return acc;
+    }, {});
+  }
+  if (typeof keys === 'string') {
+    return Object.prototype.hasOwnProperty.call(mockStorage, keys) ? { [keys]: mockStorage[keys] } : {};
+  }
+  return {};
+}
+
+async function loadPopup(initialStorage = {}) {
+  vi.resetModules();
+  setupDom();
+  mockStorage = { ...initialStorage };
+  mockTabs = [];
+
+  global.chrome = {
+    storage: {
+      local: {
+        get: vi.fn((keys, cb) => cb(getStorageResult(keys))),
+        set: vi.fn((data, cb) => {
+          Object.assign(mockStorage, data);
+          if (cb) cb();
+        }),
+      },
     },
-  },
-  tabs: {
-    query: vi.fn((q, cb) => cb([])),
-    sendMessage: vi.fn(() => Promise.resolve()),
-  },
-  runtime: {
-    openOptionsPage: vi.fn(),
-  },
-};
+    tabs: {
+      query: vi.fn((query, cb) => cb(mockTabs)),
+      sendMessage: vi.fn(() => Promise.resolve()),
+    },
+    runtime: {
+      getManifest: vi.fn(() => ({ version: '1.1.0' })),
+      openOptionsPage: vi.fn(),
+    },
+  };
 
-await import('../src/popup.js');
-
-const toggle = document.getElementById('enabled');
-const status = document.getElementById('status');
-const settingsLink = document.getElementById('settings');
+  await import('../src/popup.js');
+}
 
 describe('popup.js', () => {
+  beforeEach(async () => {
+    await loadPopup();
+  });
+
   describe('initial state', () => {
-    it('loads enabled state from storage (default enabled)', () => {
-      // Trigger the storage callback with empty data (default = enabled)
-      storageGetCallbacks['dobbyEnabled']({});
-      expect(toggle.checked).toBe(true);
-      expect(status.textContent).toBe('Enabled');
+    it('renders the manifest version', () => {
+      expect(document.getElementById('version').textContent).toBe('v1.1.0');
     });
 
-    it('loads disabled state from storage when explicitly disabled', () => {
-      storageGetCallbacks['dobbyEnabled']({ dobbyEnabled: false });
-      expect(toggle.checked).toBe(false);
-      expect(status.textContent).toBe('Disabled');
+    it('loads default toggle states', () => {
+      expect(document.getElementById('enabled').checked).toBe(true);
+      expect(document.getElementById('status').textContent).toBe('On');
+      expect(document.getElementById('screenshot-enabled').checked).toBe(true);
+      expect(document.getElementById('screenshot-status').textContent).toBe('On');
+      expect(document.getElementById('autosuggest-enabled').checked).toBe(false);
+      expect(document.getElementById('autosuggest-status').textContent).toBe('Off');
     });
 
-    it('loads enabled state from storage when explicitly enabled', () => {
-      storageGetCallbacks['dobbyEnabled']({ dobbyEnabled: true });
-      expect(toggle.checked).toBe(true);
-      expect(status.textContent).toBe('Enabled');
+    it('loads explicit disabled/enabled settings from storage', async () => {
+      await loadPopup({
+        dobbyEnabled: false,
+        screenshotEnabled: false,
+        autosuggestEnabled: true,
+      });
+
+      expect(document.getElementById('enabled').checked).toBe(false);
+      expect(document.getElementById('status').textContent).toBe('Off');
+      expect(document.getElementById('screenshot-enabled').checked).toBe(false);
+      expect(document.getElementById('screenshot-status').textContent).toBe('Off');
+      expect(document.getElementById('autosuggest-enabled').checked).toBe(true);
+      expect(document.getElementById('autosuggest-status').textContent).toBe('On');
     });
   });
 
-  describe('toggle change', () => {
+  describe('usage status', () => {
+    it('shows default free-tier message before quota is synced', () => {
+      expect(document.getElementById('usage-primary').textContent).toBe('30 free questions/day');
+      expect(document.getElementById('usage-secondary').textContent).toContain('Ask once to sync');
+    });
+
+    it('shows remaining free quota and local counters', async () => {
+      await loadPopup({
+        dobbyUsage: {
+          day: currentUtcDay(),
+          freeChatRemaining: 18,
+          chatRequests: 12,
+          autosuggestRequests: 7,
+          screenshotRequests: 2,
+        },
+      });
+
+      expect(document.getElementById('usage-primary').textContent).toBe('18/30 free left');
+      expect(document.getElementById('usage-secondary').textContent).toContain('12 chats, 7 suggestions, 2 screenshots');
+      expect(document.getElementById('usage-card').classList.contains('ok')).toBe(true);
+    });
+
+    it('warns when free quota is low', async () => {
+      await loadPopup({
+        dobbyUsage: {
+          day: currentUtcDay(),
+          freeChatRemaining: 4,
+          chatRequests: 26,
+        },
+      });
+
+      expect(document.getElementById('usage-primary').textContent).toBe('4/30 free left');
+      expect(document.getElementById('usage-card').classList.contains('warning')).toBe(true);
+    });
+
+    it('shows limit reached when free quota is exhausted', async () => {
+      await loadPopup({
+        dobbyUsage: {
+          day: currentUtcDay(),
+          freeChatRemaining: 0,
+          chatRequests: 30,
+        },
+      });
+
+      expect(document.getElementById('usage-primary').textContent).toBe('Free quota used');
+      expect(document.getElementById('usage-card').classList.contains('danger')).toBe(true);
+    });
+
+    it('shows API key status when a key is configured', async () => {
+      await loadPopup({
+        userApiKey: 'sk-user',
+        dobbyUsage: {
+          day: currentUtcDay(),
+          chatRequests: 3,
+          autosuggestRequests: 2,
+          screenshotRequests: 1,
+        },
+      });
+
+      expect(document.getElementById('usage-primary').textContent).toBe('Using your API key');
+      expect(document.getElementById('usage-secondary').textContent).toContain('3 chats, 2 suggestions, 1 screenshots');
+    });
+
+    it('ignores stale usage from previous UTC days', async () => {
+      await loadPopup({
+        dobbyUsage: {
+          day: '2000-01-01',
+          freeChatRemaining: 1,
+          chatRequests: 29,
+        },
+      });
+
+      expect(document.getElementById('usage-primary').textContent).toBe('30 free questions/day');
+    });
+  });
+
+  describe('toggle changes', () => {
     beforeEach(() => {
       vi.clearAllMocks();
-      // Re-mock tabs.query so it provides tabs
-      chrome.tabs.query.mockImplementation((q, cb) => cb([]));
-      chrome.tabs.sendMessage.mockReturnValue(Promise.resolve());
+      mockTabs = [{ id: 1 }, { id: 2 }];
     });
 
-    it('updates status text to Disabled when unchecked', () => {
-      toggle.checked = false;
-      toggle.dispatchEvent(new Event('change'));
-      expect(status.textContent).toBe('Disabled');
-    });
+    it('persists and broadcasts Dobby enabled state', () => {
+      const input = document.getElementById('enabled');
+      input.checked = false;
+      input.dispatchEvent(new Event('change'));
 
-    it('updates status text to Enabled when checked', () => {
-      toggle.checked = true;
-      toggle.dispatchEvent(new Event('change'));
-      expect(status.textContent).toBe('Enabled');
-    });
-
-    it('calls chrome.storage.local.set with correct value', () => {
-      toggle.checked = true;
-      toggle.dispatchEvent(new Event('change'));
-      expect(chrome.storage.local.set).toHaveBeenCalledWith({ dobbyEnabled: true });
-
-      toggle.checked = false;
-      toggle.dispatchEvent(new Event('change'));
       expect(chrome.storage.local.set).toHaveBeenCalledWith({ dobbyEnabled: false });
+      expect(document.getElementById('status').textContent).toBe('Off');
+      expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(1, { type: 'DOBBY_TOGGLE', enabled: false });
+      expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(2, { type: 'DOBBY_TOGGLE', enabled: false });
     });
 
-    it('broadcasts DOBBY_TOGGLE message to all http/https tabs', () => {
-      const mockTabs = [{ id: 1 }, { id: 2 }];
-      chrome.tabs.query.mockImplementation((q, cb) => cb(mockTabs));
+    it('persists and broadcasts screenshot state', () => {
+      const input = document.getElementById('screenshot-enabled');
+      input.checked = false;
+      input.dispatchEvent(new Event('change'));
 
-      toggle.checked = true;
-      toggle.dispatchEvent(new Event('change'));
+      expect(chrome.storage.local.set).toHaveBeenCalledWith({ screenshotEnabled: false });
+      expect(document.getElementById('screenshot-status').textContent).toBe('Off');
+      expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(1, { type: 'SCREENSHOT_TOGGLE', enabled: false });
+    });
 
-      expect(chrome.tabs.query).toHaveBeenCalledWith(
-        { url: ['http://*/*', 'https://*/*'] },
-        expect.any(Function),
-      );
-      expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(1, { type: 'DOBBY_TOGGLE', enabled: true });
-      expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(2, { type: 'DOBBY_TOGGLE', enabled: true });
+    it('persists and broadcasts autosuggest state', () => {
+      const input = document.getElementById('autosuggest-enabled');
+      input.checked = true;
+      input.dispatchEvent(new Event('change'));
+
+      expect(chrome.storage.local.set).toHaveBeenCalledWith({ autosuggestEnabled: true });
+      expect(document.getElementById('autosuggest-status').textContent).toBe('On');
+      expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(1, { type: 'AUTOSUGGEST_TOGGLE', enabled: true });
     });
   });
 
-  describe('settings link', () => {
-    beforeEach(() => {
-      vi.clearAllMocks();
-    });
-
-    it('opens options page when clicked', () => {
-      settingsLink.click();
+  describe('quick actions', () => {
+    it('opens options page from Settings', () => {
+      document.getElementById('settings').click();
       expect(chrome.runtime.openOptionsPage).toHaveBeenCalled();
     });
-  });
 
-  describe('screenshot mode toggle', () => {
-    it('renders screenshot toggle', () => {
-      const toggle = document.getElementById('screenshot-enabled');
-      expect(toggle).not.toBeNull();
-      expect(toggle.type).toBe('checkbox');
+    it('disables history actions when there is no history', () => {
+      expect(document.getElementById('history').disabled).toBe(true);
+      expect(document.getElementById('clear-history').disabled).toBe(true);
     });
 
-    it('defaults to enabled', () => {
-      storageGetCallbacks['screenshotEnabled']({});
-      const toggle = document.getElementById('screenshot-enabled');
-      expect(toggle.checked).toBe(true);
+    it('opens history on the active tab when history exists', async () => {
+      await loadPopup({ chatHistory: [{ id: '1', text: 'hello' }] });
+      mockTabs = [{ id: 7 }];
+
+      document.getElementById('history').click();
+
+      expect(chrome.tabs.query).toHaveBeenCalledWith(
+        { active: true, currentWindow: true },
+        expect.any(Function),
+      );
+      expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(7, { type: 'SHOW_HISTORY' });
+      await vi.waitFor(() => {
+        expect(document.getElementById('action-feedback').textContent).toBe('History opened on this page.');
+      });
     });
 
-    it('persists toggle state to chrome.storage', () => {
-      vi.clearAllMocks();
-      chrome.tabs.query.mockImplementation((q, cb) => cb([]));
-      const toggle = document.getElementById('screenshot-enabled');
-      toggle.checked = false;
-      toggle.dispatchEvent(new Event('change'));
-      expect(chrome.storage.local.set).toHaveBeenCalledWith({ screenshotEnabled: false });
+    it('shows feedback when history cannot open on the active tab', async () => {
+      await loadPopup({ chatHistory: [{ id: '1', text: 'hello' }] });
+      mockTabs = [];
+
+      document.getElementById('history').click();
+
+      expect(document.getElementById('action-feedback').textContent).toBe('Open a regular webpage to show history.');
     });
 
-    it('notifies content scripts on toggle', () => {
-      vi.clearAllMocks();
-      chrome.tabs.query.mockImplementation((q, cb) => cb([{ id: 1 }]));
-      chrome.tabs.sendMessage.mockReturnValue(Promise.resolve());
-      const toggle = document.getElementById('screenshot-enabled');
-      toggle.checked = false;
-      toggle.dispatchEvent(new Event('change'));
-      expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(1, { type: 'SCREENSHOT_TOGGLE', enabled: false });
+    it('clears chat history from storage', async () => {
+      await loadPopup({ chatHistory: [{ id: '1', text: 'hello' }] });
+
+      document.getElementById('clear-history').click();
+
+      expect(chrome.storage.local.set).toHaveBeenCalledWith({ chatHistory: [] }, expect.any(Function));
+      expect(mockStorage.chatHistory).toEqual([]);
+      expect(document.getElementById('history').disabled).toBe(true);
+      expect(document.getElementById('action-feedback').textContent).toBe('History cleared.');
     });
   });
 
   describe('theme toggle', () => {
-    it('renders three theme option buttons', () => {
-      const options = document.querySelectorAll('.theme-option');
-      expect(options.length).toBe(3);
-      expect(options[0].dataset.theme).toBe('auto');
-      expect(options[1].dataset.theme).toBe('light');
-      expect(options[2].dataset.theme).toBe('dark');
-    });
-
-    it('defaults to Auto active when theme absent from storage', () => {
-      storageGetCallbacks['theme']({});
-      const options = document.querySelectorAll('.theme-option');
-      expect(options[0].classList.contains('active')).toBe(true);
-      expect(options[1].classList.contains('active')).toBe(false);
-      expect(options[2].classList.contains('active')).toBe(false);
-    });
-
-    it('loads light theme from storage and activates Light button', () => {
-      storageGetCallbacks['theme']({ theme: 'light' });
+    it('loads light theme from storage and activates Light button', async () => {
+      await loadPopup({ theme: 'light' });
       const options = document.querySelectorAll('.theme-option');
       expect(options[0].classList.contains('active')).toBe(false);
       expect(options[1].classList.contains('active')).toBe(true);
       expect(options[2].classList.contains('active')).toBe(false);
-    });
-
-    it('loads dark theme from storage and activates Dark button', () => {
-      storageGetCallbacks['theme']({ theme: 'dark' });
-      const options = document.querySelectorAll('.theme-option');
-      expect(options[0].classList.contains('active')).toBe(false);
-      expect(options[1].classList.contains('active')).toBe(false);
-      expect(options[2].classList.contains('active')).toBe(true);
     });
 
     it('persists theme to chrome.storage on click', () => {
       vi.clearAllMocks();
-      const darkBtn = document.querySelector('.theme-option[data-theme="dark"]');
-      darkBtn.click();
+      document.querySelector('.theme-option[data-theme="dark"]').click();
       expect(chrome.storage.local.set).toHaveBeenCalledWith({ theme: 'dark' });
-    });
-
-    it('updates active class on click', () => {
-      const lightBtn = document.querySelector('.theme-option[data-theme="light"]');
-      lightBtn.click();
-      const options = document.querySelectorAll('.theme-option');
-      expect(options[1].classList.contains('active')).toBe(true);
-      expect(options[0].classList.contains('active')).toBe(false);
-      expect(options[2].classList.contains('active')).toBe(false);
-    });
-  });
-
-  describe('autosuggest toggle', () => {
-    it('renders autosuggest toggle', () => {
-      const toggle = document.getElementById('autosuggest-enabled');
-      expect(toggle).not.toBeNull();
-      expect(toggle.type).toBe('checkbox');
-    });
-
-    it('defaults to disabled', () => {
-      chrome.storage.local.get.mockImplementation((key, cb) => cb({}));
-      const toggle = document.getElementById('autosuggest-enabled');
-      expect(toggle.checked).toBe(false);
-    });
-
-    it('persists toggle state to chrome.storage', () => {
-      const toggle = document.getElementById('autosuggest-enabled');
-      toggle.checked = true;
-      toggle.dispatchEvent(new Event('change'));
-      expect(chrome.storage.local.set).toHaveBeenCalledWith({ autosuggestEnabled: true });
-    });
-
-    it('notifies content scripts on toggle', () => {
-      chrome.tabs.query.mockImplementation((q, cb) => cb([{ id: 1 }]));
-      const toggle = document.getElementById('autosuggest-enabled');
-      toggle.checked = true;
-      toggle.dispatchEvent(new Event('change'));
-      expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(1, { type: 'AUTOSUGGEST_TOGGLE', enabled: true });
     });
   });
 });


### PR DESCRIPTION
## What changed

- Redesigned the extension icon popup around quick status and controls.
- Added free quota/API-key status, low-quota warning styling, local usage counters, and reset-time copy.
- Added quick actions for opening history on the active page, clearing chat history, and opening settings.
- Made all popup toggles show consistent on/off state and clearer labels.
- Records local daily usage for chat, autosuggest, and screenshot captures.
- Reads extension version dynamically in popup/options and fixes the stale settings-page version.
- Adds a content-script `SHOW_HISTORY` path so the popup history action can open the existing history panel.
- Guards delayed toolbar cleanup after jsdom/browser teardown.

Closes #145

## Validation

- `npm run build`
- `npm test`
- `npm test --prefix proxy`
- `npm audit --audit-level=moderate`
- `npm audit --audit-level=moderate --prefix proxy`
- Manual Chrome validation against a local popup harness served from `127.0.0.1`, covering low quota, history open feedback, clear history, and API-key mode.

## Screenshots / GIF

![Popup demo](https://raw.githubusercontent.com/Duobi-AI/dobby-ai/docs/pr-demo-gifs/pr-145-popup/popup-demo.gif)

- [Low quota state](https://raw.githubusercontent.com/Duobi-AI/dobby-ai/docs/pr-demo-gifs/pr-145-popup/popup-low-quota.jpg)
- [History action feedback](https://raw.githubusercontent.com/Duobi-AI/dobby-ai/docs/pr-demo-gifs/pr-145-popup/popup-history-action.jpg)
- [Clear history action](https://raw.githubusercontent.com/Duobi-AI/dobby-ai/docs/pr-demo-gifs/pr-145-popup/popup-clear-action.jpg)
- [API key state](https://raw.githubusercontent.com/Duobi-AI/dobby-ai/docs/pr-demo-gifs/pr-145-popup/popup-api-key.jpg)
