### PR TITLE
fix(security): drop <all_urls> host permission (least privilege)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,8 +6,7 @@
   "permissions": ["contextMenus", "activeTab", "storage", "notifications"],
   "host_permissions": [
     "https://dobby-ai-proxy.zhongnansu.workers.dev/*",
-    "https://api.openai.com/*",
-    "<all_urls>"
+    "https://api.openai.com/*"
   ],
   "background": {
     "service_worker": "background.js"


### PR DESCRIPTION
## Change
Remove `<all_urls>` from `manifest.json` `host_permissions`. The array now contains exactly the two origins the extension actually calls:
- `https://dobby-ai-proxy.zhongnansu.workers.dev/*`
- `https://api.openai.com/*`

## Why these are kept
- `api.openai.com` — the **bring-your-own-key** path fetches OpenAI directly from the background service worker, so removing it would break BYOK.
- `content_scripts.matches` is **unchanged** (still `["<all_urls>"]`) so text-selection / screenshot triggers keep working on every page. This PR only narrows the extension's host/fetch reach, not where the content script injects.

## Impact
Least-privilege tightening; reduces the "read your data on all websites" host grant and eases Chrome Web Store review. No behavior change for users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)