### PR TITLE
[codex] Define shared TypeScript contracts

### DIFF
--- a/src/shared/types/ai.ts
+++ b/src/shared/types/ai.ts
@@ -1,0 +1,44 @@
+export type ChatRole = 'system' | 'user' | 'assistant';
+
+export type TextContentPart = {
+  type: 'text';
+  text: string;
+};
+
+export type ImageContentPart = {
+  type: 'image_url';
+  image_url: {
+    url: string;
+  };
+};
+
+export type ChatContentPart = TextContentPart | ImageContentPart;
+export type ChatContent = string | ChatContentPart[];
+
+export type ChatMessage = {
+  role: ChatRole;
+  content: ChatContent;
+};
+
+export type ProxyPurpose = 'chat' | 'autosuggest';
+
+export type ProxyChatPayload = {
+  messages: ChatMessage[];
+  signature: string;
+  timestamp: number;
+  purpose?: ProxyPurpose;
+};
+
+export type StreamRequestHandle = {
+  cancel: () => void;
+};
+
+export type ChatUsageInfo = {
+  remaining: number | null;
+  usingOwnKey: boolean;
+};
+
+export type RateLimitInfo = {
+  remaining: number;
+  resetAt?: string | number;
+};

--- a/src/shared/types/content.ts
+++ b/src/shared/types/content.ts
@@ -1,0 +1,80 @@
+export type ThemeMode = 'auto' | 'light' | 'dark';
+export type ResolvedTheme = Exclude<ThemeMode, 'auto'>;
+
+export type ContentType =
+  | 'code'
+  | 'foreign'
+  | 'error'
+  | 'math'
+  | 'data'
+  | 'email'
+  | 'long'
+  | 'default'
+  | 'image';
+
+export type CodeSubtype =
+  | 'javascript'
+  | 'python'
+  | 'rust'
+  | 'go'
+  | 'sql'
+  | 'java'
+  | 'c/c++'
+  | 'ruby'
+  | 'php';
+
+export type ForeignSubtype =
+  | 'japanese'
+  | 'chinese'
+  | 'korean'
+  | 'arabic'
+  | 'russian'
+  | 'hindi'
+  | 'thai';
+
+export type ContentSubtype = CodeSubtype | ForeignSubtype | null;
+
+export type DetectionResult = {
+  type: ContentType;
+  subType: ContentSubtype;
+  confidence: number | 'high';
+  wordCount?: number;
+  charCount?: number;
+};
+
+export type Preset = {
+  label: string;
+  instruction: string;
+};
+
+export type PresetGroup = {
+  suggested: Preset[];
+  all?: Preset[];
+};
+
+export type PresetUsage = Record<string, Record<string, number>>;
+
+export type AutosuggestPageContext = {
+  pageTitle?: string;
+  pageUrl?: string;
+  fieldHint?: string;
+  fieldLabel?: string;
+  formFields?: string[];
+  surroundingText?: string;
+};
+
+export type CaptureRect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export type SelectionRect = {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+  width?: number;
+  height?: number;
+};

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -1,0 +1,5 @@
+export type * from './ai';
+export type * from './content';
+export type * from './messages';
+export type * from './storage';
+export type * from './ui';

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -1,0 +1,118 @@
+import type { ChatMessage } from './ai';
+
+export type ToggleMessageType =
+  | 'DOBBY_TOGGLE'
+  | 'SCREENSHOT_TOGGLE'
+  | 'AUTOSUGGEST_TOGGLE';
+
+export type ToggleMessage = {
+  type: ToggleMessageType;
+  enabled: boolean;
+};
+
+export type ShowHistoryMessage = {
+  type: 'SHOW_HISTORY';
+};
+
+export type ShowBubbleTextMessage = {
+  type: 'SHOW_BUBBLE';
+  text: string;
+  image?: never;
+};
+
+export type ShowBubbleImageMessage = {
+  type: 'SHOW_BUBBLE';
+  image: string;
+  text?: never;
+};
+
+export type ContentRuntimeMessage =
+  | ToggleMessage
+  | ShowHistoryMessage
+  | ShowBubbleTextMessage
+  | ShowBubbleImageMessage;
+
+export type CaptureScreenshotMessage = {
+  type: 'CAPTURE_SCREENSHOT';
+};
+
+export type OpenOptionsMessage = {
+  type: 'OPEN_OPTIONS';
+};
+
+export type ValidateApiKeyMessage = {
+  type: 'VALIDATE_API_KEY';
+  apiKey: string;
+};
+
+export type BackgroundRuntimeMessage =
+  | CaptureScreenshotMessage
+  | OpenOptionsMessage
+  | ValidateApiKeyMessage;
+
+export type RuntimeMessage = ContentRuntimeMessage | BackgroundRuntimeMessage;
+
+export type CaptureScreenshotResponse = {
+  dataUrl?: string;
+  error?: string;
+};
+
+export type ValidateApiKeyResponse =
+  | { valid: true }
+  | { valid: false; error: string };
+
+export type StreamPortName = 'chat-stream' | 'autosuggest-stream';
+
+export type ChatStreamRequest = {
+  type: 'CHAT_REQUEST';
+  messages: ChatMessage[];
+};
+
+export type AutosuggestStreamRequest = {
+  type: 'AUTOSUGGEST_REQUEST';
+  messages: ChatMessage[];
+};
+
+export type StreamTokenMessage = {
+  type: 'token';
+  text: string;
+};
+
+export type StreamErrorMessage = {
+  type: 'error';
+  code: number;
+  message: string;
+};
+
+export type ChatStreamDoneMessage = {
+  type: 'done';
+  remaining: number | null;
+  usingOwnKey: boolean;
+};
+
+export type AutosuggestStreamDoneMessage = {
+  type: 'done';
+};
+
+export type ChatRateLimitedMessage = {
+  type: 'rate_limited';
+  remaining: number;
+  resetAt?: string | number;
+};
+
+export type AutosuggestRateLimitedMessage = {
+  type: 'rate_limited';
+  remaining: number;
+};
+
+export type ChatStreamResponse =
+  | StreamTokenMessage
+  | StreamErrorMessage
+  | ChatStreamDoneMessage
+  | ChatRateLimitedMessage;
+
+export type AutosuggestStreamResponse =
+  | StreamTokenMessage
+  | StreamErrorMessage
+  | AutosuggestStreamDoneMessage
+  | AutosuggestRateLimitedMessage;

