### PR TITLE
Release v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to Dobby AI (formerly Ask AI) will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2] - 2026-06-07
+
+### Changed
+- Added scalable Dobby AI SVG logo assets for docs, README, popup, options, and reusable brand placements.
+- Updated the icon generation pipeline to produce SVG masters, Chrome extension PNG icons, docs copies, and bundled brand data from the approved source artwork.
+- Centralized semantic UI colors and shared theme resolution so future palette changes can be made from one source.
+- Applied the Hearthlight ivory, amber, walnut, and graphite palette across light and dark modes.
+
+### Fixed
+- Fixed light, dark, and auto theme propagation across popup, options, toolbar, and response bubble surfaces.
+- Centered the Dobby logo consistently in collapsed and expanded toolbar states.
+
 ## [1.2.1] - 2026-05-27
 
 ### Changed
@@ -99,6 +111,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Page context injection (title + URL)
 - CI/CD workflows (tests, coverage, security, release, PR preview, permission guard)
 
+[1.2.2]: https://github.com/Duobi-AI/dobby-ai/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/Duobi-AI/dobby-ai/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/Duobi-AI/dobby-ai/compare/v1.1.0...v1.2.0
 [2.1.0]: https://github.com/Duobi-AI/dobby-ai/compare/v2.0.0...v2.1.0

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/Duobi-AI/dobby-ai/actions/workflows/ci.yml"><img src="https://github.com/Duobi-AI/dobby-ai/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://github.com/Duobi-AI/dobby-ai/actions/workflows/security.yml"><img src="https://github.com/Duobi-AI/dobby-ai/actions/workflows/security.yml/badge.svg" alt="Security"></a>
   <a href="https://github.com/Duobi-AI/dobby-ai/actions/workflows/coverage.yml"><img src="https://github.com/Duobi-AI/dobby-ai/actions/workflows/coverage.yml/badge.svg" alt="Coverage"></a>
-  <img src="https://img.shields.io/badge/version-1.2.1-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-1.2.2-blue" alt="Version">
   <img src="https://img.shields.io/badge/manifest-v3-green" alt="Manifest V3">
   <a href="https://github.com/Duobi-AI/dobby-ai/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-yellow" alt="License"></a>
   <a href="https://chromewebstore.google.com/detail/fobblgpebpnelefaneijkpbcljdlofoo?utm_source=item-share-cb"><img src="https://img.shields.io/badge/chrome-web%20store-orange?logo=googlechrome&logoColor=white" alt="Chrome Web Store"></a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -836,7 +836,7 @@
       <div class="hero-inner">
         <div class="hero-badge">
           <span class="dot"></span>
-          Free Chrome Extension &mdash; v1.1.0
+          Free Chrome Extension &mdash; v1.2.2
         </div>
         <div class="hero-logo">
           <img src="images/dobby-logo.svg" alt="Dobby AI" width="88" height="88">

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dobby AI",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Select text and get instant AI explanations inline on any page",
   "permissions": ["contextMenus", "activeTab", "storage", "notifications"],
   "host_permissions": [

--- a/options.html
+++ b/options.html
@@ -130,7 +130,7 @@
       <img src="icons/dobby-logo-mark.svg" alt="Dobby AI">
       <div>
         <h1>Dobby AI</h1>
-        <div class="version" id="extension-version">v1.2.1</div>
+        <div class="version" id="extension-version">v1.2.2</div>
       </div>
     </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dobby-ai",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dobby-ai",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "devDependencies": {
         "@playwright/test": "^1.58.2",
         "@vitest/coverage-v8": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dobby-ai",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "description": "Select text or screenshot any region on the web — get instant AI answers right where you are",
   "scripts": {


### PR DESCRIPTION
## Release v1.2.2

**Previous version:** `1.2.1`
**New version:** `1.2.2`
**Release date:** `2026-06-07`

### Included changes

- scalable Dobby AI SVG logo assets and updated icon generation pipeline
- corrected light, dark, and auto theme propagation across extension surfaces
- centered toolbar logo in collapsed and expanded states
- centralized semantic color tokens and shared theme resolution
- applied the Hearthlight color palette

### Release checklist

- [x] Version numbers consistent in `manifest.json`, `package.json`, `package-lock.json`, options, README, and docs
- [x] Changelog reviewed against commits since `v1.2.1`
- [x] Build passed
- [x] Extension tests passed: 608
- [x] Proxy tests passed: 75
- [x] Browser E2E tests passed: 23
- [x] Release ZIP validated: 866 KB
- [x] Confirmed `v1.2.2` tag does not already exist
- [ ] Merge release PR
- [ ] Tag merged commit as `v1.2.2` to create the GitHub release and trigger optional Chrome Web Store publishing

### Known development-tooling advisory

`npm audit` reports GHSA-5xrq-8626-4rwp in Vitest 3.x. Vitest is a development-only dependency and is not included in the extension ZIP. The available fix upgrades to Vitest 4 and should be handled separately because it is a breaking toolchain upgrade.