### PR TITLE
perf(content): minify prod bundle, throttle screenshot drag, reuse ghost-text overlay

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -22,7 +22,7 @@ const sharedConfig = {
   bundle: true,
   format: 'iife',
   target: 'chrome115',
-  minify: false,
+  minify: !isWatch,
 };
 
 async function build() {

--- a/src/content/autosuggest/ghost-text.js
+++ b/src/content/autosuggest/ghost-text.js
@@ -6,64 +6,38 @@ import {
 } from '../shared/state.js';
 import { getGhostTextStyles } from './styles.js';
 
-export function showGhostText(textarea, suggestion) {
-  setAutosuggestCurrentSuggestion(suggestion);
+// Cached references to the persistent overlay's internal nodes, plus the textarea
+// the expensive getComputedStyle-derived metrics were last computed for. These let
+// repeat showGhostText() calls reuse the Shadow DOM instead of rebuilding it.
+let overlayRefs = null; // { container, mirror, ghost }
+let styledTextarea = null;
 
-  // Remove existing overlay if any
-  const existing = autosuggestOverlayHost;
-  if (existing) existing.remove();
-
-  // Create Shadow DOM host
+function buildOverlay() {
   const host = document.createElement('div');
   host.setAttribute('data-dobby-autosuggest', '');
-
-  const computed = window.getComputedStyle(textarea);
-  const rect = textarea.getBoundingClientRect();
-
-  // Position overlay exactly over the textarea
   host.style.position = 'absolute';
-  host.style.top = `${rect.top + window.scrollY}px`;
-  host.style.left = `${rect.left + window.scrollX}px`;
-  host.style.width = `${rect.width}px`;
-  host.style.height = `${rect.height}px`;
   host.style.pointerEvents = 'none';
   host.style.zIndex = '2147483640';
   host.style.overflow = 'hidden';
 
   const shadow = host.attachShadow({ mode: 'open' });
 
-  // Inject styles
   const style = document.createElement('style');
   style.textContent = getGhostTextStyles();
   shadow.appendChild(style);
 
-  // Create container that mirrors textarea's text metrics
   const container = document.createElement('div');
   container.className = 'ghost-container';
-  container.style.fontSize = computed.fontSize;
-  container.style.fontFamily = computed.fontFamily;
-  container.style.lineHeight = computed.lineHeight;
-  container.style.paddingTop = computed.paddingTop;
-  container.style.paddingLeft = computed.paddingLeft;
-  container.style.paddingRight = computed.paddingRight;
-  container.style.paddingBottom = computed.paddingBottom;
-  container.style.borderTop = `${computed.borderTopWidth} solid transparent`;
-  container.style.borderLeft = `${computed.borderLeftWidth} solid transparent`;
-  container.style.letterSpacing = computed.letterSpacing;
-  container.style.wordSpacing = computed.wordSpacing;
   container.style.width = '100%';
   container.style.boxSizing = 'border-box';
 
   // Mirror text before cursor (invisible) so ghost text is positioned correctly
-  const textBeforeCursor = textarea.value.substring(0, textarea.selectionStart);
   const mirror = document.createElement('span');
   mirror.className = 'ghost-mirror';
-  mirror.textContent = textBeforeCursor;
 
   // Ghost suggestion (visible, faded)
   const ghost = document.createElement('span');
   ghost.className = 'ghost-text';
-  ghost.textContent = suggestion;
 
   // Paw indicator
   const paw = document.createElement('span');
@@ -75,11 +49,74 @@ export function showGhostText(textarea, suggestion) {
   container.appendChild(paw);
   shadow.appendChild(container);
 
-  // Match textarea scroll position
-  container.scrollTop = textarea.scrollTop;
-
   document.body.appendChild(host);
   setAutosuggestOverlayHost(host);
+  overlayRefs = { container, mirror, ghost };
+  return host;
+}
+
+// Recompute the expensive getComputedStyle-derived text metrics. Only called when
+// the target textarea changes, not on every keystroke.
+function applyTextareaStyles(textarea, container) {
+  const computed = window.getComputedStyle(textarea);
+  container.style.fontSize = computed.fontSize;
+  container.style.fontFamily = computed.fontFamily;
+  container.style.lineHeight = computed.lineHeight;
+  container.style.paddingTop = computed.paddingTop;
+  container.style.paddingLeft = computed.paddingLeft;
+  container.style.paddingRight = computed.paddingRight;
+  container.style.paddingBottom = computed.paddingBottom;
+  container.style.borderTop = `${computed.borderTopWidth} solid transparent`;
+  container.style.borderLeft = `${computed.borderLeftWidth} solid transparent`;
+  container.style.letterSpacing = computed.letterSpacing;
+  container.style.wordSpacing = computed.wordSpacing;
+}
+
+// Returns false and hides the overlay when the textarea is detached or has a
+// zero-area bounding rect (detached node or SPA re-render artefact).
+function positionOverlay(host, textarea) {
+  if (!textarea.isConnected) {
+    hideGhostText();
+    return false;
+  }
+  const rect = textarea.getBoundingClientRect();
+  if (rect.width === 0 && rect.height === 0) {
+    hideGhostText();
+    return false;
+  }
+  host.style.top = `${rect.top + window.scrollY}px`;
+  host.style.left = `${rect.left + window.scrollX}px`;
+  host.style.width = `${rect.width}px`;
+  host.style.height = `${rect.height}px`;
+  return true;
+}
+
+export function showGhostText(textarea, suggestion) {
+  setAutosuggestCurrentSuggestion(suggestion);
+
+  // Create the host + shadow root once, then reuse it across calls.
+  let host = autosuggestOverlayHost;
+  if (!host || !overlayRefs) {
+    host = buildOverlay();
+  }
+  const { container, mirror, ghost } = overlayRefs;
+
+  // Recompute expensive getComputedStyle metrics when the textarea changes OR
+  // when the cached textarea has been detached (SPA re-render / node recycling).
+  if (textarea !== styledTextarea || !textarea.isConnected) {
+    applyTextareaStyles(textarea, container);
+    styledTextarea = textarea;
+  }
+
+  // Reposition (cheap) and bail if the textarea is no longer in the DOM.
+  if (!positionOverlay(host, textarea)) return;
+
+  const textBeforeCursor = textarea.value.substring(0, textarea.selectionStart);
+  mirror.textContent = textBeforeCursor;
+  ghost.textContent = suggestion;
+
+  // Match textarea scroll position
+  container.scrollTop = textarea.scrollTop;
 }
 
 export function hideGhostText() {
@@ -88,6 +125,8 @@ export function hideGhostText() {
     host.remove();
     setAutosuggestOverlayHost(null);
   }
+  overlayRefs = null;
+  styledTextarea = null;
   setAutosuggestCurrentSuggestion('');
 }
 

--- a/src/content/shared/state.js
+++ b/src/content/shared/state.js
@@ -44,6 +44,8 @@ export const screenshotState = {
   startY: 0,
   rect: null,
   dragStarted: false,
+  rafId: null,
+  pendingRect: null,
 };
 
 export function resetScreenshotState() {
@@ -52,6 +54,8 @@ export function resetScreenshotState() {
   screenshotState.startY = 0;
   screenshotState.rect = null;
   screenshotState.dragStarted = false;
+  screenshotState.rafId = null;
+  screenshotState.pendingRect = null;
 }
 
 // Long-press state

--- a/src/content/trigger/screenshot.js
+++ b/src/content/trigger/screenshot.js
@@ -7,6 +7,17 @@ import { _removeProgressRing } from './progress-ring.js';
 import { showBubbleWithPresets } from '../bubble/core.js';
 import { captureScreenshot } from '../image-capture.js';
 
+// Cancels any pending drag-update animation frame scheduled by the mousemove
+// coalescing logic in selection.js, and clears the coalescing state. Operates
+// on shared screenshotState directly to avoid a circular import.
+function cancelPendingDragRect() {
+  if (screenshotState.rafId !== null) {
+    cancelAnimationFrame(screenshotState.rafId);
+    screenshotState.rafId = null;
+  }
+  screenshotState.pendingRect = null;
+}
+
 export function startScreenshotMode() {
   if (longPressState.ringTimer) { clearTimeout(longPressState.ringTimer); longPressState.ringTimer = null; }
   _removeProgressRing();
@@ -87,6 +98,9 @@ export function startScreenshotMode() {
   screenshotState.overlay.addEventListener('mouseup', (e) => {
     // Ignore the mouseup from the long-press release (no drag started yet)
     if (!screenshotState.dragStarted) return;
+
+    // Drag is ending — cancel any coalesced rAF so it can't apply a stale rect.
+    cancelPendingDragRect();
 
     const x = Math.min(screenshotState.startX, e.clientX);
     const y = Math.min(screenshotState.startY, e.clientY);
@@ -236,6 +250,7 @@ function _showConfirmToolbar(overlay, banner, rect) {
 }
 
 export function cancelScreenshotMode() {
+  cancelPendingDragRect();
   if (screenshotState.overlay) {
     if (screenshotState.overlay._escHandler) {
       document.removeEventListener('keydown', screenshotState.overlay._escHandler);

--- a/src/content/trigger/selection.js
+++ b/src/content/trigger/selection.js
@@ -24,6 +24,21 @@ const INTERACTIVE_TAGS = new Set([
   'INPUT', 'TEXTAREA', 'SELECT', 'BUTTON', 'A', 'VIDEO', 'AUDIO', 'LABEL', 'OPTION',
 ]);
 
+// Applies the most recent drag rect to the DOM, then clears the pending rAF flag
+// so the next mousemove can schedule a fresh frame. Coordinates are read from
+// screenshotState.pendingRect (the latest move), keeping the final rect exact.
+function _applyPendingDragRect() {
+  screenshotState.rafId = null;
+  const pending = screenshotState.pendingRect;
+  if (!pending || !screenshotState.rect) return;
+  Object.assign(screenshotState.rect.style, {
+    left: pending.x + 'px',
+    top: pending.y + 'px',
+    width: pending.w + 'px',
+    height: pending.h + 'px',
+  });
+}
+
 export function isInteractiveElement(el) {
   if (!el || !el.tagName) return false;
   if (INTERACTIVE_TAGS.has(el.tagName)) return true;
@@ -142,18 +157,18 @@ export function registerListeners() {
       }
     }
 
-    // Screenshot region drag
+    // Screenshot region drag — coalesce DOM updates to at most one per animation frame
     if (screenshotState.overlay && screenshotState.rect && screenshotState.dragStarted) {
-      const x = Math.min(screenshotState.startX, e.clientX);
-      const y = Math.min(screenshotState.startY, e.clientY);
-      const w = Math.abs(e.clientX - screenshotState.startX);
-      const h = Math.abs(e.clientY - screenshotState.startY);
-      Object.assign(screenshotState.rect.style, {
-        left: x + 'px',
-        top: y + 'px',
-        width: w + 'px',
-        height: h + 'px',
-      });
+      // Store the latest pointer-derived rect; the scheduled rAF applies the freshest value.
+      screenshotState.pendingRect = {
+        x: Math.min(screenshotState.startX, e.clientX),
+        y: Math.min(screenshotState.startY, e.clientY),
+        w: Math.abs(e.clientX - screenshotState.startX),
+        h: Math.abs(e.clientY - screenshotState.startY),
+      };
+      if (screenshotState.rafId === null) {
+        screenshotState.rafId = requestAnimationFrame(_applyPendingDragRect);
+      }
     }
   });
 

--- a/tests/autosuggest-ghost-text.test.js
+++ b/tests/autosuggest-ghost-text.test.js
@@ -97,4 +97,104 @@ describe('ghost text overlay', () => {
     acceptSuggestion(textarea);
     expect(inputSpy).toHaveBeenCalled();
   });
+
+  it('reuses the same host and shadow root across repeat calls', () => {
+    showGhostText(textarea, 'world');
+    const host1 = document.querySelector('[data-dobby-autosuggest]');
+    const shadow1 = host1.shadowRoot;
+    showGhostText(textarea, 'world, how are you?');
+    const host2 = document.querySelector('[data-dobby-autosuggest]');
+    expect(host2).toBe(host1);
+    expect(host2.shadowRoot).toBe(shadow1);
+  });
+
+  it('updates ghost text content on repeat calls', () => {
+    showGhostText(textarea, 'world');
+    showGhostText(textarea, 'updated text');
+    const host = document.querySelector('[data-dobby-autosuggest]');
+    expect(host.shadowRoot.querySelector('.ghost-text').textContent).toBe('updated text');
+  });
+
+  it('does not recompute getComputedStyle on repeat calls for the same textarea', () => {
+    window.getComputedStyle.mockClear();
+    showGhostText(textarea, 'world');
+    expect(window.getComputedStyle).toHaveBeenCalledTimes(1);
+    showGhostText(textarea, 'world again');
+    showGhostText(textarea, 'world once more');
+    // Still only the single computation from the first call
+    expect(window.getComputedStyle).toHaveBeenCalledTimes(1);
+  });
+
+  it('recomputes getComputedStyle when switching to a different textarea', () => {
+    showGhostText(textarea, 'world');
+    window.getComputedStyle.mockClear();
+
+    const other = document.createElement('textarea');
+    other.value = 'Hi ';
+    other.selectionStart = 3;
+    other.getBoundingClientRect = vi.fn(() => ({
+      top: 10, left: 20, width: 300, height: 150, bottom: 160, right: 320,
+    }));
+    document.body.appendChild(other);
+
+    showGhostText(other, 'there');
+    expect(window.getComputedStyle).toHaveBeenCalledTimes(1);
+    const host = document.querySelector('[data-dobby-autosuggest]');
+    expect(host.shadowRoot.querySelector('.ghost-text').textContent).toBe('there');
+    expect(host.style.top).toBe('10px');
+  });
+
+  it('recomputes styles after hideGhostText resets cached state', () => {
+    showGhostText(textarea, 'world');
+    hideGhostText();
+    window.getComputedStyle.mockClear();
+    showGhostText(textarea, 'world');
+    // Host was torn down on hide, so styles must be recomputed
+    expect(window.getComputedStyle).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides overlay and does not desync when same textarea ref is detached before call', () => {
+    showGhostText(textarea, 'world');
+    expect(document.querySelector('[data-dobby-autosuggest]')).not.toBeNull();
+
+    // Detach the textarea from the DOM (SPA re-render scenario)
+    textarea.remove();
+    expect(textarea.isConnected).toBe(false);
+
+    // Calling showGhostText with the same (now-detached) ref must hide, not desync
+    showGhostText(textarea, 'world again');
+    expect(document.querySelector('[data-dobby-autosuggest]')).toBeNull();
+  });
+
+  it('hides overlay when getBoundingClientRect returns 0x0 (invisible/moved node)', () => {
+    showGhostText(textarea, 'world');
+    expect(document.querySelector('[data-dobby-autosuggest]')).not.toBeNull();
+
+    // Simulate node that is connected but reports a zero-area rect
+    textarea.getBoundingClientRect = vi.fn(() => ({
+      top: 0, left: 0, width: 0, height: 0, bottom: 0, right: 0,
+    }));
+
+    showGhostText(textarea, 'world again');
+    expect(document.querySelector('[data-dobby-autosuggest]')).toBeNull();
+  });
+
+  it('recomputes getComputedStyle when same textarea ref is detached (stale cache)', () => {
+    showGhostText(textarea, 'world');
+    // Re-attach a fresh textarea with same variable name (simulate SPA swap)
+    textarea.remove();
+    const fresh = document.createElement('textarea');
+    fresh.value = 'Hi ';
+    fresh.selectionStart = 3;
+    fresh.getBoundingClientRect = vi.fn(() => ({
+      top: 10, left: 20, width: 300, height: 150, bottom: 160, right: 320,
+    }));
+    document.body.appendChild(fresh);
+    window.getComputedStyle.mockClear();
+
+    showGhostText(fresh, 'there');
+    // fresh !== styledTextarea, so styles must be recomputed
+    expect(window.getComputedStyle).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('[data-dobby-autosuggest]')).not.toBeNull();
+  });
 });

--- a/tests/trigger.test.js
+++ b/tests/trigger.test.js
@@ -1,8 +1,9 @@
 // tests/trigger.test.js
 // @vitest-environment jsdom
 
-import { describe, it, expect, beforeEach, beforeAll, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, beforeAll, vi } from 'vitest';
 import { setupChromeMocks, mockSelection as sharedMockSelection } from './helpers.js';
+import { screenshotState } from '../src/content/shared/state.js';
 
 // Mock the bubble module (trigger modules import from it)
 vi.mock('../src/content/bubble/core.js', () => ({
@@ -379,6 +380,107 @@ describe('screenshot mode', () => {
     toolbar = overlay.querySelector('[data-screenshot-toolbar]');
     expect(toolbar).not.toBeNull();
     cancelScreenshotMode();
+  });
+
+  describe('drag rect rAF coalescing', () => {
+    let rafCallbacks;
+    let originalRaf;
+    let originalCancelRaf;
+
+    beforeEach(() => {
+      rafCallbacks = new Map();
+      let nextId = 1;
+      originalRaf = global.requestAnimationFrame;
+      originalCancelRaf = global.cancelAnimationFrame;
+      global.requestAnimationFrame = vi.fn((cb) => {
+        const id = nextId++;
+        rafCallbacks.set(id, cb);
+        return id;
+      });
+      global.cancelAnimationFrame = vi.fn((id) => {
+        rafCallbacks.delete(id);
+      });
+    });
+
+    afterEach(() => {
+      global.requestAnimationFrame = originalRaf;
+      global.cancelAnimationFrame = originalCancelRaf;
+    });
+
+    function flushRaf() {
+      const cbs = [...rafCallbacks.values()];
+      rafCallbacks.clear();
+      cbs.forEach((cb) => cb());
+    }
+
+    it('coalesces rapid mousemoves into a single rAF and applies the latest coords', () => {
+      startScreenshotMode();
+      const overlay = document.querySelector('div[style*="crosshair"]');
+      overlay.dispatchEvent(new MouseEvent('mousedown', { clientX: 50, clientY: 50, bubbles: true }));
+      const rect = overlay.querySelector('div[style*="dashed"]');
+
+      // Three rapid moves before any frame fires
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 100, clientY: 100, bubbles: true }));
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 150, clientY: 150, bubbles: true }));
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 200, clientY: 220, bubbles: true }));
+
+      // Only one frame scheduled, DOM not yet resized (still at the initial 0px from mousedown)
+      expect(global.requestAnimationFrame).toHaveBeenCalledTimes(1);
+      expect(rect.style.width).toBe('0px');
+
+      // Frame applies the most recent coordinates exactly
+      flushRaf();
+      expect(rect.style.left).toBe('50px');
+      expect(rect.style.top).toBe('50px');
+      expect(rect.style.width).toBe('150px'); // |200 - 50|
+      expect(rect.style.height).toBe('170px'); // |220 - 50|
+
+      cancelScreenshotMode();
+    });
+
+    it('schedules a fresh frame after the previous one is applied', () => {
+      startScreenshotMode();
+      const overlay = document.querySelector('div[style*="crosshair"]');
+      overlay.dispatchEvent(new MouseEvent('mousedown', { clientX: 50, clientY: 50, bubbles: true }));
+
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 100, clientY: 100, bubbles: true }));
+      expect(global.requestAnimationFrame).toHaveBeenCalledTimes(1);
+      flushRaf();
+
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 120, clientY: 120, bubbles: true }));
+      expect(global.requestAnimationFrame).toHaveBeenCalledTimes(2);
+
+      cancelScreenshotMode();
+    });
+
+    it('cancels the pending frame when the drag ends so no stale update lands', () => {
+      startScreenshotMode();
+      const overlay = document.querySelector('div[style*="crosshair"]');
+      overlay.dispatchEvent(new MouseEvent('mousedown', { clientX: 50, clientY: 50, bubbles: true }));
+
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 200, clientY: 200, bubbles: true }));
+      expect(screenshotState.rafId).not.toBeNull();
+
+      // End the drag — pending frame must be cancelled
+      overlay.dispatchEvent(new MouseEvent('mouseup', { clientX: 200, clientY: 200, bubbles: true }));
+      expect(global.cancelAnimationFrame).toHaveBeenCalled();
+      expect(screenshotState.rafId).toBeNull();
+      expect(screenshotState.pendingRect).toBeNull();
+
+      cancelScreenshotMode();
+    });
+
+    it('cancelScreenshotMode clears any pending frame', () => {
+      startScreenshotMode();
+      const overlay = document.querySelector('div[style*="crosshair"]');
+      overlay.dispatchEvent(new MouseEvent('mousedown', { clientX: 50, clientY: 50, bubbles: true }));
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 200, clientY: 200, bubbles: true }));
+      expect(screenshotState.rafId).not.toBeNull();
+
+      cancelScreenshotMode();
+      expect(screenshotState.rafId).toBeNull();
+      expect(screenshotState.pendingRect).toBeNull();
+    });
   });
 
   it('does not start screenshot mode when clicking on scrollbar area', async () => {


### PR DESCRIPTION
Three independent content-script / build performance fixes.

## 1. Minify production bundle
`esbuild.config.js` shipped `content.js` **unminified** to every page on every load. Now `minify: !isWatch` — production builds minify, `npm run dev`/watch stays readable for debugging.

## 2. rAF-coalesce screenshot drag
The screenshot drag registered an unthrottled document `mousemove` that mutated `rect.style.{left,top,width,height}` on every pixel move (60+ reflows/sec). Now the latest coords are stored and a single `requestAnimationFrame` applies them once per frame; `cancelAnimationFrame` fires on drag-end / mode-exit (no leak, no stale write). The final captured rect is computed directly from the mouseup event, so it stays exact.

## 3. Reuse ghost-text overlay
`showGhostText()` destroyed and rebuilt the entire Shadow DOM overlay (and called `getComputedStyle`) on **every keystroke**. Now the host is built once and reused; only the ghost text content updates per call, and `getComputedStyle`-derived styles recompute only when the target textarea changes. Added a guard so a detached / 0×0 textarea (SPA re-renders) hides the overlay instead of desyncing.

## Testing
- Full build passes; affected unit tests pass (`tests/trigger.test.js`, `tests/autosuggest-ghost-text.test.js`), including new tests for rAF coalescing, overlay reuse, and the detached-textarea guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)