--- a/src/shared/types/storage.ts
+++ b/src/shared/types/storage.ts
@@ -1,0 +1,50 @@
+import type { PresetUsage, ThemeMode } from './content';
+
+export type UsageRequestKind = 'chat' | 'autosuggest' | 'screenshot';
+
+export type UsageState = {
+  day: string;
+  chatRequests: number;
+  autosuggestRequests: number;
+  screenshotRequests: number;
+  freeChatRemaining: number | null;
+  usingOwnKey: boolean;
+  lastUpdated: number;
+};
+
+export type UsageUpdateDetails = {
+  remaining?: number | null;
+  usingOwnKey?: boolean;
+  rateLimited?: boolean;
+};
+
+export type HistoryEntryDraft = {
+  text?: string;
+  instruction?: string;
+  response?: string | null;
+  pageUrl?: string;
+  pageTitle?: string;
+};
+
+export type HistoryEntry = {
+  id: string;
+  text?: string;
+  instruction?: string;
+  response: string;
+  pageUrl?: string;
+  pageTitle?: string;
+  timestamp: number;
+};
+
+export type StorageState = {
+  dobbyEnabled?: boolean;
+  screenshotEnabled?: boolean;
+  autosuggestEnabled?: boolean;
+  theme?: ThemeMode;
+  userApiKey?: string;
+  dobbyUsage?: UsageState;
+  chatHistory?: HistoryEntry[];
+  presetUsage?: PresetUsage;
+};
+
+export type StorageKey = keyof StorageState;

--- a/src/shared/types/ui.ts
+++ b/src/shared/types/ui.ts
@@ -1,0 +1,68 @@
+import type { ImageContentPart, StreamRequestHandle } from './ai';
+import type { ContentSubtype, ContentType } from './content';
+
+export type Cleanup = () => void;
+export type ToolbarState = 'collapsed' | 'expanded' | 'input' | 'morphed';
+
+export type PreservedSelection = {
+  rangeCount: 1;
+  getRangeAt: (index: 0) => Range;
+};
+
+export type SelectionData = {
+  text?: string;
+  anchorNode?: Node | null;
+  images?: ImageContentPart[] | null;
+  selection?: Selection | PreservedSelection | null;
+};
+
+export interface ToolbarHost extends HTMLDivElement {
+  _themeCleanup?: Cleanup;
+  _detectedType?: ContentType;
+  _detectedSubType?: ContentSubtype;
+  _selectedText?: string;
+  _anchorNode?: Node | null;
+  _images?: ImageContentPart[] | null;
+  _imagesPromise?: Promise<ImageContentPart[] | null> | null;
+  _selectionForImages?: PreservedSelection | null;
+  _selectionRequestId?: number;
+  _isMorphing?: boolean;
+}
+
+export interface BubbleHost extends HTMLDivElement {
+  _isPinned?: boolean;
+  _escHandler?: (event: KeyboardEvent) => void;
+  _themeCleanup?: Cleanup;
+  _dragCleanup?: Cleanup;
+  _resizeCleanup?: Cleanup;
+}
+
+export interface ScreenshotOverlay extends HTMLDivElement {
+  _escHandler?: (event: KeyboardEvent) => void;
+}
+
+export type ScreenshotState = {
+  overlay: ScreenshotOverlay | null;
+  startX: number;
+  startY: number;
+  rect: HTMLDivElement | null;
+  dragStarted: boolean;
+};
+
+export type LongPressState = {
+  timer: ReturnType<typeof setTimeout> | null;
+  startX: number;
+  startY: number;
+  ring: HTMLDivElement | null;
+  ringTimer: ReturnType<typeof setTimeout> | null;
+};
+
+export type ContentScriptState = {
+  bubbleHost: BubbleHost | null;
+  currentRequest: StreamRequestHandle | null;
+  triggerButton: ToolbarHost | null;
+  toolbarHost: ToolbarHost | null;
+  toolbarState: ToolbarState;
+  screenshotState: ScreenshotState;
+  longPressState: LongPressState;
+};


### PR DESCRIPTION
## Summary

- define type-only contracts for chat and multimodal AI messages
- define discriminated unions for Chrome runtime and streaming port messages
- define storage, usage, history, preset, detection, and theme contracts
- define custom toolbar, bubble, screenshot, and content-script state interfaces

## Compatibility

All additions are `export type` declarations under `src/shared/types`. No runtime module imports them in this task, and no JavaScript, manifest, HTML, package, build, proxy, test, or E2E files changed. Unique type-only symbols are absent from generated extension bundles.

## Validation

- `npm run typecheck`
- `npm run build`
- `npm test` — 615 passed
- `npm run test:e2e` — 24 passed
- `git diff --check`

Closes #164