### PR TITLE
release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to Dobby AI (formerly Ask AI) will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-05-26
+
+### Added
+- Popup usage monitor with API status, request/token totals, and quick actions for history, clearing usage, and settings
+- Keyboard shortcuts for toggling Dobby AI and screenshot mode
+- Per-message copy button for AI responses
+- Popup controls for theme, screenshot mode, and auto-suggest behavior
+
+### Changed
+- Hardened CI/CD workflows and refreshed release documentation
+
+### Fixed
+- Dependency advisories in extension and proxy lockfiles
+- Auto-suggest initialization and token-limit handling
+- Selected image handling, prompt budgeting, and null image capture inputs
+
 ## [2.1.0] - 2026-03-11
 
 ### Changed
@@ -78,7 +94,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Page context injection (title + URL)
 - CI/CD workflows (tests, coverage, security, release, PR preview, permission guard)
 
-[2.1.0]: https://github.com/zhongnansu/dobby-ai/compare/v2.0.0...v2.1.0
-[2.0.0]: https://github.com/zhongnansu/dobby-ai/compare/v1.1.0...v2.0.0
-[1.1.0]: https://github.com/zhongnansu/dobby-ai/compare/v1.0.0...v1.1.0
-[1.0.0]: https://github.com/zhongnansu/dobby-ai/releases/tag/v1.0.0
+[1.2.0]: https://github.com/Duobi-AI/dobby-ai/compare/v1.1.0...v1.2.0
+[2.1.0]: https://github.com/Duobi-AI/dobby-ai/compare/v2.0.0...v2.1.0
+[2.0.0]: https://github.com/Duobi-AI/dobby-ai/compare/v1.1.0...v2.0.0
+[1.1.0]: https://github.com/Duobi-AI/dobby-ai/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/Duobi-AI/dobby-ai/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/Duobi-AI/dobby-ai/actions/workflows/ci.yml"><img src="https://github.com/Duobi-AI/dobby-ai/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://github.com/Duobi-AI/dobby-ai/actions/workflows/security.yml"><img src="https://github.com/Duobi-AI/dobby-ai/actions/workflows/security.yml/badge.svg" alt="Security"></a>
   <a href="https://github.com/Duobi-AI/dobby-ai/actions/workflows/coverage.yml"><img src="https://github.com/Duobi-AI/dobby-ai/actions/workflows/coverage.yml/badge.svg" alt="Coverage"></a>
-  <img src="https://img.shields.io/badge/version-1.1.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-1.2.0-blue" alt="Version">
   <img src="https://img.shields.io/badge/manifest-v3-green" alt="Manifest V3">
   <a href="https://github.com/Duobi-AI/dobby-ai/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-yellow" alt="License"></a>
   <a href="https://chromewebstore.google.com/detail/fobblgpebpnelefaneijkpbcljdlofoo?utm_source=item-share-cb"><img src="https://img.shields.io/badge/chrome-web%20store-orange?logo=googlechrome&logoColor=white" alt="Chrome Web Store"></a>

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dobby AI",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Select text and get instant AI explanations inline on any page",
   "permissions": ["contextMenus", "activeTab", "storage", "notifications"],
   "host_permissions": [

--- a/options.html
+++ b/options.html
@@ -147,7 +147,7 @@
       <img src="icons/icon48.png" alt="Dobby AI">
       <div>
         <h1>Dobby AI</h1>
-        <div class="version" id="extension-version">v1.1.0</div>
+        <div class="version" id="extension-version">v1.2.0</div>
       </div>
     </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dobby-ai",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dobby-ai",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "devDependencies": {
         "@playwright/test": "^1.58.2",
         "@vitest/coverage-v8": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dobby-ai",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "description": "Select text or screenshot any region on the web — get instant AI answers right where you are",
   "scripts": {

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -69,7 +69,7 @@ async function loadPopup(initialStorage = {}) {
       sendMessage: vi.fn(() => Promise.resolve()),
     },
     runtime: {
-      getManifest: vi.fn(() => ({ version: '1.1.0' })),
+      getManifest: vi.fn(() => ({ version: '1.2.0' })),
       openOptionsPage: vi.fn(),
     },
   };
@@ -84,7 +84,7 @@ describe('popup.js', () => {
 
   describe('initial state', () => {
     it('renders the manifest version', () => {
-      expect(document.getElementById('version').textContent).toBe('v1.1.0');
+      expect(document.getElementById('version').textContent).toBe('v1.2.0');
     });
 
     it('loads default toggle states', () => {


### PR DESCRIPTION
## Summary
- bump extension release metadata to 1.2.0
- update visible version text, README badge, popup version test, and changelog

## Validation
- npm run build
- npm test
- npm test --prefix proxy
- npm audit --audit-level=moderate
- npm audit --audit-level=moderate --prefix proxy
- npm run test:e2e