### PR TITLE
[codex] Fix theme propagation and toolbar centering

### DIFF
--- a/options.html
+++ b/options.html
@@ -120,24 +120,41 @@
     .provider-panel { display: none; }
     .provider-panel.active { display: block; }
     .hint { font-size: 12px; color: #a1a1aa; margin-top: 4px; }
+    html[data-resolved-theme="dark"] body { background: #18181b; color: #e4e4e7; }
+    html[data-resolved-theme="dark"] .card { background: #27272a; border-color: #3f3f46; }
+    html[data-resolved-theme="dark"] .card p { color: #a1a1aa; }
+    html[data-resolved-theme="dark"] .input-group input { background: #18181b; border-color: #3f3f46; color: #e4e4e7; }
+    html[data-resolved-theme="dark"] .input-group input:focus { border-color: #a78bfa; box-shadow: 0 0 0 3px rgba(167,139,250,0.15); }
+    html[data-resolved-theme="dark"] .current-key { background: #3f3f46; }
+    html[data-resolved-theme="dark"] .current-key .key-value { color: #a1a1aa; }
+    html[data-resolved-theme="dark"] .btn-danger { background: #27272a; border-color: #7f1d1d; color: #f87171; }
+    html[data-resolved-theme="dark"] .btn-danger:hover { background: #371717; }
+    html[data-resolved-theme="dark"] .usage-info { background: rgba(124,58,237,0.1); border-color: rgba(124,58,237,0.2); color: #c4b5fd; }
+    html[data-resolved-theme="dark"] .provider-tab { background: #3f3f46; border-color: #52525b; color: #a1a1aa; }
+    html[data-resolved-theme="dark"] .provider-tab.active { background: #27272a; color: #e4e4e7; border-bottom-color: #27272a; }
+    html[data-resolved-theme="dark"] .provider-content { background: #27272a; border-color: #3f3f46; }
+    html[data-resolved-theme="dark"] .steps li::before { background: #a78bfa; }
+    html[data-resolved-theme="dark"] .steps a { color: #a78bfa; }
+    html[data-resolved-theme="dark"] .hint { color: #71717a; }
+    html[data-resolved-theme="dark"] .header .version { color: #71717a; }
     @media (prefers-color-scheme: dark) {
-      body { background: #18181b; color: #e4e4e7; }
-      .card { background: #27272a; border-color: #3f3f46; }
-      .card p { color: #a1a1aa; }
-      .input-group input { background: #18181b; border-color: #3f3f46; color: #e4e4e7; }
-      .input-group input:focus { border-color: #a78bfa; box-shadow: 0 0 0 3px rgba(167,139,250,0.15); }
-      .current-key { background: #3f3f46; }
-      .current-key .key-value { color: #a1a1aa; }
-      .btn-danger { background: #27272a; border-color: #7f1d1d; color: #f87171; }
-      .btn-danger:hover { background: #371717; }
-      .usage-info { background: rgba(124,58,237,0.1); border-color: rgba(124,58,237,0.2); color: #c4b5fd; }
-      .provider-tab { background: #3f3f46; border-color: #52525b; color: #a1a1aa; }
-      .provider-tab.active { background: #27272a; color: #e4e4e7; border-bottom-color: #27272a; }
-      .provider-content { background: #27272a; border-color: #3f3f46; }
-      .steps li::before { background: #a78bfa; }
-      .steps a { color: #a78bfa; }
-      .hint { color: #71717a; }
-      .header .version { color: #71717a; }
+      html:not([data-resolved-theme]) body { background: #18181b; color: #e4e4e7; }
+      html:not([data-resolved-theme]) .card { background: #27272a; border-color: #3f3f46; }
+      html:not([data-resolved-theme]) .card p { color: #a1a1aa; }
+      html:not([data-resolved-theme]) .input-group input { background: #18181b; border-color: #3f3f46; color: #e4e4e7; }
+      html:not([data-resolved-theme]) .input-group input:focus { border-color: #a78bfa; box-shadow: 0 0 0 3px rgba(167,139,250,0.15); }
+      html:not([data-resolved-theme]) .current-key { background: #3f3f46; }
+      html:not([data-resolved-theme]) .current-key .key-value { color: #a1a1aa; }
+      html:not([data-resolved-theme]) .btn-danger { background: #27272a; border-color: #7f1d1d; color: #f87171; }
+      html:not([data-resolved-theme]) .btn-danger:hover { background: #371717; }
+      html:not([data-resolved-theme]) .usage-info { background: rgba(124,58,237,0.1); border-color: rgba(124,58,237,0.2); color: #c4b5fd; }
+      html:not([data-resolved-theme]) .provider-tab { background: #3f3f46; border-color: #52525b; color: #a1a1aa; }
+      html:not([data-resolved-theme]) .provider-tab.active { background: #27272a; color: #e4e4e7; border-bottom-color: #27272a; }
+      html:not([data-resolved-theme]) .provider-content { background: #27272a; border-color: #3f3f46; }
+      html:not([data-resolved-theme]) .steps li::before { background: #a78bfa; }
+      html:not([data-resolved-theme]) .steps a { color: #a78bfa; }
+      html:not([data-resolved-theme]) .hint { color: #71717a; }
+      html:not([data-resolved-theme]) .header .version { color: #71717a; }
     }
   </style>
 </head>

--- a/popup.html
+++ b/popup.html
@@ -177,23 +177,53 @@
     color: #71717a;
     text-align: center;
   }
+  html[data-resolved-theme="dark"] body { background: #1e1e28; color: #e4e4e7; }
+  html[data-resolved-theme="dark"] .toggle-row,
+  html[data-resolved-theme="dark"] .theme-row,
+  html[data-resolved-theme="dark"] .usage-card,
+  html[data-resolved-theme="dark"] .quick-actions { border-color: rgba(255,255,255,0.08); }
+  html[data-resolved-theme="dark"] .status,
+  html[data-resolved-theme="dark"] .usage-secondary,
+  html[data-resolved-theme="dark"] .action-feedback,
+  html[data-resolved-theme="dark"] .state-badge,
+  html[data-resolved-theme="dark"] .version { color: #a1a1aa; }
+  html[data-resolved-theme="dark"] .settings-link { color: #a78bfa; }
+  html[data-resolved-theme="dark"] .usage-card { background: #242432; }
+  html[data-resolved-theme="dark"] .usage-card.warning { background: #3a3018; border-color: rgba(245,158,11,0.3); }
+  html[data-resolved-theme="dark"] .usage-card.danger { background: #3a1f24; border-color: rgba(239,68,68,0.3); }
+  html[data-resolved-theme="dark"] .state-badge.on { color: #86efac; }
+  html[data-resolved-theme="dark"] .state-badge.off { color: #fca5a5; }
+  html[data-resolved-theme="dark"] .quick-action { background: #2a2a3a; color: #e4e4e7; border-color: rgba(255,255,255,0.08); }
+  html[data-resolved-theme="dark"] .quick-action:hover { background: #333348; }
+  html[data-resolved-theme="dark"] .quick-action:disabled { color: #71717a; }
+  html[data-resolved-theme="dark"] .theme-segment { background: #2a2a3a; border-color: rgba(255,255,255,0.08); }
+  html[data-resolved-theme="dark"] .theme-option { color: #a1a1aa; }
+  html[data-resolved-theme="dark"] .theme-option:hover { color: #e4e4e7; }
+  html[data-resolved-theme="dark"] .theme-option.active { background: #7c3aed; color: #fff; }
   @media (prefers-color-scheme: dark) {
-    body { background: #1e1e28; color: #e4e4e7; }
-    .toggle-row, .theme-row, .usage-card, .quick-actions { border-color: rgba(255,255,255,0.08); }
-    .status, .usage-secondary, .action-feedback, .state-badge, .version { color: #a1a1aa; }
-    .settings-link { color: #a78bfa; }
-    .usage-card { background: #242432; }
-    .usage-card.warning { background: #3a3018; border-color: rgba(245,158,11,0.3); }
-    .usage-card.danger { background: #3a1f24; border-color: rgba(239,68,68,0.3); }
-    .state-badge.on { color: #86efac; }
-    .state-badge.off { color: #fca5a5; }
-    .quick-action { background: #2a2a3a; color: #e4e4e7; border-color: rgba(255,255,255,0.08); }
-    .quick-action:hover { background: #333348; }
-    .quick-action:disabled { color: #71717a; }
-    .theme-segment { background: #2a2a3a; border-color: rgba(255,255,255,0.08); }
-    .theme-option { color: #a1a1aa; }
-    .theme-option:hover { color: #e4e4e7; }
-    .theme-option.active { background: #7c3aed; color: #fff; }
+    html:not([data-resolved-theme]) body { background: #1e1e28; color: #e4e4e7; }
+    html:not([data-resolved-theme]) .toggle-row,
+    html:not([data-resolved-theme]) .theme-row,
+    html:not([data-resolved-theme]) .usage-card,
+    html:not([data-resolved-theme]) .quick-actions { border-color: rgba(255,255,255,0.08); }
+    html:not([data-resolved-theme]) .status,
+    html:not([data-resolved-theme]) .usage-secondary,
+    html:not([data-resolved-theme]) .action-feedback,
+    html:not([data-resolved-theme]) .state-badge,
+    html:not([data-resolved-theme]) .version { color: #a1a1aa; }
+    html:not([data-resolved-theme]) .settings-link { color: #a78bfa; }
+    html:not([data-resolved-theme]) .usage-card { background: #242432; }
+    html:not([data-resolved-theme]) .usage-card.warning { background: #3a3018; border-color: rgba(245,158,11,0.3); }
+    html:not([data-resolved-theme]) .usage-card.danger { background: #3a1f24; border-color: rgba(239,68,68,0.3); }
+    html:not([data-resolved-theme]) .state-badge.on { color: #86efac; }
+    html:not([data-resolved-theme]) .state-badge.off { color: #fca5a5; }
+    html:not([data-resolved-theme]) .quick-action { background: #2a2a3a; color: #e4e4e7; border-color: rgba(255,255,255,0.08); }
+    html:not([data-resolved-theme]) .quick-action:hover { background: #333348; }
+    html:not([data-resolved-theme]) .quick-action:disabled { color: #71717a; }
+    html:not([data-resolved-theme]) .theme-segment { background: #2a2a3a; border-color: rgba(255,255,255,0.08); }
+    html:not([data-resolved-theme]) .theme-option { color: #a1a1aa; }
+    html:not([data-resolved-theme]) .theme-option:hover { color: #e4e4e7; }
+    html:not([data-resolved-theme]) .theme-option.active { background: #7c3aed; color: #fff; }
   }
 </style>
 </head>

--- a/src/content/bubble/core.js
+++ b/src/content/bubble/core.js
@@ -9,6 +9,7 @@ import {
 } from '../shared/state.js';
 import { Z_INDEX, TIMING } from '../shared/constants.js';
 import { removeElement } from '../shared/dom-utils.js';
+import { detectTheme, watchThemeChanges } from '../shared/theme.js';
 import { getStyles } from './styles.js';
 import { renderMarkdown, escapeHtml } from './markdown.js';
 import { startStreaming, handleFollowUp } from './stream.js';
@@ -19,23 +20,7 @@ import { buildChatMessages } from '../prompt.js';
 import { recordPresetUsage, buildTypeKey } from '../shared/preset-usage.js';
 import { BRAND_MARK_DATA_URI, BRAND_NAME } from '../../shared/brand.js';
 
-export async function detectTheme() {
-  return new Promise((resolve) => {
-    chrome.storage.local.get('theme', (data) => {
-      const stored = data.theme;
-      if (stored === 'light' || stored === 'dark') {
-        resolve(stored);
-        return;
-      }
-      // 'auto' or absent — fall back to OS preference
-      if (typeof window !== 'undefined' && window.matchMedia) {
-        resolve(window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
-      } else {
-        resolve('light');
-      }
-    });
-  });
-}
+export { detectTheme };
 
 function truncatePreview(text, maxLen = 120) {
   if (!text) return '';
@@ -61,17 +46,11 @@ function createBubbleHost(selectionRect) {
   host._escHandler = (e) => { if (e.key === 'Escape') hideBubble(); };
   document.addEventListener('keydown', host._escHandler);
 
-  // Live-update theme when storage changes
-  host._storageChangeHandler = (changes) => {
-    if (!changes.theme) return;
-    const raw = changes.theme.newValue || 'auto';
-    const theme = (raw === 'light' || raw === 'dark') ? raw
-      : window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    if (!bubbleHost || !bubbleHost.shadowRoot) return;
-    const styleEl = bubbleHost.shadowRoot.querySelector('style');
+  host._themeCleanup = watchThemeChanges((theme) => {
+    if (!host.shadowRoot) return;
+    const styleEl = host.shadowRoot.querySelector('style');
     if (styleEl) styleEl.textContent = getStyles(theme);
-  };
-  chrome.storage.onChanged.addListener(host._storageChangeHandler);
+  });
 
   setBubbleHost(host);
   return host;
@@ -387,8 +366,8 @@ export function hideBubble() {
       bubbleHost._resizeCleanup();
     }
     if (bubbleHost._escHandler) document.removeEventListener('keydown', bubbleHost._escHandler);
-    if (bubbleHost._storageChangeHandler) {
-      chrome.storage.onChanged.removeListener(bubbleHost._storageChangeHandler);
+    if (bubbleHost._themeCleanup) {
+      bubbleHost._themeCleanup();
     }
     removeElement(bubbleHost);
   }

--- a/src/content/shared/theme.js
+++ b/src/content/shared/theme.js
@@ -1,0 +1,83 @@
+// src/content/shared/theme.js — Theme resolution shared by content UI surfaces
+
+const COLOR_SCHEME_QUERY = '(prefers-color-scheme: dark)';
+
+export function normalizeThemeMode(value) {
+  return value === 'light' || value === 'dark' || value === 'auto' ? value : 'auto';
+}
+
+export function getSystemTheme() {
+  if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+    return window.matchMedia(COLOR_SCHEME_QUERY).matches ? 'dark' : 'light';
+  }
+  return 'light';
+}
+
+export function resolveTheme(value) {
+  const mode = normalizeThemeMode(value);
+  return mode === 'auto' ? getSystemTheme() : mode;
+}
+
+export function detectTheme() {
+  return new Promise((resolve) => {
+    if (typeof chrome === 'undefined' || !chrome.storage?.local?.get) {
+      resolve(resolveTheme('auto'));
+      return;
+    }
+
+    chrome.storage.local.get('theme', (data) => {
+      resolve(resolveTheme(data?.theme));
+    });
+  });
+}
+
+export function watchThemeChanges(applyTheme) {
+  let mode = 'auto';
+  const mediaQuery = typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+    ? window.matchMedia(COLOR_SCHEME_QUERY)
+    : null;
+
+  const applyResolved = () => applyTheme(resolveTheme(mode));
+
+  const storageHandler = (changes, areaName) => {
+    if (areaName && areaName !== 'local') return;
+    if (!changes.theme) return;
+    mode = normalizeThemeMode(changes.theme.newValue);
+    applyResolved();
+  };
+
+  const mediaHandler = () => {
+    if (mode === 'auto') applyResolved();
+  };
+
+  if (typeof chrome !== 'undefined' && chrome.storage?.local?.get) {
+    chrome.storage.local.get('theme', (data) => {
+      mode = normalizeThemeMode(data?.theme);
+    });
+  }
+
+  if (typeof chrome !== 'undefined' && chrome.storage?.onChanged?.addListener) {
+    chrome.storage.onChanged.addListener(storageHandler);
+  }
+
+  if (mediaQuery) {
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', mediaHandler);
+    } else if (typeof mediaQuery.addListener === 'function') {
+      mediaQuery.addListener(mediaHandler);
+    }
+  }
+
+  return () => {
+    if (typeof chrome !== 'undefined' && chrome.storage?.onChanged?.removeListener) {
+      chrome.storage.onChanged.removeListener(storageHandler);
+    }
+    if (mediaQuery) {
+      if (typeof mediaQuery.removeEventListener === 'function') {
+        mediaQuery.removeEventListener('change', mediaHandler);
+      } else if (typeof mediaQuery.removeListener === 'function') {
+        mediaQuery.removeListener(mediaHandler);
+      }
+    }
+  };
+}

--- a/src/content/trigger/button.js
+++ b/src/content/trigger/button.js
@@ -4,6 +4,7 @@
 
 import { getToolbarStyles } from './styles.js';
 import { detectTheme, showBubble } from '../bubble/core.js';
+import { watchThemeChanges } from '../shared/theme.js';
 import { buildChatMessages } from '../prompt.js';
 import { Z_INDEX, TIMING } from '../shared/constants.js';
 import {
@@ -121,15 +122,9 @@ async function createToolbar() {
 
   shadow.appendChild(toolbar);
 
-  // Live-update theme when storage changes
-  host._storageChangeHandler = (changes) => {
-    if (!changes.theme) return;
-    const raw = changes.theme.newValue || 'auto';
-    const theme = (raw === 'light' || raw === 'dark') ? raw
-      : window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  host._themeCleanup = watchThemeChanges((theme) => {
     style.textContent = getToolbarStyles(theme);
-  };
-  chrome.storage.onChanged.addListener(host._storageChangeHandler);
+  });
 
   // --- Event handlers ---
   toolbar.addEventListener('mouseenter', () => {
@@ -526,8 +521,8 @@ export function hideTrigger() {
   }
   const host = document.getElementById('dobby-ai-toolbar-host');
   if (host) {
-    if (host._storageChangeHandler) {
-      chrome.storage.onChanged.removeListener(host._storageChangeHandler);
+    if (host._themeCleanup) {
+      host._themeCleanup();
     }
     host.remove();
   }

--- a/src/content/trigger/styles.js
+++ b/src/content/trigger/styles.js
@@ -23,8 +23,10 @@ export function getToolbarStyles(theme) {
       background: ${isDark ? 'rgba(28, 25, 38, 0.82)' : 'rgba(255, 255, 255, 0.82)'};
       backdrop-filter: blur(12px) saturate(180%);
       -webkit-backdrop-filter: blur(12px) saturate(180%);
-      border: 1px solid ${isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.08)'};
-      box-shadow: 0 2px 12px ${isDark ? 'rgba(0,0,0,0.4)' : 'rgba(0,0,0,0.15)'};
+      border: none;
+      box-shadow:
+        inset 0 0 0 1px ${isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.08)'},
+        0 2px 12px ${isDark ? 'rgba(0,0,0,0.4)' : 'rgba(0,0,0,0.15)'};
       cursor: pointer;
       user-select: none;
       transition: width 0.22s cubic-bezier(0.4,0,0.2,1),

--- a/src/options.js
+++ b/src/options.js
@@ -8,9 +8,35 @@ const hasKeySection = document.getElementById('has-key');
 const noKeySection = document.getElementById('no-key');
 const keyDisplay = document.getElementById('key-display');
 const versionEl = document.getElementById('extension-version');
+const COLOR_SCHEME_QUERY = '(prefers-color-scheme: dark)';
+let themeMode = 'auto';
 
 if (versionEl && chrome.runtime.getManifest) {
   versionEl.textContent = `v${chrome.runtime.getManifest().version}`;
+}
+
+function normalizeThemeMode(value) {
+  return value === 'light' || value === 'dark' || value === 'auto' ? value : 'auto';
+}
+
+function getSystemTheme() {
+  if (typeof window.matchMedia === 'function') {
+    return window.matchMedia(COLOR_SCHEME_QUERY).matches ? 'dark' : 'light';
+  }
+  return 'light';
+}
+
+function resolveTheme(value) {
+  const mode = normalizeThemeMode(value);
+  return mode === 'auto' ? getSystemTheme() : mode;
+}
+
+function applyTheme(value) {
+  themeMode = normalizeThemeMode(value);
+  const resolvedTheme = resolveTheme(themeMode);
+  document.documentElement.dataset.themeMode = themeMode;
+  document.documentElement.dataset.resolvedTheme = resolvedTheme;
+  document.documentElement.style.colorScheme = resolvedTheme;
 }
 
 function maskKey(key) {
@@ -33,13 +59,33 @@ function showNoKey() {
 }
 
 // Load current state
-chrome.storage.local.get(['userApiKey'], (result) => {
+chrome.storage.local.get(['userApiKey', 'theme'], (result) => {
+  applyTheme(result.theme || 'auto');
   if (result.userApiKey) {
     showHasKey(result.userApiKey);
   } else {
     showNoKey();
   }
 });
+
+if (typeof chrome.storage.onChanged?.addListener === 'function') {
+  chrome.storage.onChanged.addListener((changes, areaName) => {
+    if (areaName && areaName !== 'local') return;
+    if (changes.theme) applyTheme(changes.theme.newValue);
+  });
+}
+
+if (typeof window.matchMedia === 'function') {
+  const colorSchemeQuery = window.matchMedia(COLOR_SCHEME_QUERY);
+  const handleSystemThemeChange = () => {
+    if (themeMode === 'auto') applyTheme('auto');
+  };
+  if (typeof colorSchemeQuery.addEventListener === 'function') {
+    colorSchemeQuery.addEventListener('change', handleSystemThemeChange);
+  } else if (typeof colorSchemeQuery.addListener === 'function') {
+    colorSchemeQuery.addListener(handleSystemThemeChange);
+  }
+}
 
 // Save key
 saveBtn.addEventListener('click', async () => {

--- a/src/popup.js
+++ b/src/popup.js
@@ -16,9 +16,36 @@ const usagePrimary = document.getElementById('usage-primary');
 const usageSecondary = document.getElementById('usage-secondary');
 const versionEl = document.getElementById('version');
 const themeOptions = document.querySelectorAll('.theme-option');
+const COLOR_SCHEME_QUERY = '(prefers-color-scheme: dark)';
+let themeMode = 'auto';
+let colorSchemeQuery = null;
 
 function getUtcDay() {
   return new Date().toISOString().split('T')[0];
+}
+
+function normalizeThemeMode(value) {
+  return value === 'light' || value === 'dark' || value === 'auto' ? value : 'auto';
+}
+
+function getSystemTheme() {
+  if (typeof window.matchMedia === 'function') {
+    return window.matchMedia(COLOR_SCHEME_QUERY).matches ? 'dark' : 'light';
+  }
+  return 'light';
+}
+
+function resolveTheme(value) {
+  const mode = normalizeThemeMode(value);
+  return mode === 'auto' ? getSystemTheme() : mode;
+}
+
+function applyTheme(value) {
+  themeMode = normalizeThemeMode(value);
+  const resolvedTheme = resolveTheme(themeMode);
+  document.documentElement.dataset.themeMode = themeMode;
+  document.documentElement.dataset.resolvedTheme = resolvedTheme;
+  document.documentElement.style.colorScheme = resolvedTheme;
 }
 
 function getResetTimeLabel() {
@@ -99,6 +126,7 @@ function loadPopupState() {
     setSwitchState(screenshotToggle, screenshotStatus, data.screenshotEnabled !== false);
     setSwitchState(autosuggestToggle, autosuggestStatus, data.autosuggestEnabled === true);
     setActiveThemeOption(data.theme || 'auto');
+    applyTheme(data.theme || 'auto');
     renderUsage({ userApiKey: data.userApiKey, dobbyUsage: data.dobbyUsage });
     setHistoryState(data.chatHistory || []);
   });
@@ -177,5 +205,18 @@ themeOptions.forEach((btn) => {
     const value = btn.dataset.theme;
     chrome.storage.local.set({ theme: value });
     setActiveThemeOption(value);
+    applyTheme(value);
   });
 });
+
+if (typeof window.matchMedia === 'function') {
+  colorSchemeQuery = window.matchMedia(COLOR_SCHEME_QUERY);
+  const handleSystemThemeChange = () => {
+    if (themeMode === 'auto') applyTheme('auto');
+  };
+  if (typeof colorSchemeQuery.addEventListener === 'function') {
+    colorSchemeQuery.addEventListener('change', handleSystemThemeChange);
+  } else if (typeof colorSchemeQuery.addListener === 'function') {
+    colorSchemeQuery.addListener(handleSystemThemeChange);
+  }
+}

--- a/tests/bubble.test.js
+++ b/tests/bubble.test.js
@@ -152,19 +152,30 @@ describe('bubble.js', () => {
   });
 
   describe('detectTheme', () => {
+    it('returns stored light or dark theme without checking OS preference', async () => {
+      window.matchMedia = vi.fn(() => ({ matches: false }));
+      chrome.storage.local.get = vi.fn((key, cb) => cb({ theme: 'dark' }));
+
+      expect(await detectTheme()).toBe('dark');
+      expect(window.matchMedia).not.toHaveBeenCalled();
+    });
+
     it('returns light when OS prefers light', async () => {
+      chrome.storage.local.get = vi.fn((key, cb) => cb({}));
       window.matchMedia = vi.fn(() => ({ matches: false }));
       expect(await detectTheme()).toBe('light');
       expect(window.matchMedia).toHaveBeenCalledWith('(prefers-color-scheme: dark)');
     });
 
     it('returns dark when OS prefers dark', async () => {
+      chrome.storage.local.get = vi.fn((key, cb) => cb({}));
       window.matchMedia = vi.fn(() => ({ matches: true }));
       expect(await detectTheme()).toBe('dark');
       expect(window.matchMedia).toHaveBeenCalledWith('(prefers-color-scheme: dark)');
     });
 
     it('defaults to light when matchMedia unavailable', async () => {
+      chrome.storage.local.get = vi.fn((key, cb) => cb({}));
       const original = window.matchMedia;
       window.matchMedia = undefined;
       expect(await detectTheme()).toBe('light');

--- a/tests/options.test.js
+++ b/tests/options.test.js
@@ -45,6 +45,20 @@ const noKeySection = document.getElementById('no-key');
 const keyDisplay = document.getElementById('key-display');
 
 describe('options.js', () => {
+  describe('theme', () => {
+    it('applies stored dark theme to the settings page', () => {
+      storageGetCallback({ theme: 'dark' });
+      expect(document.documentElement.dataset.themeMode).toBe('dark');
+      expect(document.documentElement.dataset.resolvedTheme).toBe('dark');
+    });
+
+    it('defaults to resolved light theme when no theme is stored', () => {
+      storageGetCallback({});
+      expect(document.documentElement.dataset.themeMode).toBe('auto');
+      expect(document.documentElement.dataset.resolvedTheme).toBe('light');
+    });
+  });
+
   describe('maskKey', () => {
     it('returns dots for short keys (less than 12 chars)', () => {
       // Load with a short key to see masking

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -11,6 +11,9 @@ function currentUtcDay() {
 }
 
 function setupDom() {
+  document.documentElement.removeAttribute('data-theme-mode');
+  document.documentElement.removeAttribute('data-resolved-theme');
+  document.documentElement.style.colorScheme = '';
   document.body.innerHTML = `
     <div id="version"></div>
     <div id="usage-card" class="usage-card">
@@ -281,12 +284,41 @@ describe('popup.js', () => {
       expect(options[0].classList.contains('active')).toBe(false);
       expect(options[1].classList.contains('active')).toBe(true);
       expect(options[2].classList.contains('active')).toBe(false);
+      expect(document.documentElement.dataset.themeMode).toBe('light');
+      expect(document.documentElement.dataset.resolvedTheme).toBe('light');
     });
 
     it('persists theme to chrome.storage on click', () => {
       vi.clearAllMocks();
       document.querySelector('.theme-option[data-theme="dark"]').click();
       expect(chrome.storage.local.set).toHaveBeenCalledWith({ theme: 'dark' });
+      expect(document.documentElement.dataset.themeMode).toBe('dark');
+      expect(document.documentElement.dataset.resolvedTheme).toBe('dark');
+    });
+
+    it('resolves auto theme from OS preference', async () => {
+      window.matchMedia = vi.fn(() => ({ matches: true }));
+      await loadPopup({ theme: 'auto' });
+      expect(document.documentElement.dataset.themeMode).toBe('auto');
+      expect(document.documentElement.dataset.resolvedTheme).toBe('dark');
+    });
+
+    it('updates auto theme when the OS color scheme changes', async () => {
+      let mediaHandler;
+      const mediaQuery = {
+        matches: false,
+        addEventListener: vi.fn((event, handler) => {
+          if (event === 'change') mediaHandler = handler;
+        }),
+      };
+      window.matchMedia = vi.fn(() => mediaQuery);
+
+      await loadPopup({ theme: 'auto' });
+      expect(document.documentElement.dataset.resolvedTheme).toBe('light');
+
+      mediaQuery.matches = true;
+      mediaHandler();
+      expect(document.documentElement.dataset.resolvedTheme).toBe('dark');
     });
   });
 });


### PR DESCRIPTION
## What changed
- make explicit Light and Dark settings apply across the popup, settings page, floating toolbar, and response bubble
- keep Auto mode synchronized with operating-system color-scheme changes
- centralize content-script theme resolution and clean up live listeners when UI surfaces close
- keep the 36px toolbar logo mathematically centered by rendering its outline as an inset shadow instead of a layout-affecting border
- add regression coverage for stored themes, Auto resolution, and live OS changes

## Root cause
The popup and settings page styled themselves directly from `prefers-color-scheme`, so saved Light/Dark choices did not control every visual surface. Content-script surfaces also did not react when the OS scheme changed while Auto was selected. Separately, the toolbar's 1px border reduced its content box and shifted the centered logo relative to the outer circle.

## Impact
Theme selection now behaves consistently across every extension-owned surface, and the toolbar mark remains exactly centered in collapsed and expanded states.

## Validation
- `npm test` (603 tests passed)
- `npm run build`
- local visual verification of popup, settings, collapsed/expanded toolbar, and response bubble in Light, Dark, and Auto override cases
