### PR TITLE
[codex] Introduce scoped JavaScript type checking

### DIFF
--- a/src/content/history.js
+++ b/src/content/history.js
@@ -1,3 +1,8 @@
+// @ts-check
+
+/** @typedef {import('../shared/types').HistoryEntry} HistoryEntry */
+/** @typedef {import('../shared/types').HistoryEntryDraft} HistoryEntryDraft */
+
 // history.js — Chat history storage (chrome.storage.local)
 
 export const MAX_HISTORY = 100;
@@ -9,7 +14,7 @@ function generateId() {
 
 /**
  * Save a completed conversation to history.
- * @param {{ text, instruction, response, pageUrl, pageTitle }} entry
+ * @param {HistoryEntryDraft} entry
  * @returns {Promise<void>}
  */
 export function saveConversation(entry) {
@@ -20,7 +25,7 @@ export function saveConversation(entry) {
         resolve();
         return;
       }
-      const history = result.chatHistory || [];
+      const history = /** @type {HistoryEntry[]} */ (result.chatHistory || []);
 
       // Errata #12: null safety for missing response
       const resp = entry.response || '';
@@ -50,7 +55,7 @@ export function saveConversation(entry) {
 
 /**
  * Get all history entries, most recent first.
- * @returns {Promise<Array>}
+ * @returns {Promise<HistoryEntry[]>}
  */
 export function getHistory() {
   return new Promise((resolve) => {
@@ -60,7 +65,7 @@ export function getHistory() {
         resolve([]);
         return;
       }
-      resolve(result.chatHistory || []);
+      resolve(/** @type {HistoryEntry[]} */ (result.chatHistory || []));
     });
   });
 }

--- a/src/content/prompt.js
+++ b/src/content/prompt.js
@@ -1,3 +1,8 @@
+// @ts-check
+
+/** @typedef {import('../shared/types').ChatMessage} ChatMessage */
+/** @typedef {import('../shared/types').ImageContentPart} ImageContentPart */
+
 // prompt.js — OpenAI chat message format
 export const MAX_TEXT_LENGTH = 6000;
 const MAX_INSTRUCTION_LENGTH = 500;
@@ -31,8 +36,8 @@ function buildSourceSuffix(includePageContext) {
  * @param {string} selectedText
  * @param {string} instruction - Preset or custom instruction (can be empty/null)
  * @param {boolean} includePageContext
- * @param {Array} [images] - Optional array of {type: "image_url", image_url: {url}} objects
- * @returns {Array<{role: string, content: string|Array}>}
+ * @param {ImageContentPart[]} [images] - Optional image content objects
+ * @returns {ChatMessage[]}
  */
 export function buildChatMessages(selectedText, instruction, includePageContext, images) {
   const safeInstruction = instruction
@@ -43,6 +48,7 @@ export function buildChatMessages(selectedText, instruction, includePageContext,
   const textBudget = MAX_TEXT_LENGTH - SYSTEM_PROMPT.length - instructionPrefix.length - sourceSuffix.length;
   const text = truncateToBudget(selectedText || '', textBudget);
 
+  /** @type {ChatMessage[]} */
   const messages = [];
 
   // System message sets the assistant's role
@@ -57,6 +63,7 @@ export function buildChatMessages(selectedText, instruction, includePageContext,
 
   // When images are present, build multimodal content array
   if (images && images.length > 0) {
+    /** @type {import('../shared/types').ChatContentPart[]} */
     const contentParts = [];
     // If there's meaningful text, put it first
     if (text.trim()) {
@@ -78,9 +85,9 @@ export function buildChatMessages(selectedText, instruction, includePageContext,
 
 /**
  * Append a follow-up question to an existing conversation.
- * @param {Array} existingMessages
+ * @param {ChatMessage[]} existingMessages
  * @param {string} newQuestion
- * @returns {Array}
+ * @returns {ChatMessage[]}
  */
 export function buildFollowUp(existingMessages, newQuestion) {
   return [...existingMessages, { role: 'user', content: newQuestion }];

--- a/src/content/shared/preset-usage.js
+++ b/src/content/shared/preset-usage.js
@@ -1,7 +1,13 @@
+// @ts-check
+
+/** @typedef {import('../../shared/types').Preset} Preset */
+/** @typedef {import('../../shared/types').PresetUsage} PresetUsage */
+
 // src/content/shared/preset-usage.js — Tracks preset click frequency for reordering
 // Usage data is cached in a module-level variable for instant sync access.
 // Persisted to chrome.storage.local under the key "presetUsage".
 
+/** @type {PresetUsage} */
 let usageCache = {};
 
 /**
@@ -21,7 +27,7 @@ export function buildTypeKey(type, subType) {
 export function loadUsageData() {
   try {
     chrome.storage.local.get('presetUsage', (data) => {
-      usageCache = (data && data.presetUsage) || {};
+      usageCache = /** @type {PresetUsage} */ ((data && data.presetUsage) || {});
     });
   } catch {
     // Graceful fallback — storage unavailable in some contexts
@@ -52,9 +58,9 @@ export function recordPresetUsage(typeKey, label) {
 /**
  * Returns presets reordered by usage frequency if any preset has 5+ clicks.
  * Always returns a shallow copy — never mutates the input array.
- * @param {Array<{label: string, instruction: string}>} presets
+ * @param {Preset[]} presets
  * @param {string} typeKey - Key from buildTypeKey()
- * @returns {Array<{label: string, instruction: string}>}
+ * @returns {Preset[]}
  */
 export function getReorderedPresets(presets, typeKey) {
   const usage = usageCache[typeKey];

--- a/src/shared/theme.js
+++ b/src/shared/theme.js
@@ -1,9 +1,16 @@
+// @ts-check
+
+/** @typedef {import('./types').ResolvedTheme} ResolvedTheme */
+/** @typedef {import('./types').ThemeMode} ThemeMode */
+
 export const COLOR_SCHEME_QUERY = '(prefers-color-scheme: dark)';
 
+/** @param {unknown} value @returns {ThemeMode} */
 export function normalizeThemeMode(value) {
   return value === 'light' || value === 'dark' || value === 'auto' ? value : 'auto';
 }
 
+/** @returns {ResolvedTheme} */
 function getSystemTheme() {
   if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
     return window.matchMedia(COLOR_SCHEME_QUERY).matches ? 'dark' : 'light';
@@ -11,11 +18,13 @@ function getSystemTheme() {
   return 'light';
 }
 
+/** @param {unknown} value @returns {ResolvedTheme} */
 export function resolveTheme(value) {
   const mode = normalizeThemeMode(value);
   return mode === 'auto' ? getSystemTheme() : mode;
 }
 
+/** @returns {Promise<ResolvedTheme>} */
 export function detectTheme() {
   return new Promise((resolve) => {
     if (typeof chrome === 'undefined' || !chrome.storage?.local?.get) {
@@ -29,7 +38,12 @@ export function detectTheme() {
   });
 }
 
+/**
+ * @param {(theme: ResolvedTheme) => void} applyTheme
+ * @returns {() => void}
+ */
 export function watchThemeChanges(applyTheme) {
+  /** @type {ThemeMode} */
   let mode = 'auto';
   const mediaQuery = typeof window !== 'undefined' && typeof window.matchMedia === 'function'
     ? window.matchMedia(COLOR_SCHEME_QUERY)


### PR DESCRIPTION
## Summary

- enable `// @ts-check` for theme resolution, prompt construction, history persistence, and preset usage
- reference the shared TypeScript contracts through type-only JSDoc imports
- add compile-time assertions at existing `chrome.storage` boundaries where values are intentionally dynamic

## Compatibility

This PR keeps all files as JavaScript and does not change runtime control flow, exports, message strings, storage keys, payloads, DOM, or build entry points. The only expression-level changes are JSDoc type assertions around existing storage fallback expressions.

## Validation

- `npm run typecheck`
- `npm run build`
- `npm test` — 615 passed
- `npm run test:e2e` — 24 passed
- `git diff --check`

Closes #165