### PR TITLE
Release v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to Dobby AI (formerly Ask AI) will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2026-05-27
+
+### Changed
+- Replaced legacy logo assets with the approved centered Dobby AI cockapoo logo across the extension, docs, screenshots, and generated icon sizes
+
 ## [1.2.0] - 2026-05-26
 
 ### Added
@@ -94,6 +99,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Page context injection (title + URL)
 - CI/CD workflows (tests, coverage, security, release, PR preview, permission guard)
 
+[1.2.1]: https://github.com/Duobi-AI/dobby-ai/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/Duobi-AI/dobby-ai/compare/v1.1.0...v1.2.0
 [2.1.0]: https://github.com/Duobi-AI/dobby-ai/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/Duobi-AI/dobby-ai/compare/v1.1.0...v2.0.0

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/Duobi-AI/dobby-ai/actions/workflows/ci.yml"><img src="https://github.com/Duobi-AI/dobby-ai/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://github.com/Duobi-AI/dobby-ai/actions/workflows/security.yml"><img src="https://github.com/Duobi-AI/dobby-ai/actions/workflows/security.yml/badge.svg" alt="Security"></a>
   <a href="https://github.com/Duobi-AI/dobby-ai/actions/workflows/coverage.yml"><img src="https://github.com/Duobi-AI/dobby-ai/actions/workflows/coverage.yml/badge.svg" alt="Coverage"></a>
-  <img src="https://img.shields.io/badge/version-1.2.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-1.2.1-blue" alt="Version">
   <img src="https://img.shields.io/badge/manifest-v3-green" alt="Manifest V3">
   <a href="https://github.com/Duobi-AI/dobby-ai/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-yellow" alt="License"></a>
   <a href="https://chromewebstore.google.com/detail/fobblgpebpnelefaneijkpbcljdlofoo?utm_source=item-share-cb"><img src="https://img.shields.io/badge/chrome-web%20store-orange?logo=googlechrome&logoColor=white" alt="Chrome Web Store"></a>

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dobby AI",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Select text and get instant AI explanations inline on any page",
   "permissions": ["contextMenus", "activeTab", "storage", "notifications"],
   "host_permissions": [

--- a/options.html
+++ b/options.html
@@ -147,7 +147,7 @@
       <img src="icons/store-icon.png" alt="Dobby AI">
       <div>
         <h1>Dobby AI</h1>
-        <div class="version" id="extension-version">v1.2.0</div>
+        <div class="version" id="extension-version">v1.2.1</div>
       </div>
     </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dobby-ai",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dobby-ai",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "devDependencies": {
         "@playwright/test": "^1.58.2",
         "@vitest/coverage-v8": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dobby-ai",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "description": "Select text or screenshot any region on the web — get instant AI answers right where you are",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bump Dobby AI from 1.2.0 to 1.2.1 in manifest, package metadata, lockfile, README badge, and options page.
- Add changelog entry for the centered approved logo patch.

## Validation
- npm run build
- npm test (598 tests)

## Release
After merge, tag `v1.2.1` to trigger the release workflow.
