### PR TITLE
fix(proxy): atomic Durable Object rate limiting

### DIFF
--- a/proxy/src/index.js
+++ b/proxy/src/index.js
@@ -1,8 +1,23 @@
 // proxy/src/index.js
 import { validatePayload, verifyHmac } from './validate.js';
-import { checkRateLimit, incrementCounters } from './rate-limit.js';
 import { createChatStream } from './openai.js';
 import { AUTOSUGGEST_MAX_SUGGESTION_TOKENS } from '../../src/shared/autosuggest-limits.js';
+
+export { RateLimiter } from './rate-limit-do.js';
+
+// Routes an atomic check-and-increment through the per-IP RateLimiter Durable Object.
+// All rate-limit reads and writes happen inside the DO so they are strongly
+// consistent and serialized (no read-then-write race across concurrent requests).
+async function checkRateLimitDO(env, ip, purpose) {
+  const id = env.RATE_LIMITER.idFromName(ip);
+  const stub = env.RATE_LIMITER.get(id);
+  const res = await stub.fetch('https://rate-limiter/check', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ip, purpose }),
+  });
+  return res.json();
+}
 
 const MAX_BODY_SIZE = 2097152; // 2MB
 
@@ -86,7 +101,7 @@ export default {
       && request.headers.get('X-Dev-Token') === env.DEV_BYPASS_TOKEN;
     const rateResult = devBypass
       ? { allowed: true, remaining: null }
-      : await checkRateLimit(ip, env.RATE_LIMIT_KV, purpose);
+      : await checkRateLimitDO(env, ip, purpose);
     if (!rateResult.allowed) {
       return jsonResponse(
         { error: rateResult.reason, remaining: rateResult.remaining ?? 0 },
@@ -95,8 +110,6 @@ export default {
         { 'Retry-After': String(rateResult.retryAfter || 60) }
       );
     }
-
-    if (!devBypass) await incrementCounters(ip, env.RATE_LIMIT_KV, purpose);
 
     const maxTokens = purpose === 'autosuggest' ? AUTOSUGGEST_MAX_SUGGESTION_TOKENS : undefined;
     const openaiResponse = await createChatStream(body.messages, env.OPENAI_API_KEY, undefined, maxTokens);

--- a/proxy/src/rate-limit-do.js
+++ b/proxy/src/rate-limit-do.js
@@ -1,0 +1,181 @@
+// proxy/src/rate-limit-do.js
+import { checkRateLimit, incrementCounters, LIMITS } from './rate-limit.js';
+
+// Wraps Durable Object transactional storage as a get/put/delete store compatible
+// with the interface rate-limit.js expects. DO storage has no TTL support, so the
+// `opts` argument (expirationTtl) is accepted but ignored — stale bucket keys are
+// pruned explicitly by incrementCounters on every write (previous-window keys are
+// deleted), bounding storage to O(1) active keys per IP.
+function doStorage(storage) {
+  return {
+    get(key) {
+      return storage.get(key);
+    },
+    put(key, value, _opts) {
+      return storage.put(key, value);
+    },
+    delete(key) {
+      return storage.delete(key);
+    },
+  };
+}
+
+// RateLimiter is a single Durable Object class that serves two roles:
+//
+//   Per-IP instance  (idFromName("<ip>"))
+//     Holds per-minute, per-day, and burst counters for that IP.
+//     Calls the __global__ instance's /global/check-increment endpoint ONCE
+//     (after per-IP checks pass, before per-IP increment) so the global cap
+//     decision and increment are one serialized atomic operation — no TOCTOU
+//     gap between reading and writing the global counter.
+//
+//   Global instance  (idFromName("__global__"))
+//     Holds only the rl:global:<day> counter. The /global/check-increment
+//     endpoint performs read → check → conditional-increment inside ONE
+//     blockConcurrencyWhile call so concurrent per-IP DOs are serialized here
+//     and cannot both read 499 < 500 and both pass before either increments.
+//
+// Using one class for both roles avoids a second DO binding and keeps
+// wrangler.toml simple (one durable_objects entry, one migration).
+//
+// The Cloudflare runtime passes (state, env) to the constructor; env provides
+// env.RATE_LIMITER so per-IP instances can reach the __global__ sibling.
+export class RateLimiter {
+  constructor(state, env) {
+    this.state = state;
+    this.env = env;
+    this.storage = doStorage(state.storage);
+  }
+
+  // ── Global-counter endpoint (served by the __global__ instance) ─────────────
+  //
+  // Atomically checks and conditionally increments the global daily counter in
+  // ONE blockConcurrencyWhile callback. The read and the write happen inside the
+  // same serialized gate, so two concurrent callers cannot both observe count < cap
+  // and both increment — the TOCTOU that existed when check and increment were
+  // separate round-trips.
+  async _handleGlobalCheckIncrement(request) {
+    const { dayKey, prevDayKey } = await request.json();
+    const result = await this.state.blockConcurrencyWhile(async () => {
+      const count = parseInt(await this.storage.get(dayKey)) || 0;
+      if (count >= LIMITS.globalPerDay) {
+        return { allowed: false };
+      }
+      // Increment and prune previous-day key atomically with the decision.
+      await Promise.all([
+        this.storage.put(dayKey, String(count + 1), {}),
+        this.storage.delete(prevDayKey),
+      ]);
+      return { allowed: true };
+    });
+    return new Response(JSON.stringify(result), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // ── Helper used by per-IP instances to call the __global__ instance ──────────
+
+  _globalStub() {
+    if (!this.env || !this.env.RATE_LIMITER) return null;
+    return this.env.RATE_LIMITER.get(
+      this.env.RATE_LIMITER.idFromName('__global__')
+    );
+  }
+
+  // Calls the __global__ DO's single atomic check-increment endpoint.
+  // Returns { allowed: true } if the global cap has not been reached (and
+  // increments it), or { allowed: false } if the cap is exhausted.
+  //
+  // Fail-closed on any error: if the binding is absent or the DO call fails we
+  // deny the request rather than letting it through. This is the deliberate
+  // choice because the global counter is a cost backstop — failing open under
+  // an infra fault could allow unbounded spend.
+  async _globalCheckIncrement(dayKey, prevDayKey) {
+    const stub = this._globalStub();
+    if (!stub) {
+      // No binding available (e.g. misconfigured env) — fail closed.
+      return { allowed: false, missing: true };
+    }
+    let res;
+    try {
+      res = await stub.fetch(new Request('https://rate-limiter/global/check-increment', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ dayKey, prevDayKey }),
+      }));
+    } catch {
+      // Network/DO error — fail closed.
+      return { allowed: false, error: true };
+    }
+    if (!res.ok) {
+      // Non-2xx from __global__ DO — fail closed.
+      return { allowed: false, error: true };
+    }
+    try {
+      return await res.json();
+    } catch {
+      // Malformed/empty body — fail closed (keeps the fail-closed guarantee total).
+      return { allowed: false, error: true };
+    }
+  }
+
+  // ── Main dispatch ────────────────────────────────────────────────────────────
+
+  async fetch(request) {
+    const url = new URL(request.url);
+
+    // Global-counter sub-route (handled by the __global__ instance).
+    if (url.pathname === '/global/check-increment') {
+      return this._handleGlobalCheckIncrement(request);
+    }
+
+    // Per-IP rate-limit check+increment (handled by per-IP instances).
+    let payload;
+    try {
+      payload = await request.json();
+    } catch {
+      return new Response(JSON.stringify({ error: 'Invalid DO request' }), { status: 400 });
+    }
+
+    const { ip, purpose } = payload;
+    const today = new Date().toISOString().split('T')[0];
+    const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];
+    const globalKey = `rl:global:${today}`;
+    const prevGlobalKey = `rl:global:${yesterday}`;
+
+    // blockConcurrencyWhile serializes all concurrent requests to this per-IP
+    // instance so the read (checkRateLimit) and write (incrementCounters) cannot
+    // race — fixing the eventual-consistency issue that existed with KV.
+    const result = await this.state.blockConcurrencyWhile(async () => {
+      // 1. Check per-IP limits (minute/day/burst) against this instance's storage.
+      //    Pass this.storage as globalStore too so checkRateLimit does not read the
+      //    global key locally — global cap enforcement is delegated to __global__.
+      const perIpResult = await checkRateLimit(
+        ip, this.storage, purpose, this.storage
+      );
+      if (!perIpResult.allowed) return perIpResult;
+
+      // 2. Atomically check-and-increment the service-wide global daily cap via
+      //    the __global__ DO. This is ONE round-trip: decision + mutation happen
+      //    inside a single blockConcurrencyWhile on __global__, so concurrent
+      //    per-IP DOs cannot both read below-cap and both increment past it.
+      const globalResult = await this._globalCheckIncrement(globalKey, prevGlobalKey);
+      if (!globalResult.allowed) {
+        return { allowed: false, reason: 'Service busy, try later', retryAfter: 3600 };
+      }
+
+      // 3. Global cap passed and has been incremented. Now increment per-IP
+      //    counters. Order matters: global increment first so a denial here never
+      //    leaves the global counter inflated without a corresponding per-IP write
+      //    (the global counter is a cost backstop; slight over-caution is correct).
+      await incrementCounters(ip, this.storage, purpose, this.storage);
+
+      return perIpResult;
+    });
+
+    return new Response(JSON.stringify(result), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}

--- a/proxy/src/rate-limit.js
+++ b/proxy/src/rate-limit.js
@@ -2,7 +2,9 @@
 const LIMITS = {
   perMinute: 5,
   perDay: 30,
-  globalPerDay: 5000,
+  // Lowered from 5000 to 500 as a cost backstop. NOTE: the real cost backstop is
+  // an upstream OpenAI account hard spend cap (an external dashboard setting, out of code scope).
+  globalPerDay: 500,
 };
 
 const AUTOSUGGEST_LIMITS = {
@@ -18,6 +20,11 @@ function dayBucket() {
   return new Date().toISOString().split('T')[0];
 }
 
+function prevDayBucket() {
+  const d = new Date(Date.now() - 86400000);
+  return d.toISOString().split('T')[0];
+}
+
 function tenSecBucket() {
   return Math.floor(Date.now() / 10000);
 }
@@ -26,9 +33,15 @@ function keyPrefix(purpose) {
   return purpose === 'autosuggest' ? 'as' : 'rl';
 }
 
-export async function checkRateLimit(ip, kv, purpose = 'chat') {
+function toCount(v) {
+  return parseInt(v) || 0;
+}
+
+// checkRateLimit reads per-IP counters from `store` and the global daily counter
+// from `globalStore` (falls back to `store` when not provided, e.g. KV tests).
+export async function checkRateLimit(ip, store, purpose = 'chat', globalStore = store) {
   // Check block list first (shared across both purposes)
-  const blocked = await kv.get(`blocked:${ip}`);
+  const blocked = await store.get(`blocked:${ip}`);
   if (blocked) {
     return { allowed: false, reason: 'IP blocked for abuse', retryAfter: 3600 };
   }
@@ -41,9 +54,9 @@ export async function checkRateLimit(ip, kv, purpose = 'chat') {
   const globalKey = `rl:global:${dayBucket()}`;
 
   const [minCount, dayCount, globalCount] = await Promise.all([
-    kv.get(minKey).then((v) => parseInt(v) || 0),
-    kv.get(dayKey).then((v) => parseInt(v) || 0),
-    kv.get(globalKey).then((v) => parseInt(v) || 0),
+    store.get(minKey).then(toCount),
+    store.get(dayKey).then(toCount),
+    globalStore.get(globalKey).then(toCount),
   ]);
 
   if (minCount >= limits.perMinute) {
@@ -61,33 +74,66 @@ export async function checkRateLimit(ip, kv, purpose = 'chat') {
   return { allowed: true, remaining: limits.perDay - dayCount - 1 };
 }
 
-export async function incrementCounters(ip, kv, purpose = 'chat') {
+// incrementCounters writes per-IP counters to `store` and the global daily counter
+// to `globalStore` (falls back to `store` when not provided, e.g. KV tests).
+// Each write also deletes the previous window's key to prevent unbounded storage growth.
+export async function incrementCounters(ip, store, purpose = 'chat', globalStore = store) {
   const prefix = keyPrefix(purpose);
 
-  const minKey = `${prefix}:min:${ip}:${minuteBucket()}`;
-  const dayKey = `${prefix}:day:${ip}:${dayBucket()}`;
-  const globalKey = `rl:global:${dayBucket()}`;
-  const burstKey = `rl:10s:${ip}:${tenSecBucket()}`;
+  const minBucket = minuteBucket();
+  const day = dayBucket();
+  const tenSecB = tenSecBucket();
+
+  const minKey = `${prefix}:min:${ip}:${minBucket}`;
+  const dayKey = `${prefix}:day:${ip}:${day}`;
+  const globalKey = `rl:global:${day}`;
+  const burstKey = `rl:10s:${ip}:${tenSecB}`;
+
+  // Previous-window keys for pruning stale buckets (bounds storage growth per IP to O(1))
+  const prevMinKey = `${prefix}:min:${ip}:${minBucket - 1}`;
+  const prevDayKey = `${prefix}:day:${ip}:${prevDayBucket()}`;
+  const prevGlobalKey = `rl:global:${prevDayBucket()}`;
+  const prevBurstKey = `rl:10s:${ip}:${tenSecB - 1}`;
 
   const [minCount, dayCount, globalCount, burstCount] = await Promise.all([
-    kv.get(minKey).then((v) => parseInt(v) || 0),
-    kv.get(dayKey).then((v) => parseInt(v) || 0),
-    kv.get(globalKey).then((v) => parseInt(v) || 0),
-    kv.get(burstKey).then((v) => parseInt(v) || 0),
+    store.get(minKey).then(toCount),
+    store.get(dayKey).then(toCount),
+    globalStore.get(globalKey).then(toCount),
+    store.get(burstKey).then(toCount),
   ]);
 
-  // Note: KV is eventually consistent so counts are best-effort, which is acceptable for rate limiting
   const puts = [
-    kv.put(minKey, String(minCount + 1), { expirationTtl: 120 }),
-    kv.put(dayKey, String(dayCount + 1), { expirationTtl: 86400 }),
-    kv.put(globalKey, String(globalCount + 1), { expirationTtl: 86400 }),
-    kv.put(burstKey, String(burstCount + 1), { expirationTtl: 60 }),
+    store.put(minKey, String(minCount + 1), { expirationTtl: 120 }),
+    store.put(dayKey, String(dayCount + 1), { expirationTtl: 86400 }),
+    globalStore.put(globalKey, String(globalCount + 1), { expirationTtl: 86400 }),
+    store.put(burstKey, String(burstCount + 1), { expirationTtl: 60 }),
+    // Prune previous-window keys; errors are non-fatal (delete may no-op if absent)
+    store.delete(prevMinKey),
+    store.delete(prevDayKey),
+    globalStore.delete(prevGlobalKey),
+    store.delete(prevBurstKey),
   ];
 
   // Abuse detection: 10+ requests in 10 seconds → 1-hour block
   if (burstCount + 1 >= 10) {
-    puts.push(kv.put(`blocked:${ip}`, '1', { expirationTtl: 3600 }));
+    puts.push(store.put(`blocked:${ip}`, '1', { expirationTtl: 3600 }));
   }
 
   await Promise.all(puts);
 }
+
+// Atomic check-and-increment intended to run inside a Durable Object, where a
+// single-threaded execution model serializes reads and writes for a given IP.
+// `store` holds per-IP counters; `globalStore` holds the service-wide global daily
+// counter (a separate DO instance so the cap is truly cross-IP, not per-IP).
+// Only increments when the request is allowed — limit decision and increment cannot race.
+export async function checkAndIncrement(ip, store, purpose = 'chat', globalStore = store) {
+  const result = await checkRateLimit(ip, store, purpose, globalStore);
+  if (!result.allowed) {
+    return result;
+  }
+  await incrementCounters(ip, store, purpose, globalStore);
+  return result;
+}
+
+export { LIMITS, AUTOSUGGEST_LIMITS };

--- a/proxy/tests/index.test.js
+++ b/proxy/tests/index.test.js
@@ -8,11 +8,6 @@ vi.mock('../src/validate.js', () => ({
   verifyHmac: vi.fn(() => Promise.resolve(true)),
 }));
 
-vi.mock('../src/rate-limit.js', () => ({
-  checkRateLimit: vi.fn(() => Promise.resolve({ allowed: true, remaining: 29 })),
-  incrementCounters: vi.fn(() => Promise.resolve()),
-}));
-
 vi.mock('../src/openai.js', () => ({
   createChatStream: vi.fn(() =>
     Promise.resolve({
@@ -25,8 +20,31 @@ vi.mock('../src/openai.js', () => ({
 
 import handler from '../src/index.js';
 import { validatePayload, verifyHmac } from '../src/validate.js';
-import { checkRateLimit, incrementCounters } from '../src/rate-limit.js';
 import { createChatStream } from '../src/openai.js';
+
+// Result that the mock RateLimiter Durable Object stub will return for each request.
+let doRateResult = { allowed: true, remaining: 29 };
+// Records the payloads ({ ip, purpose }) the DO stub was asked to check.
+let doCalls = [];
+
+// Hand-rolled Durable Object namespace stub: idFromName(ip) -> stub, and the stub's
+// fetch() returns the configured doRateResult as a JSON Response, mirroring the real DO.
+function makeRateLimiterBinding() {
+  doCalls = [];
+  return {
+    idFromName: vi.fn((name) => ({ name })),
+    get: vi.fn((id) => ({
+      fetch: vi.fn(async (_url, init) => {
+        const body = JSON.parse(init.body);
+        doCalls.push(body);
+        return new Response(JSON.stringify(doRateResult), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }),
+    })),
+  };
+}
 
 function makeRequest(path, options = {}) {
   const url = `https://proxy.workers.dev${path}`;
@@ -43,7 +61,7 @@ function makeEnv(overrides = {}) {
     HMAC_SECRET: 'test-secret',
     ENABLED: 'true',
     ALLOWED_ORIGINS: 'chrome-extension://test-id,https://localhost',
-    RATE_LIMIT_KV: {},
+    RATE_LIMITER: makeRateLimiterBinding(),
     ...overrides,
   };
 }
@@ -105,8 +123,7 @@ describe('POST /chat', () => {
     vi.clearAllMocks();
     validatePayload.mockReturnValue({ valid: true });
     verifyHmac.mockResolvedValue(true);
-    checkRateLimit.mockResolvedValue({ allowed: true, remaining: 29 });
-    incrementCounters.mockResolvedValue();
+    doRateResult = { allowed: true, remaining: 29 };
     createChatStream.mockResolvedValue({ ok: true, status: 200, body: new ReadableStream() });
   });
 
@@ -133,7 +150,7 @@ describe('POST /chat', () => {
   });
 
   it('returns 429 when rate limited', async () => {
-    checkRateLimit.mockResolvedValue({ allowed: false, reason: 'Daily limit', remaining: 0 });
+    doRateResult = { allowed: false, reason: 'Daily limit', remaining: 0 };
     const req = makeRequest('/chat', {
       method: 'POST',
       body: { messages: [{ role: 'user', content: 'hi' }], signature: 'x', timestamp: 1 },
@@ -155,11 +172,11 @@ describe('POST /chat', () => {
     expect(res.status).toBe(200);
     expect(res.headers.get('Content-Type')).toBe('text/event-stream');
     expect(res.headers.get('Cache-Control')).toBe('no-cache');
-    expect(incrementCounters).toHaveBeenCalled();
+    expect(doCalls.length).toBe(1);
   });
 
   it('returns remaining count in X-RateLimit-Remaining header', async () => {
-    checkRateLimit.mockResolvedValue({ allowed: true, remaining: 15 });
+    doRateResult = { allowed: true, remaining: 15 };
     const req = makeRequest('/chat', {
       method: 'POST',
       body: { messages: [{ role: 'user', content: 'hi' }], signature: 'x', timestamp: 1 },
@@ -191,8 +208,7 @@ describe('POST /chat', () => {
       headers: { 'Content-Type': 'application/json' },
     });
     await handler.fetch(req, makeEnv());
-    expect(checkRateLimit).toHaveBeenCalledWith('1.2.3.4', expect.anything(), 'autosuggest');
-    expect(incrementCounters).toHaveBeenCalledWith('1.2.3.4', expect.anything(), 'autosuggest');
+    expect(doCalls).toEqual([{ ip: '1.2.3.4', purpose: 'autosuggest' }]);
   });
 
   it('defaults purpose to chat when not specified', async () => {
@@ -202,8 +218,7 @@ describe('POST /chat', () => {
       headers: { 'Content-Type': 'application/json' },
     });
     await handler.fetch(req, makeEnv());
-    expect(checkRateLimit).toHaveBeenCalledWith('1.2.3.4', expect.anything(), 'chat');
-    expect(incrementCounters).toHaveBeenCalledWith('1.2.3.4', expect.anything(), 'chat');
+    expect(doCalls).toEqual([{ ip: '1.2.3.4', purpose: 'chat' }]);
   });
 
   it('passes the shared autosuggest token limit to createChatStream for autosuggest', async () => {
@@ -263,8 +278,7 @@ describe('dev bypass token', () => {
     vi.clearAllMocks();
     validatePayload.mockReturnValue({ valid: true });
     verifyHmac.mockResolvedValue(true);
-    checkRateLimit.mockResolvedValue({ allowed: true, remaining: 29 });
-    incrementCounters.mockResolvedValue();
+    doRateResult = { allowed: true, remaining: 29 };
     createChatStream.mockResolvedValue({ ok: true, status: 200, body: new ReadableStream() });
   });
 
@@ -274,10 +288,11 @@ describe('dev bypass token', () => {
       body: { messages: [{ role: 'user', content: 'hi' }], signature: 'x', timestamp: 1 },
       headers: { 'Content-Type': 'application/json', 'X-Dev-Token': 'my-secret-token' },
     });
-    const res = await handler.fetch(req, makeEnv({ DEV_BYPASS_TOKEN: 'my-secret-token' }));
+    const env = makeEnv({ DEV_BYPASS_TOKEN: 'my-secret-token' });
+    const res = await handler.fetch(req, env);
     expect(res.status).toBe(200);
-    expect(checkRateLimit).not.toHaveBeenCalled();
-    expect(incrementCounters).not.toHaveBeenCalled();
+    expect(env.RATE_LIMITER.idFromName).not.toHaveBeenCalled();
+    expect(doCalls.length).toBe(0);
   });
 
   it('applies rate limiting when X-Dev-Token does not match', async () => {
@@ -288,8 +303,7 @@ describe('dev bypass token', () => {
     });
     const res = await handler.fetch(req, makeEnv({ DEV_BYPASS_TOKEN: 'my-secret-token' }));
     expect(res.status).toBe(200);
-    expect(checkRateLimit).toHaveBeenCalled();
-    expect(incrementCounters).toHaveBeenCalled();
+    expect(doCalls.length).toBe(1);
   });
 
   it('applies rate limiting when DEV_BYPASS_TOKEN is not set', async () => {
@@ -300,7 +314,6 @@ describe('dev bypass token', () => {
     });
     const res = await handler.fetch(req, makeEnv());
     expect(res.status).toBe(200);
-    expect(checkRateLimit).toHaveBeenCalled();
-    expect(incrementCounters).toHaveBeenCalled();
+    expect(doCalls.length).toBe(1);
   });
 });

--- a/proxy/tests/rate-limit.test.js
+++ b/proxy/tests/rate-limit.test.js
@@ -1,6 +1,7 @@
 // proxy/tests/rate-limit.test.js
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { checkRateLimit, incrementCounters } from '../src/rate-limit.js';
+import { checkRateLimit, incrementCounters, checkAndIncrement } from '../src/rate-limit.js';
+import { RateLimiter } from '../src/rate-limit-do.js';
 
 function createMockKV(data = {}) {
   const store = { ...data };
@@ -8,6 +9,10 @@ function createMockKV(data = {}) {
     get: vi.fn((key) => Promise.resolve(store[key] || null)),
     put: vi.fn((key, value, opts) => {
       store[key] = String(value);
+      return Promise.resolve();
+    }),
+    delete: vi.fn((key) => {
+      delete store[key];
       return Promise.resolve();
     }),
     _store: store,
@@ -52,13 +57,24 @@ describe('checkRateLimit', () => {
   it('blocks when global daily cap reached', async () => {
     const kv = createMockKV();
     kv.get.mockImplementation((key) => {
-      if (key.startsWith('rl:global:')) return Promise.resolve('5000');
+      if (key.startsWith('rl:global:')) return Promise.resolve('500');
       return Promise.resolve(null);
     });
 
     const result = await checkRateLimit('1.2.3.4', kv);
     expect(result.allowed).toBe(false);
     expect(result.reason).toContain('busy');
+  });
+
+  it('allows just below the lowered global daily cap', async () => {
+    const kv = createMockKV();
+    kv.get.mockImplementation((key) => {
+      if (key.startsWith('rl:global:')) return Promise.resolve('499');
+      return Promise.resolve(null);
+    });
+
+    const result = await checkRateLimit('1.2.3.4', kv);
+    expect(result.allowed).toBe(true);
   });
 
   it('blocks IP on abuse list', async () => {
@@ -91,6 +107,7 @@ describe('incrementCounters', () => {
     const kv = createMockKV();
     await incrementCounters('1.2.3.4', kv);
 
+    // 4 puts (min, day, global, burst) + 4 deletes (previous-window pruning)
     expect(kv.put).toHaveBeenCalledTimes(4);
     // Verify minute counter
     const minuteCall = kv.put.mock.calls.find((c) => c[0].startsWith('rl:min:'));
@@ -189,7 +206,7 @@ describe('checkRateLimit with autosuggest purpose', () => {
   it('shares global daily limit with chat', async () => {
     const kv = createMockKV();
     kv.get.mockImplementation((key) => {
-      if (key.startsWith('rl:global:')) return Promise.resolve('5000');
+      if (key.startsWith('rl:global:')) return Promise.resolve('500');
       return Promise.resolve(null);
     });
 
@@ -244,5 +261,250 @@ describe('incrementCounters with autosuggest purpose', () => {
     // Autosuggest should still be allowed (different prefix)
     const asResult = await checkRateLimit('1.2.3.4', kv, 'autosuggest');
     expect(asResult.allowed).toBe(true);
+  });
+});
+
+// A consistent in-memory store mirroring Durable Object storage semantics:
+// get returns the stored value directly (numbers, not strings) and writes are
+// immediately visible to subsequent reads — i.e. strongly consistent, no KV lag.
+function createConsistentStore(initial = {}) {
+  const map = new Map(Object.entries(initial));
+  return {
+    get: vi.fn(async (key) => (map.has(key) ? map.get(key) : null)),
+    put: vi.fn(async (key, value) => {
+      map.set(key, value);
+    }),
+    delete: vi.fn(async (key) => {
+      map.delete(key);
+    }),
+    _map: map,
+  };
+}
+
+describe('checkAndIncrement', () => {
+  it('allows and increments on the first request', async () => {
+    const store = createConsistentStore();
+    const result = await checkAndIncrement('1.2.3.4', store, 'chat');
+    expect(result.allowed).toBe(true);
+    // minute, day, global, burst counters all written
+    expect(store.put).toHaveBeenCalledTimes(4);
+  });
+
+  it('does not increment when the request is denied', async () => {
+    const store = createConsistentStore();
+    store.get.mockImplementation(async (key) =>
+      key.startsWith('rl:day:') ? '30' : null
+    );
+    const result = await checkAndIncrement('1.2.3.4', store, 'chat');
+    expect(result.allowed).toBe(false);
+    expect(store.put).not.toHaveBeenCalled();
+  });
+
+  it('enforces the per-minute cap across sequential calls (no read-then-write race)', async () => {
+    const store = createConsistentStore();
+    const results = [];
+    // perMinute for chat is 5; the 6th sequential call must be blocked.
+    for (let i = 0; i < 6; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      results.push(await checkAndIncrement('9.9.9.9', store, 'chat'));
+    }
+    const allowed = results.filter((r) => r.allowed).length;
+    expect(allowed).toBe(5);
+    expect(results[5].allowed).toBe(false);
+    expect(results[5].reason).toContain('per-minute');
+  });
+});
+
+// Hand-rolled Durable Object state stub: serializes work via blockConcurrencyWhile
+// and backs storage with a strongly-consistent in-memory map.
+function createDOState() {
+  const store = createConsistentStore();
+  let chain = Promise.resolve();
+  return {
+    storage: store,
+    blockConcurrencyWhile: vi.fn((fn) => {
+      // Serialize callbacks the way a real DO does: each runs only after the prior settles.
+      const next = chain.then(() => fn());
+      chain = next.catch(() => {});
+      return next;
+    }),
+  };
+}
+
+function doRequest(ip, purpose) {
+  return new Request('https://rate-limiter/check', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ip, purpose }),
+  });
+}
+
+// Creates a fake env.RATE_LIMITER binding backed by real RateLimiter DO instances
+// in memory. Instances are created lazily and cached by name so the __global__
+// instance is shared across all per-IP instances — matching the real Cloudflare
+// behaviour where idFromName("__global__") always resolves to the same DO.
+function createRateLimiterBinding() {
+  const instances = new Map();
+
+  function getOrCreate(name) {
+    if (!instances.has(name)) {
+      const state = createDOState();
+      // Instances get a reference back to this binding so per-IP DOs can reach
+      // __global__ via env.RATE_LIMITER — mirroring the real runtime.
+      const env = { RATE_LIMITER: binding };  // forward ref; binding is defined below
+      instances.set(name, new RateLimiter(state, env));
+    }
+    return instances.get(name);
+  }
+
+  const binding = {
+    idFromName: (name) => ({ name }),
+    get: ({ name }) => getOrCreate(name),
+  };
+  return binding;
+}
+
+describe('RateLimiter Durable Object', () => {
+  it('returns an allowed result and increments storage', async () => {
+    const state = createDOState();
+    const limiter = new RateLimiter(state, { RATE_LIMITER: createRateLimiterBinding() });
+    const res = await limiter.fetch(doRequest('5.5.5.5', 'chat'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.allowed).toBe(true);
+    expect(body.remaining).toBe(29);
+    expect(state.blockConcurrencyWhile).toHaveBeenCalledTimes(1);
+  });
+
+  it('enforces the per-minute cap under concurrent requests (atomic, no race)', async () => {
+    const binding = createRateLimiterBinding();
+    const state = createDOState();
+    const limiter = new RateLimiter(state, { RATE_LIMITER: binding });
+    // Fire 8 requests concurrently; chat perMinute cap is 5.
+    const responses = await Promise.all(
+      Array.from({ length: 8 }, () => limiter.fetch(doRequest('7.7.7.7', 'chat')))
+    );
+    const bodies = await Promise.all(responses.map((r) => r.json()));
+    const allowed = bodies.filter((b) => b.allowed).length;
+    expect(allowed).toBe(5);
+    expect(bodies.filter((b) => !b.allowed)).toHaveLength(3);
+  });
+
+  it('returns 400 for an unparseable request body', async () => {
+    const state = createDOState();
+    const limiter = new RateLimiter(state);
+    const res = await limiter.fetch(
+      new Request('https://rate-limiter/check', { method: 'POST', body: 'not-json' })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('global cap is truly shared across different IPs (not per-IP)', async () => {
+    // Use a binding where LIMITS.globalPerDay would be 2 — we cannot override the
+    // constant, so instead we saturate the real cap (500) via the __global__ DO
+    // directly, then verify a fresh IP is blocked.
+    const binding = createRateLimiterBinding();
+
+    // Pre-fill the __global__ DO's counter to globalPerDay (500) by calling its
+    // /global/increment endpoint directly 500 times — too slow; instead write
+    // directly to the __global__ instance's storage.
+    const today = new Date().toISOString().split('T')[0];
+    const globalKey = `rl:global:${today}`;
+    const globalInstance = binding.get(binding.idFromName('__global__'));
+    // Write the count directly to the __global__ DO's underlying storage map.
+    await globalInstance.storage.put(globalKey, String(500));
+
+    // IP-A: should be blocked by global cap.
+    const stateA = createDOState();
+    const limiterA = new RateLimiter(stateA, { RATE_LIMITER: binding });
+    const resA = await limiterA.fetch(doRequest('10.0.0.1', 'chat'));
+    const bodyA = await resA.json();
+    expect(bodyA.allowed).toBe(false);
+    expect(bodyA.reason).toContain('busy');
+
+    // IP-B (different IP, same global state): also blocked.
+    const stateB = createDOState();
+    const limiterB = new RateLimiter(stateB, { RATE_LIMITER: binding });
+    const resB = await limiterB.fetch(doRequest('10.0.0.2', 'chat'));
+    const bodyB = await resB.json();
+    expect(bodyB.allowed).toBe(false);
+    expect(bodyB.reason).toContain('busy');
+  });
+
+  it('two IPs share global cap: first two pass, third is globally throttled', async () => {
+    // Seed the global counter at globalPerDay - 1 (499) so that one more request
+    // passes and the next is blocked, regardless of which IP sends it.
+    const binding = createRateLimiterBinding();
+    const today = new Date().toISOString().split('T')[0];
+    const globalKey = `rl:global:${today}`;
+    const globalInstance = binding.get(binding.idFromName('__global__'));
+    await globalInstance.storage.put(globalKey, String(499));
+
+    // IP-A: consumes the last slot.
+    const stateA = createDOState();
+    const limiterA = new RateLimiter(stateA, { RATE_LIMITER: binding });
+    const resA = await limiterA.fetch(doRequest('11.0.0.1', 'chat'));
+    expect((await resA.json()).allowed).toBe(true);
+
+    // IP-B: global cap now at 500 — blocked even though it has no per-IP history.
+    const stateB = createDOState();
+    const limiterB = new RateLimiter(stateB, { RATE_LIMITER: binding });
+    const resB = await limiterB.fetch(doRequest('11.0.0.2', 'chat'));
+    const bodyB = await resB.json();
+    expect(bodyB.allowed).toBe(false);
+    expect(bodyB.reason).toContain('busy');
+  });
+
+  it('old bucket keys are pruned on increment (no unbounded storage growth)', async () => {
+    const binding = createRateLimiterBinding();
+    const state = createDOState();
+    const limiter = new RateLimiter(state, { RATE_LIMITER: binding });
+
+    // Manually plant a stale previous-minute key in per-IP storage.
+    const prevMinBucket = Math.floor(Date.now() / 60000) - 1;
+    const staleKey = `rl:min:2.2.2.2:${prevMinBucket}`;
+    await state.storage._map.set(staleKey, '3');
+    expect(state.storage._map.has(staleKey)).toBe(true);
+
+    // After one allowed request the stale key must be deleted.
+    await limiter.fetch(doRequest('2.2.2.2', 'chat'));
+    expect(state.storage._map.has(staleKey)).toBe(false);
+  });
+
+  it('concurrent requests from DIFFERENT IPs cannot exceed global cap (no TOCTOU race)', async () => {
+    // Seed the global counter at globalPerDay - 1 (499) leaving exactly ONE slot.
+    // Fire 4 requests concurrently from two different IP DOs (2 requests each).
+    // Without the atomic check-increment fix both IPs would read 499 < 500 and
+    // both pass, yielding 2+ allowed. With the fix exactly 1 is allowed total.
+    const binding = createRateLimiterBinding();
+    const today = new Date().toISOString().split('T')[0];
+    const globalKey = `rl:global:${today}`;
+    const globalInstance = binding.get(binding.idFromName('__global__'));
+    await globalInstance.storage.put(globalKey, String(499));
+
+    // Two independent per-IP DO instances, each with their own serialization chain.
+    const stateA = createDOState();
+    const limiterA = new RateLimiter(stateA, { RATE_LIMITER: binding });
+    const stateB = createDOState();
+    const limiterB = new RateLimiter(stateB, { RATE_LIMITER: binding });
+
+    // Concurrently fire 2 requests from IP-A and 2 from IP-B (4 total, 1 slot left).
+    const responses = await Promise.all([
+      limiterA.fetch(doRequest('20.0.0.1', 'chat')),
+      limiterB.fetch(doRequest('20.0.0.2', 'chat')),
+      limiterA.fetch(doRequest('20.0.0.1', 'chat')),
+      limiterB.fetch(doRequest('20.0.0.2', 'chat')),
+    ]);
+    const bodies = await Promise.all(responses.map((r) => r.json()));
+    const allowed = bodies.filter((b) => b.allowed);
+    const denied  = bodies.filter((b) => !b.allowed);
+
+    // Exactly one request may pass (the single remaining global slot).
+    expect(allowed).toHaveLength(1);
+    // The other three must be denied — either by global cap or per-IP minute cap.
+    expect(denied).toHaveLength(3);
+    // The global-cap denials carry the 'busy' reason.
+    const busyDenials = denied.filter((b) => b.reason && b.reason.includes('busy'));
+    expect(busyDenials.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/proxy/wrangler.toml
+++ b/proxy/wrangler.toml
@@ -8,6 +8,19 @@ compatibility_date = "2024-01-01"
 binding = "RATE_LIMIT_KV"
 id = "d4714a769c944734babf5e75732207f7"
 
+# Durable Object: strongly-consistent, atomic rate-limit counters.
+# RateLimiter serves two roles via named instances:
+#   idFromName("<ip>")      — per-IP minute/day/burst counters (one DO per IP)
+#   idFromName("__global__") — service-wide daily counter shared across all IPs
+# Replaces the racy, eventually-consistent KV check-then-increment.
+[[durable_objects.bindings]]
+name = "RATE_LIMITER"
+class_name = "RateLimiter"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["RateLimiter"]
+
 # Secrets (set via `wrangler secret put <NAME>`):
 # - OPENAI_API_KEY
 # - HMAC_SECRET


### PR DESCRIPTION
## Problem
The proxy's rate limiting used Cloudflare KV, which is eventually consistent. Concurrent requests all read the same low count and passed the cap before any increment landed — so `perMinute`/`perDay`/`globalPerDay` were not actually enforced (cost / denial-of-wallet risk).

## Fix
- Replace KV counters with a **Cloudflare Durable Object** that does check-and-increment inside `blockConcurrencyWhile` (serialized, strongly consistent).
- Per-IP DO holds minute/day/burst counters.
- The service-wide **global** cap routes through a single dedicated `__global__` DO instance via one **atomic `/global/check-increment` endpoint** — decision + mutation in one serialized gate, so there's no cross-DO TOCTOU. **Fail-closed** on missing binding / fetch error / malformed response.
- Per-IP counters are incremented only *after* the global check passes (a global denial never inflates per-IP counts).
- Lower `globalPerDay` 5000 → 500 as a cost backstop.
- Prune previous-window bucket keys so DO storage stays O(1) per IP.

> Note: the real cost backstop is an **upstream OpenAI account hard spend cap** (an account dashboard setting, outside this repo).

## Testing
- 86 proxy tests pass, including a new **concurrent distinct-IP** test that seeds the global counter one slot from the cap, fires 4 concurrent requests from 2 IPs sharing the `__global__` DO, and asserts exactly one is allowed (would fail against the old split check/increment design).
- `node --check` clean on all changed sources.

## Deploy note
Not deployed. `wrangler.toml` adds the `RateLimiter` DO binding + `new_sqlite_classes` migration; deploying will require `wrangler deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)