### PR TITLE
[codex] Fix Dobby input shortcut conflicts

### DIFF
--- a/e2e/extension.spec.js
+++ b/e2e/extension.spec.js
@@ -1,6 +1,6 @@
 // e2e/extension.spec.js — Extension loads and basic functionality
 const { test, expect } = require('@playwright/test');
-const { launchExtension, selectText, waitForToolbar } = require('./helpers');
+const { launchExtension, selectText, waitForToolbar, hoverToolbar } = require('./helpers');
 
 let context, extensionId, page;
 
@@ -28,6 +28,35 @@ test('toolbar hides when selection is cleared', async () => {
   await page.click('body', { position: { x: 10, y: 10 } });
   await page.waitForTimeout(300);
   await expect(toolbar).not.toBeVisible();
+});
+
+test('toolbar input isolates typing from page shortcuts', async () => {
+  await selectText(page, 'h1');
+  await waitForToolbar(page);
+  await hoverToolbar(page);
+
+  await page.evaluate(() => {
+    window.__dobbyShortcutCount = 0;
+    window.__dobbyShortcutHandler = (event) => {
+      if (event.key === 's') window.__dobbyShortcutCount += 1;
+    };
+    document.addEventListener('keydown', window.__dobbyShortcutHandler);
+
+    const host = document.getElementById('dobby-ai-toolbar-host');
+    host.shadowRoot.querySelector('.toolbar-pencil').click();
+  });
+
+  const input = page.locator('#dobby-ai-toolbar-host').locator('.toolbar-input-field');
+  await input.press('s');
+
+  await expect(input).toHaveValue('s');
+  expect(await page.evaluate(() => window.__dobbyShortcutCount)).toBe(0);
+
+  await page.evaluate(() => {
+    document.removeEventListener('keydown', window.__dobbyShortcutHandler);
+    delete window.__dobbyShortcutHandler;
+    delete window.__dobbyShortcutCount;
+  });
 });
 
 test('popup page loads and toggle works', async () => {

--- a/src/content/bubble/core.js
+++ b/src/content/bubble/core.js
@@ -8,7 +8,7 @@ import {
   clearRawResponses,
 } from '../shared/state.js';
 import { Z_INDEX, TIMING } from '../shared/constants.js';
-import { removeElement } from '../shared/dom-utils.js';
+import { removeElement, stopShadowRootKeyboardEventPropagation } from '../shared/dom-utils.js';
 import { detectTheme, watchThemeChanges } from '../../shared/theme.js';
 import { getStyles } from './styles.js';
 import { renderMarkdown, escapeHtml } from './markdown.js';
@@ -253,6 +253,10 @@ async function initBubble(selectionRect, selectedText, previewLabel, showPresets
   createBubbleHost(selectionRect);
   bubbleHost._isPinned = false;
   const shadow = bubbleHost.attachShadow({ mode: 'open' });
+  stopShadowRootKeyboardEventPropagation(shadow);
+  shadow.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') hideBubble();
+  });
 
   const style = document.createElement('style');
   style.textContent = getStyles(await detectTheme());

--- a/src/content/shared/dom-utils.js
+++ b/src/content/shared/dom-utils.js
@@ -4,6 +4,15 @@ export function removeElement(el) {
   if (el?.parentNode) el.parentNode.removeChild(el);
 }
 
+export function stopShadowRootKeyboardEventPropagation(shadowRoot) {
+  for (const eventType of ['keydown', 'keypress', 'keyup']) {
+    shadowRoot.addEventListener(eventType, (event) => {
+      // Keep composed keyboard events from reaching host-page bubble listeners.
+      event.stopPropagation();
+    });
+  }
+}
+
 export function isClickInsideUI(target, getBubbleContainer) {
   const trigger = document.getElementById('dobby-ai-trigger');
   if (trigger?.contains(target)) return true;

--- a/src/content/trigger/button.js
+++ b/src/content/trigger/button.js
@@ -17,6 +17,7 @@ import { getSuggestedPresetsForType } from '../presets.js';
 import { captureImage } from '../image-capture.js';
 import { recordPresetUsage, buildTypeKey } from '../shared/preset-usage.js';
 import { BRAND_MARK_DATA_URI, BRAND_NAME } from '../../shared/brand.js';
+import { stopShadowRootKeyboardEventPropagation } from '../shared/dom-utils.js';
 
 const pencilSvg = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/><path d="m15 5 4 4"/></svg>`;
 const closeSvg = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>`;
@@ -56,6 +57,7 @@ async function createToolbar() {
   });
 
   const shadow = host.attachShadow({ mode: 'open', delegatesFocus: true });
+  stopShadowRootKeyboardEventPropagation(shadow);
 
   // Inject styles
   const style = document.createElement('style');

--- a/tests/bubble.test.js
+++ b/tests/bubble.test.js
@@ -194,6 +194,22 @@ describe('bubble.js', () => {
       input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
       expect(promptModule.buildFollowUp).toHaveBeenCalled();
     });
+
+    it('keeps typing shortcuts from reaching the host page', async () => {
+      await showBubble({ bottom: 100, left: 50, right: 250 }, [{ role: 'user', content: 'hi' }]);
+      const input = _getBubbleContainer().shadowRoot.querySelector('.follow-up-input');
+      const pageShortcut = vi.fn();
+      document.addEventListener('keydown', pageShortcut);
+
+      input.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 's',
+        bubbles: true,
+        composed: true,
+      }));
+
+      expect(pageShortcut).not.toHaveBeenCalled();
+      document.removeEventListener('keydown', pageShortcut);
+    });
   });
 
   describe('history preview', () => {
@@ -315,6 +331,17 @@ describe('bubble.js', () => {
       await showBubble({ bottom: 100, left: 50, right: 250 }, []);
       expect(_getBubbleContainer()).not.toBeNull();
       document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      expect(_getBubbleContainer()).toBeNull();
+    });
+
+    it('closes bubble on Escape from inside its shadow root', async () => {
+      await showBubble({ bottom: 100, left: 50, right: 250 }, []);
+      const input = _getBubbleContainer().shadowRoot.querySelector('.follow-up-input');
+      input.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        composed: true,
+      }));
       expect(_getBubbleContainer()).toBeNull();
     });
   });

