### PR TITLE
Release v1.2.3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,14 @@
 {
   "manifest_version": 3,
   "name": "Dobby AI",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Select text and get instant AI explanations inline on any page",
-  "permissions": ["contextMenus", "activeTab", "storage", "notifications"],
+  "permissions": [
+    "contextMenus",
+    "activeTab",
+    "storage",
+    "notifications"
+  ],
   "host_permissions": [
     "https://dobby-ai-proxy.zhongnansu.workers.dev/*",
     "https://api.openai.com/*",
@@ -12,10 +17,16 @@
   "background": {
     "service_worker": "background.js"
   },
-  "content_scripts": [{
-    "matches": ["<all_urls>"],
-    "js": ["content.js"]
-  }],
+  "content_scripts": [
+    {
+      "matches": [
+        "<all_urls>"
+      ],
+      "js": [
+        "content.js"
+      ]
+    }
+  ],
   "action": {
     "default_popup": "popup.html",
     "default_icon": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dobby-ai",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "description": "Select text or screenshot any region on the web — get instant AI answers right where you are",
   "scripts": {


### PR DESCRIPTION
## Release v1.2.3

**Bump type:** `patch`
**Previous version:** `1.2.2`
**New version:** `1.2.3`
**Last tag:** `v1.2.2`

### Changes since last tag

- `e5923a0` Fix Dobby input shortcut conflicts
- `a0e0498` Retry transient Chrome Web Store publishes (#161)

### Release checklist

- [x] Version numbers correct in `manifest.json` and `package.json`
- [ ] All tests passing
- [ ] Manual smoke/E2E test completed
- [ ] Ready for Chrome Web Store

The Version Bump workflow created this branch successfully but could not create the PR because GitHub Actions is not permitted to create pull requests.