### PR TITLE
[codex] Add non-invasive TypeScript infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
           node-version-file: .nvmrc
           cache: 'npm'
       - run: npm ci
+      - run: npm run typecheck
       - run: npm run build
       - run: npm test
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "1.2.2",
       "devDependencies": {
         "@playwright/test": "^1.58.2",
+        "@types/chrome": "^0.1.43",
         "@vitest/coverage-v8": "^3.2.4",
         "esbuild": "^0.27.4",
         "jsdom": "^28.1.0",
         "playwright": "^1.58.2",
+        "typescript": "^6.0.3",
         "vitest": "^3.0.0"
       }
     },
@@ -1195,6 +1197,17 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/chrome": {
+      "version": "0.1.43",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.1.43.tgz",
+      "integrity": "sha512-ukH/HhmR6ht+UTX3PLUWJxgJ/RQcK2Foj4lBzsF24SIWsXgqhGuXqjd8FFuwioPP7d/JUKLM4g8GZxw3F4HTcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1206,6 +1219,30 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/filesystem": {
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.36.tgz",
+      "integrity": "sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filewriter": "*"
+      }
+    },
+    "node_modules/@types/filewriter": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.33.tgz",
+      "integrity": "sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/har-format": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.16.tgz",
+      "integrity": "sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==",
       "dev": true,
       "license": "MIT"
     },
@@ -2704,6 +2741,20 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici": {

--- a/package.json
+++ b/package.json
@@ -8,14 +8,17 @@
     "dev": "node esbuild.config.js --watch",
     "test": "vitest run",
     "test:e2e": "npm run build && npx playwright test",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",
+    "@types/chrome": "^0.1.43",
     "@vitest/coverage-v8": "^3.2.4",
     "esbuild": "^0.27.4",
     "jsdom": "^28.1.0",
     "playwright": "^1.58.2",
+    "typescript": "^6.0.3",
     "vitest": "^3.0.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable", "WebWorker"],
+    "types": ["chrome"],
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true,
+    "strict": false,
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/**/*.js",
+    "src/**/*.ts",
+    "proxy/src/**/*.js",
+    "proxy/src/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

- add TypeScript and Chrome extension type definitions as development dependencies
- add a gradual-migration `tsconfig.json` that keeps JavaScript enabled, disables JavaScript checking, and emits no files
- add `npm run typecheck` and run it in the main CI test job

## Compatibility

This PR does not rename or modify production source files. It does not change the extension build configuration, manifest, HTML, runtime messages, storage shapes, DOM structure, or proxy behavior.

## Validation

- `npm ci`
- `npm run typecheck`
- `npm run build`
- `npm test` — 615 passed
- `npm run test:e2e` — 24 passed
- `git diff --check`

Closes #163