--- a/tests/dom-utils.test.js
+++ b/tests/dom-utils.test.js
@@ -3,7 +3,13 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { removeElement, isClickInsideUI, getSelectedText, getSelectionRect } = await import('../src/content/shared/dom-utils.js');
+const {
+  removeElement,
+  stopShadowRootKeyboardEventPropagation,
+  isClickInsideUI,
+  getSelectedText,
+  getSelectionRect,
+} = await import('../src/content/shared/dom-utils.js');
 
 beforeEach(() => {
   document.body.innerHTML = '';
@@ -28,6 +34,49 @@ describe('removeElement', () => {
 
   it('is safe when called with undefined', () => {
     expect(() => removeElement(undefined)).not.toThrow();
+  });
+});
+
+describe('stopShadowRootKeyboardEventPropagation', () => {
+  it.each(['keydown', 'keypress', 'keyup'])('keeps %s events inside the shadow root', (eventType) => {
+    const host = document.createElement('div');
+    const shadow = host.attachShadow({ mode: 'open' });
+    const input = document.createElement('input');
+    shadow.appendChild(input);
+    document.body.appendChild(host);
+
+    const inputListener = vi.fn();
+    const pageListener = vi.fn();
+    input.addEventListener(eventType, inputListener);
+    document.addEventListener(eventType, pageListener);
+    stopShadowRootKeyboardEventPropagation(shadow);
+
+    input.dispatchEvent(new KeyboardEvent(eventType, {
+      key: 's',
+      bubbles: true,
+      composed: true,
+    }));
+
+    expect(inputListener).toHaveBeenCalledOnce();
+    expect(pageListener).not.toHaveBeenCalled();
+    document.removeEventListener(eventType, pageListener);
+  });
+
+  it('does not block non-keyboard events', () => {
+    const host = document.createElement('div');
+    const shadow = host.attachShadow({ mode: 'open' });
+    const button = document.createElement('button');
+    shadow.appendChild(button);
+    document.body.appendChild(host);
+
+    const pageListener = vi.fn();
+    document.addEventListener('click', pageListener);
+    stopShadowRootKeyboardEventPropagation(shadow);
+
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
+
+    expect(pageListener).toHaveBeenCalledOnce();
+    document.removeEventListener('click', pageListener);
   });
 });
 

--- a/tests/toolbar.test.js
+++ b/tests/toolbar.test.js
@@ -346,6 +346,24 @@ describe('input mode', () => {
     expect(sendBtn.classList.contains('disabled')).toBe(false);
   });
 
+  it('keeps typing shortcuts from reaching the host page', async () => {
+    await showTrigger(200, 100, { text: 'test text', anchorNode: null });
+    const shadow = getShadow();
+    shadow.querySelector('.toolbar').dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    shadow.querySelector('.toolbar-pencil').click();
+
+    const pageShortcut = vi.fn();
+    document.addEventListener('keydown', pageShortcut);
+    shadow.querySelector('.toolbar-input-field').dispatchEvent(new KeyboardEvent('keydown', {
+      key: 's',
+      bubbles: true,
+      composed: true,
+    }));
+
+    expect(pageShortcut).not.toHaveBeenCalled();
+    document.removeEventListener('keydown', pageShortcut);
+  });
+
   it('Enter with empty input does not call showBubble', async () => {
     await showTrigger(200, 100, { text: 'test text', anchorNode: null });
     const shadow = getShadow();


### PR DESCRIPTION
## What changed

- Stop composed keyboard events from bubbling out of Dobby's toolbar and bubble ShadowRoots.
- Preserve Dobby's internal Enter and Escape behavior.
- Add unit coverage for toolbar and follow-up inputs.
- Add a real Chromium regression test that simulates a GitHub-style page shortcut.

## Root cause

Keyboard events from inputs inside Shadow DOM are composed and retargeted to the Shadow host when they reach the page. Host-page shortcut handlers can therefore see Dobby typing as page-level keyboard commands.

## Impact

Typing in Dobby's custom prompt and follow-up inputs no longer activates common host-page bubble-phase shortcuts.

## Validation

- `npm test` — 615 tests passed
- `npm run build` — passed
- `npx playwright test` — 24 tests passed
- `git diff --check` — passed