### PR TITLE
[codex] Type Chrome messages, ports, and storage boundaries

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -1,7 +1,24 @@
+// @ts-check
+
 // src/background/index.js — Dobby AI API relay + streaming hub
 // All API calls from content scripts route through here (MV3 cross-origin constraint)
 
 import { AUTOSUGGEST_MAX_SUGGESTION_TOKENS } from '../shared/autosuggest-limits.js';
+import { getLocalStorage, setLocalStorage } from '../shared/storage.js';
+
+/** @typedef {import('../shared/types').AutosuggestBackgroundPort} AutosuggestBackgroundPort */
+/** @typedef {import('../shared/types').AutosuggestStreamRequest} AutosuggestStreamRequest */
+/** @typedef {import('../shared/types').BackgroundRuntimeMessage} BackgroundRuntimeMessage */
+/** @typedef {import('../shared/types').CaptureScreenshotResponse} CaptureScreenshotResponse */
+/** @typedef {import('../shared/types').ChatMessage} ChatMessage */
+/** @typedef {import('../shared/types').ChatBackgroundPort} ChatBackgroundPort */
+/** @typedef {import('../shared/types').ChatStreamRequest} ChatStreamRequest */
+/** @typedef {import('../shared/types').ContentRuntimeMessage} ContentRuntimeMessage */
+/** @typedef {import('../shared/types').ToggleMessageType} ToggleMessageType */
+/** @typedef {import('../shared/types').UsageRequestKind} UsageRequestKind */
+/** @typedef {import('../shared/types').UsageState} UsageState */
+/** @typedef {import('../shared/types').UsageUpdateDetails} UsageUpdateDetails */
+/** @typedef {import('../shared/types').ValidateApiKeyResponse} ValidateApiKeyResponse */
 
 const PROXY_URL = 'https://dobby-ai-proxy.zhongnansu.workers.dev/chat';
 const USAGE_STORAGE_KEY = 'dobbyUsage';
@@ -11,10 +28,12 @@ const HMAC_SECRET = 'dobby-ai-v2-hmac-key-change-in-production';
 // Set to your dev token to bypass rate limits during development; leave empty for normal user behavior
 const DEV_BYPASS_TOKEN = '';
 
+/** @returns {string} */
 function getUtcDay() {
   return new Date().toISOString().split('T')[0];
 }
 
+/** @returns {UsageState} */
 function createEmptyUsage() {
   return {
     day: getUtcDay(),
@@ -27,9 +46,13 @@ function createEmptyUsage() {
   };
 }
 
+/**
+ * @param {UsageRequestKind} kind
+ * @param {UsageUpdateDetails} [details]
+ */
 async function recordUsage(kind, details = {}) {
   try {
-    const stored = await chrome.storage.local.get(USAGE_STORAGE_KEY);
+    const stored = await getLocalStorage(USAGE_STORAGE_KEY);
     const current = stored[USAGE_STORAGE_KEY];
     const usage = current && current.day === getUtcDay() ? { ...current } : createEmptyUsage();
 
@@ -50,7 +73,7 @@ async function recordUsage(kind, details = {}) {
     }
     usage.lastUpdated = Date.now();
 
-    await chrome.storage.local.set({ [USAGE_STORAGE_KEY]: usage });
+    await setLocalStorage({ [USAGE_STORAGE_KEY]: usage });
   } catch (e) {
     console.warn('[Dobby AI] Failed to record usage:', e.message);
   }
@@ -71,7 +94,7 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
 
   // Image context menu click
   if (info.mediaType === 'image' && info.srcUrl) {
-    chrome.tabs.sendMessage(tab.id, { type: 'SHOW_BUBBLE', image: info.srcUrl }).catch(() => {
+    sendContentMessage(tab.id, { type: 'SHOW_BUBBLE', image: info.srcUrl }).catch(() => {
       chrome.notifications.create({
         type: 'basic',
         iconUrl: 'icons/icon48.png',
@@ -86,7 +109,7 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
   const text = (info.selectionText || '').trim();
   if (!text) return;
 
-  chrome.tabs.sendMessage(tab.id, { type: 'SHOW_BUBBLE', text }).catch(() => {
+  sendContentMessage(tab.id, { type: 'SHOW_BUBBLE', text }).catch(() => {
     chrome.notifications.create({
       type: 'basic',
       iconUrl: 'icons/icon48.png',
@@ -98,11 +121,20 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
 
 // --- Keyboard Commands ---
 
+/**
+ * @param {number | undefined} tabId
+ * @param {ContentRuntimeMessage} message
+ */
+function sendContentMessage(tabId, message) {
+  return chrome.tabs.sendMessage(/** @type {number} */ (tabId), message);
+}
+
+/** @param {ContentRuntimeMessage} message */
 function notifyActiveTab(message) {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     const tabId = tabs?.[0]?.id;
     if (!tabId) return;
-    chrome.tabs.sendMessage(tabId, message).catch(() => {
+    sendContentMessage(tabId, message).catch(() => {
       chrome.notifications.create({
         type: 'basic',
         iconUrl: 'icons/icon48.png',
@@ -113,11 +145,15 @@ function notifyActiveTab(message) {
   });
 }
 
+/**
+ * @param {'dobbyEnabled' | 'screenshotEnabled'} storageKey
+ * @param {ToggleMessageType} messageType
+ */
 function toggleStoredSetting(storageKey, messageType) {
-  chrome.storage.local.get(storageKey, (data) => {
+  getLocalStorage(storageKey, (data) => {
     const current = data[storageKey] !== false;
     const enabled = !current;
-    chrome.storage.local.set({ [storageKey]: enabled }, () => {
+    setLocalStorage({ [storageKey]: enabled }, () => {
       notifyActiveTab({ type: messageType, enabled });
     });
   });
@@ -134,6 +170,12 @@ chrome.commands.onCommand.addListener((command) => {
 
 // --- HMAC Signing ---
 
+/**
+ * @param {ChatMessage[]} messages
+ * @param {number} timestamp
+ * @param {string} secret
+ * @returns {Promise<string>}
+ */
 export async function generateSignature(messages, timestamp, secret) {
   const payload = `${timestamp}${JSON.stringify(messages)}`;
   const encoder = new TextEncoder();
@@ -152,6 +194,10 @@ export async function generateSignature(messages, timestamp, secret) {
 
 // --- SSE Stream Parsing ---
 
+/**
+ * @param {ReadableStreamDefaultReader<Uint8Array<ArrayBuffer>>} reader
+ * @returns {AsyncGenerator<string>}
+ */
 export async function* parseSSEStream(reader) {
   const decoder = new TextDecoder();
   let buffer = '';
@@ -185,9 +231,10 @@ export async function* parseSSEStream(reader) {
 chrome.runtime.onConnect.addListener((port) => {
   if (port.name !== 'chat-stream') return;
 
+  const chatPort = /** @type {ChatBackgroundPort} */ (port);
   let abortController = null;
 
-  port.onMessage.addListener(async (msg) => {
+  chatPort.onMessage.addListener(async (/** @type {ChatStreamRequest} */ msg) => {
     if (msg.type !== 'CHAT_REQUEST') return;
 
     abortController = new AbortController();
@@ -197,7 +244,7 @@ chrome.runtime.onConnect.addListener((port) => {
     const timeout = setTimeout(() => abortController.abort(), 30000);
 
     try {
-      const stored = await chrome.storage.local.get('userApiKey');
+      const stored = await getLocalStorage('userApiKey');
       let response;
 
       if (stored.userApiKey) {
@@ -234,7 +281,7 @@ chrome.runtime.onConnect.addListener((port) => {
         let data;
         try { data = await response.json(); } catch (e) { console.warn('[Dobby AI] Failed to parse rate limit response'); data = { remaining: 0 }; }
         await recordUsage('chat', { remaining: data.remaining ?? 0, usingOwnKey: false, rateLimited: true });
-        try { port.postMessage({ type: 'rate_limited', remaining: data.remaining ?? 0, resetAt: data.resetAt }); } catch (e) { console.warn('[Dobby AI] port.postMessage failed:', e.message); }
+        try { chatPort.postMessage({ type: 'rate_limited', remaining: data.remaining ?? 0, resetAt: data.resetAt }); } catch (e) { console.warn('[Dobby AI] port.postMessage failed:', e.message); }
         return;
       }
 
@@ -243,7 +290,7 @@ chrome.runtime.onConnect.addListener((port) => {
         try { errBody = await response.text(); } catch (e) { /* ignore */ }
         console.error('[Dobby AI] API error:', response.status, errBody);
         const errMsg = errBody ? `Request failed (${response.status}): ${errBody.substring(0, 200)}` : 'Request failed';
-        try { port.postMessage({ type: 'error', code: response.status, message: errMsg }); } catch (e) { console.warn('[Dobby AI] port.postMessage failed:', e.message); }
+        try { chatPort.postMessage({ type: 'error', code: response.status, message: errMsg }); } catch (e) { console.warn('[Dobby AI] port.postMessage failed:', e.message); }
         return;
       }
 
@@ -252,15 +299,15 @@ chrome.runtime.onConnect.addListener((port) => {
 
       const reader = response.body.getReader();
       for await (const token of parseSSEStream(reader)) {
-        try { port.postMessage({ type: 'token', text: token }); } catch (e) { console.warn('[Dobby AI] port.postMessage failed:', e.message); break; }
+        try { chatPort.postMessage({ type: 'token', text: token }); } catch (e) { console.warn('[Dobby AI] port.postMessage failed:', e.message); break; }
       }
       await recordUsage('chat', { remaining, usingOwnKey });
-      try { port.postMessage({ type: 'done', remaining, usingOwnKey }); } catch (e) { console.warn('[Dobby AI] port.postMessage failed:', e.message); }
+      try { chatPort.postMessage({ type: 'done', remaining, usingOwnKey }); } catch (e) { console.warn('[Dobby AI] port.postMessage failed:', e.message); }
     } catch (err) {
       if (err.name === 'AbortError') {
-        try { port.postMessage({ type: 'error', code: 0, message: 'Request timed out' }); } catch (e) { console.warn('[Dobby AI] port.postMessage failed:', e.message); }
+        try { chatPort.postMessage({ type: 'error', code: 0, message: 'Request timed out' }); } catch (e) { console.warn('[Dobby AI] port.postMessage failed:', e.message); }
       } else {
-        try { port.postMessage({ type: 'error', code: 0, message: err.message }); } catch (e) { console.warn('[Dobby AI] port.postMessage failed:', e.message); }
+        try { chatPort.postMessage({ type: 'error', code: 0, message: err.message }); } catch (e) { console.warn('[Dobby AI] port.postMessage failed:', e.message); }
       }
     } finally {
       clearTimeout(timeout);
@@ -277,9 +324,10 @@ chrome.runtime.onConnect.addListener((port) => {
 chrome.runtime.onConnect.addListener((port) => {
   if (port.name !== 'autosuggest-stream') return;
 
+  const autosuggestPort = /** @type {AutosuggestBackgroundPort} */ (port);
   let abortController = null;
 
-  port.onMessage.addListener(async (msg) => {
+  autosuggestPort.onMessage.addListener(async (/** @type {AutosuggestStreamRequest} */ msg) => {
     if (msg.type !== 'AUTOSUGGEST_REQUEST') return;
 
     abortController = new AbortController();
@@ -289,7 +337,7 @@ chrome.runtime.onConnect.addListener((port) => {
     const timeout = setTimeout(() => abortController.abort(), 10000);
 
     try {
-      const stored = await chrome.storage.local.get('userApiKey');
+      const stored = await getLocalStorage('userApiKey');
       let response;
 
       if (stored.userApiKey) {
@@ -326,7 +374,7 @@ chrome.runtime.onConnect.addListener((port) => {
         let data;
         try { data = await response.json(); } catch (e) { data = { remaining: 0 }; }
         await recordUsage('autosuggest', { usingOwnKey: false, rateLimited: true });
-        try { port.postMessage({ type: 'rate_limited', remaining: data.remaining ?? 0 }); } catch (e) { /* port closed */ }
+        try { autosuggestPort.postMessage({ type: 'rate_limited', remaining: data.remaining ?? 0 }); } catch (e) { /* port closed */ }
         return;
       }
 
@@ -334,19 +382,19 @@ chrome.runtime.onConnect.addListener((port) => {
         let errBody = '';
         try { errBody = await response.text(); } catch (e) { /* ignore */ }
         console.error('[Dobby AI] Autosuggest API error:', response.status, errBody);
-        try { port.postMessage({ type: 'error', code: response.status, message: 'Autosuggest request failed: ' + errBody.substring(0, 200) }); } catch (e) { /* port closed */ }
+        try { autosuggestPort.postMessage({ type: 'error', code: response.status, message: 'Autosuggest request failed: ' + errBody.substring(0, 200) }); } catch (e) { /* port closed */ }
         return;
       }
 
       const reader = response.body.getReader();
       for await (const token of parseSSEStream(reader)) {
-        try { port.postMessage({ type: 'token', text: token }); } catch (e) { break; }
+        try { autosuggestPort.postMessage({ type: 'token', text: token }); } catch (e) { break; }
       }
       await recordUsage('autosuggest', { usingOwnKey: !!stored.userApiKey });
-      try { port.postMessage({ type: 'done' }); } catch (e) { /* port closed */ }
+      try { autosuggestPort.postMessage({ type: 'done' }); } catch (e) { /* port closed */ }
     } catch (err) {
       if (err.name !== 'AbortError') {
-        try { port.postMessage({ type: 'error', code: 0, message: err.message }); } catch (e) { /* port closed */ }
+        try { autosuggestPort.postMessage({ type: 'error', code: 0, message: err.message }); } catch (e) { /* port closed */ }
       }
     } finally {
       clearTimeout(timeout);
@@ -360,7 +408,11 @@ chrome.runtime.onConnect.addListener((port) => {
 
 // --- API Key Validation ---
 
-chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+chrome.runtime.onMessage.addListener((
+  /** @type {BackgroundRuntimeMessage} */ msg,
+  sender,
+  /** @type {(response: CaptureScreenshotResponse | ValidateApiKeyResponse) => void} */ sendResponse,
+) => {
   if (msg.type === 'CAPTURE_SCREENSHOT') {
     chrome.tabs.captureVisibleTab(null, { format: 'png' }, (dataUrl) => {
       if (chrome.runtime.lastError || !dataUrl) {
@@ -384,7 +436,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     })
       .then((res) => {
         if (res.ok) {
-          chrome.storage.local.set({ userApiKey: msg.apiKey });
+          setLocalStorage({ userApiKey: msg.apiKey });
           sendResponse({ valid: true });
         } else {
           sendResponse({ valid: false, error: 'Invalid API key' });

--- a/src/content/api.ts
+++ b/src/content/api.ts
@@ -1,16 +1,27 @@
 // api.js — Content script communication with background service worker
 // All API calls go through background.js (MV3 cross-origin restriction)
 
-/**
- * Request a chat completion via background service worker.
- * @param {Array} messages - OpenAI chat format messages
- * @param {Function} onToken - Called with each streamed token
- * @param {Function} onDone - Called when streaming completes
- * @param {Function} onError - Called with (code, message, data?) on error
- * @returns {{ cancel: Function }}
- */
-export function requestChat(messages, onToken, onDone, onError) {
-  const port = chrome.runtime.connect({ name: 'chat-stream' });
+import type {
+  AutosuggestDoneHandler,
+  AutosuggestErrorHandler,
+  AutosuggestStreamPort,
+  CaptureScreenshotResponse,
+  ChatDoneHandler,
+  ChatErrorHandler,
+  ChatMessage,
+  ChatStreamPort,
+  ChatTokenHandler,
+  StreamRequestHandle,
+} from '../shared/types';
+import { CAPTURE_SCREENSHOT_MESSAGE } from '../shared/runtime-messages';
+
+export function requestChat(
+  messages: ChatMessage[],
+  onToken: ChatTokenHandler,
+  onDone: ChatDoneHandler,
+  onError: ChatErrorHandler,
+): StreamRequestHandle {
+  const port = chrome.runtime.connect({ name: 'chat-stream' }) as ChatStreamPort;
 
   port.postMessage({ type: 'CHAT_REQUEST', messages });
 
@@ -43,16 +54,13 @@ export function requestChat(messages, onToken, onDone, onError) {
   return { cancel: () => port.disconnect() };
 }
 
-/**
- * Request an autosuggest completion via background service worker.
- * @param {Array} messages - OpenAI chat format messages
- * @param {Function} onToken - Called with each streamed token
- * @param {Function} onDone - Called when streaming completes
- * @param {Function} onError - Called with (code, message) on error
- * @returns {{ cancel: Function }}
- */
-export function requestAutosuggest(messages, onToken, onDone, onError) {
-  const port = chrome.runtime.connect({ name: 'autosuggest-stream' });
+export function requestAutosuggest(
+  messages: ChatMessage[],
+  onToken: ChatTokenHandler,
+  onDone: AutosuggestDoneHandler,
+  onError: AutosuggestErrorHandler,
+): StreamRequestHandle {
+  const port = chrome.runtime.connect({ name: 'autosuggest-stream' }) as AutosuggestStreamPort;
 
   port.postMessage({ type: 'AUTOSUGGEST_REQUEST', messages });
 
@@ -83,4 +91,8 @@ export function requestAutosuggest(messages, onToken, onDone, onError) {
   });
 
   return { cancel: () => port.disconnect() };
+}
+
+export function requestVisibleTabScreenshot(): Promise<CaptureScreenshotResponse> {
+  return chrome.runtime.sendMessage(CAPTURE_SCREENSHOT_MESSAGE) as Promise<CaptureScreenshotResponse>;
 }

--- a/src/content/bubble/stream.js
+++ b/src/content/bubble/stream.js
@@ -12,6 +12,7 @@ import { saveConversation } from '../history.js';
 import { renderMarkdown } from './markdown.js';
 import { TIMING } from '../shared/constants.js';
 import { getColorPalette } from '../../shared/color-palette.js';
+import { OPEN_OPTIONS_MESSAGE } from '../../shared/runtime-messages.js';
 
 const colors = getColorPalette('light');
 
@@ -185,6 +186,6 @@ export function showRateLimitUI(shadow) {
   `;
 
   shadow.querySelector('.cta').addEventListener('click', () => {
-    chrome.runtime.sendMessage({ type: 'OPEN_OPTIONS' });
+    chrome.runtime.sendMessage(OPEN_OPTIONS_MESSAGE);
   });
 }

--- a/src/content/history.ts
+++ b/src/content/history.ts
@@ -1,4 +1,5 @@
 import type { HistoryEntry, HistoryEntryDraft } from '../shared/types';
+import { getLocalStorage, setLocalStorage } from '../shared/storage';
 
 // history.js — Chat history storage (chrome.storage.local)
 
@@ -14,13 +15,13 @@ function generateId(): string {
  */
 export function saveConversation(entry: HistoryEntryDraft): Promise<void> {
   return new Promise((resolve) => {
-    chrome.storage.local.get(['chatHistory'], (result) => {
+    getLocalStorage(['chatHistory'], (result) => {
       if (chrome.runtime.lastError) {
         console.warn('[Dobby AI] Failed to read history:', chrome.runtime.lastError.message);
         resolve();
         return;
       }
-      const history = (result.chatHistory || []) as HistoryEntry[];
+      const history = result.chatHistory || [];
 
       // Errata #12: null safety for missing response
       const resp = entry.response || '';
@@ -43,7 +44,7 @@ export function saveConversation(entry: HistoryEntryDraft): Promise<void> {
         history.length = MAX_HISTORY;
       }
 
-      chrome.storage.local.set({ chatHistory: history }, resolve);
+      setLocalStorage({ chatHistory: history }, resolve);
     });
   });
 }
@@ -53,13 +54,13 @@ export function saveConversation(entry: HistoryEntryDraft): Promise<void> {
  */
 export function getHistory(): Promise<HistoryEntry[]> {
   return new Promise((resolve) => {
-    chrome.storage.local.get(['chatHistory'], (result) => {
+    getLocalStorage(['chatHistory'], (result) => {
       if (chrome.runtime.lastError) {
         console.warn('[Dobby AI] Failed to read history:', chrome.runtime.lastError.message);
         resolve([]);
         return;
       }
-      resolve((result.chatHistory || []) as HistoryEntry[]);
+      resolve(result.chatHistory || []);
     });
   });
 }
@@ -69,7 +70,7 @@ export function getHistory(): Promise<HistoryEntry[]> {
  */
 export function clearHistory(): Promise<void> {
   return new Promise((resolve) => {
-    chrome.storage.local.set({ chatHistory: [] }, () => {
+    setLocalStorage({ chatHistory: [] }, () => {
       if (chrome.runtime.lastError) {
         console.warn('[Dobby AI] Failed to clear history:', chrome.runtime.lastError.message);
       }

--- a/src/content/image-capture.js
+++ b/src/content/image-capture.js
@@ -3,6 +3,8 @@
 // Dependencies (shared global scope via manifest.json content_scripts):
 // - chrome.runtime.sendMessage (for screenshot capture via background.js)
 
+import { requestVisibleTabScreenshot } from './api.js';
+
 const MAX_BASE64_SIZE = 1048576; // 1MB
 const MAX_DOWNSCALE_ATTEMPTS = 2;
 
@@ -61,9 +63,7 @@ export async function captureImage(source) {
  */
 export async function captureScreenshot(rect) {
   try {
-    const response = await chrome.runtime.sendMessage({
-      type: 'CAPTURE_SCREENSHOT',
-    });
+    const response = await requestVisibleTabScreenshot();
 
     if (!response || !response.dataUrl) return null;
 

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // src/content/index.js — Content script entry point
 // Imports establish module initialization order
 
@@ -10,9 +12,12 @@ import { buildChatMessages } from './prompt.js';
 import { captureImage } from './image-capture.js';
 import { isClickInsideUI } from './shared/dom-utils.js';
 import { loadUsageData } from './shared/preset-usage.js';
+import { getLocalStorage } from '../shared/storage.js';
+
+/** @typedef {import('../shared/types').ContentRuntimeMessage} ContentRuntimeMessage */
 
 // Load initial enabled state
-chrome.storage.local.get('dobbyEnabled', (data) => {
+getLocalStorage('dobbyEnabled', (data) => {
   setDobbyEnabled(data.dobbyEnabled !== false);
 });
 
@@ -20,31 +25,31 @@ chrome.storage.local.get('dobbyEnabled', (data) => {
 loadUsageData();
 
 // Load screenshot mode state
-chrome.storage.local.get('screenshotEnabled', (data) => {
+getLocalStorage('screenshotEnabled', (data) => {
   setScreenshotEnabled(data.screenshotEnabled !== false); // default: enabled
 });
 
 // Load autosuggest state
-chrome.storage.local.get('autosuggestEnabled', (data) => {
+getLocalStorage('autosuggestEnabled', (data) => {
   const enabled = data.autosuggestEnabled === true;
   setAutosuggestEnabled(enabled);
   if (enabled) initAutosuggest();
 });
 
-chrome.runtime.onMessage.addListener((msg) => {
+chrome.runtime.onMessage.addListener((/** @type {ContentRuntimeMessage} */ msg) => {
   if (msg.type === 'DOBBY_TOGGLE') {
     setDobbyEnabled(msg.enabled);
     if (!msg.enabled) hideTrigger();
   }
 });
 
-chrome.runtime.onMessage.addListener((msg) => {
+chrome.runtime.onMessage.addListener((/** @type {ContentRuntimeMessage} */ msg) => {
   if (msg.type === 'SCREENSHOT_TOGGLE') {
     setScreenshotEnabled(msg.enabled);
   }
 });
 
-chrome.runtime.onMessage.addListener((msg) => {
+chrome.runtime.onMessage.addListener((/** @type {ContentRuntimeMessage} */ msg) => {
   if (msg.type === 'AUTOSUGGEST_TOGGLE') {
     setAutosuggestEnabled(msg.enabled);
     if (msg.enabled) {
@@ -56,7 +61,7 @@ chrome.runtime.onMessage.addListener((msg) => {
 });
 
 // Context menu and popup action message handler
-chrome.runtime.onMessage.addListener((msg) => {
+chrome.runtime.onMessage.addListener((/** @type {ContentRuntimeMessage} */ msg) => {
   if (msg.type === 'SHOW_HISTORY') {
     const rect = {
       top: window.innerHeight / 3 - 8,

--- a/src/content/shared/preset-usage.ts
+++ b/src/content/shared/preset-usage.ts
@@ -1,4 +1,5 @@
 import type { Preset, PresetUsage } from '../../shared/types';
+import { getLocalStorage, setLocalStorage } from '../../shared/storage';
 
 // src/content/shared/preset-usage.js — Tracks preset click frequency for reordering
 // Usage data is cached in a module-level variable for instant sync access.
@@ -22,8 +23,8 @@ export function buildTypeKey(type: string, subType: string | null | undefined): 
  */
 export function loadUsageData(): void {
   try {
-    chrome.storage.local.get('presetUsage', (data) => {
-      usageCache = ((data && data.presetUsage) || {}) as PresetUsage;
+    getLocalStorage('presetUsage', (data) => {
+      usageCache = (data && data.presetUsage) || {};
     });
   } catch {
     // Graceful fallback — storage unavailable in some contexts
@@ -45,7 +46,7 @@ export function recordPresetUsage(typeKey: string, label: string): void {
   usageCache[typeKey][label] = (usageCache[typeKey][label] || 0) + 1;
 
   try {
-    chrome.storage.local.set({ presetUsage: usageCache });
+    setLocalStorage({ presetUsage: usageCache });
   } catch {
     // Persist failure is non-fatal — in-memory cache still works this session
   }

--- a/src/options.js
+++ b/src/options.js
@@ -1,21 +1,31 @@
+// @ts-check
+
 // options.js — Dobby AI settings page
 import { applyColorVariables } from './shared/color-palette.js';
 import { COLOR_SCHEME_QUERY, normalizeThemeMode, resolveTheme } from './shared/theme.js';
+import { getLocalStorage, removeLocalStorage } from './shared/storage.js';
+import { createValidateApiKeyMessage } from './shared/runtime-messages.js';
 
-const apiKeyInput = document.getElementById('api-key-input');
-const saveBtn = document.getElementById('save-btn');
+/** @typedef {import('./shared/types').StorageState} StorageState */
+/** @typedef {import('./shared/types').ThemeMode} ThemeMode */
+/** @typedef {import('./shared/types').ValidateApiKeyResponse} ValidateApiKeyResponse */
+
+const apiKeyInput = /** @type {HTMLInputElement} */ (document.getElementById('api-key-input'));
+const saveBtn = /** @type {HTMLButtonElement} */ (document.getElementById('save-btn'));
 const removeBtn = document.getElementById('remove-btn');
 const keyStatus = document.getElementById('key-status');
 const hasKeySection = document.getElementById('has-key');
 const noKeySection = document.getElementById('no-key');
 const keyDisplay = document.getElementById('key-display');
 const versionEl = document.getElementById('extension-version');
+/** @type {ThemeMode} */
 let themeMode = 'auto';
 
 if (versionEl && chrome.runtime.getManifest) {
   versionEl.textContent = `v${chrome.runtime.getManifest().version}`;
 }
 
+/** @param {unknown} value */
 function applyTheme(value) {
   themeMode = normalizeThemeMode(value);
   const resolvedTheme = resolveTheme(themeMode);
@@ -25,11 +35,13 @@ function applyTheme(value) {
   document.documentElement.style.colorScheme = resolvedTheme;
 }
 
+/** @param {string} key */
 function maskKey(key) {
   if (!key || key.length < 12) return '••••••••';
   return key.substring(0, 7) + '••••' + key.substring(key.length - 4);
 }
 
+/** @param {string} key */
 function showHasKey(key) {
   hasKeySection.style.display = 'block';
   noKeySection.style.display = 'none';
@@ -45,7 +57,7 @@ function showNoKey() {
 }
 
 // Load current state
-chrome.storage.local.get(['userApiKey', 'theme'], (result) => {
+getLocalStorage(['userApiKey', 'theme'], (result) => {
   applyTheme(result.theme || 'auto');
   if (result.userApiKey) {
     showHasKey(result.userApiKey);
@@ -92,13 +104,13 @@ saveBtn.addEventListener('click', async () => {
   keyStatus.textContent = 'Validating...';
   keyStatus.className = 'status info';
 
-  chrome.runtime.sendMessage({ type: 'VALIDATE_API_KEY', apiKey: key }, (response) => {
+  chrome.runtime.sendMessage(createValidateApiKeyMessage(key), (/** @type {ValidateApiKeyResponse} */ response) => {
     saveBtn.disabled = false;
     if (response && response.valid) {
       keyStatus.textContent = '';
       showHasKey(key);
     } else {
-      keyStatus.textContent = response?.error || 'Invalid API key';
+      keyStatus.textContent = response && 'error' in response ? response.error : 'Invalid API key';
       keyStatus.className = 'status error';
     }
   });
@@ -111,13 +123,13 @@ apiKeyInput.addEventListener('keydown', (e) => {
 
 // Remove key
 removeBtn.addEventListener('click', () => {
-  chrome.storage.local.remove('userApiKey', () => {
+  removeLocalStorage('userApiKey', () => {
     showNoKey();
   });
 });
 
 // Provider tab switching
-document.querySelectorAll('.provider-tab').forEach((tab) => {
+/** @type {NodeListOf<HTMLElement>} */ (document.querySelectorAll('.provider-tab')).forEach((tab) => {
   tab.addEventListener('click', () => {
     document.querySelectorAll('.provider-tab').forEach((t) => t.classList.remove('active'));
     document.querySelectorAll('.provider-panel').forEach((p) => p.classList.remove('active'));

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,31 +1,45 @@
+// @ts-check
+
 import { applyColorVariables } from './shared/color-palette.js';
 import { COLOR_SCHEME_QUERY, normalizeThemeMode, resolveTheme } from './shared/theme.js';
+import { getLocalStorage, setLocalStorage } from './shared/storage.js';
+import { SHOW_HISTORY_MESSAGE } from './shared/runtime-messages.js';
+
+/** @typedef {import('./shared/types').ContentRuntimeMessage} ContentRuntimeMessage */
+/** @typedef {import('./shared/types').HistoryEntry} HistoryEntry */
+/** @typedef {import('./shared/types').StorageState} StorageState */
+/** @typedef {import('./shared/types').ThemeMode} ThemeMode */
+/** @typedef {import('./shared/types').UsageState} UsageState */
 
 const FREE_CHAT_LIMIT = 30;
 const LOW_QUOTA_THRESHOLD = 5;
 
-const toggle = document.getElementById('enabled');
+const toggle = /** @type {HTMLInputElement} */ (document.getElementById('enabled'));
 const status = document.getElementById('status');
-const screenshotToggle = document.getElementById('screenshot-enabled');
+const screenshotToggle = /** @type {HTMLInputElement} */ (document.getElementById('screenshot-enabled'));
 const screenshotStatus = document.getElementById('screenshot-status');
-const autosuggestToggle = document.getElementById('autosuggest-enabled');
+const autosuggestToggle = /** @type {HTMLInputElement} */ (document.getElementById('autosuggest-enabled'));
 const autosuggestStatus = document.getElementById('autosuggest-status');
 const settingsBtn = document.getElementById('settings');
-const historyBtn = document.getElementById('history');
-const clearHistoryBtn = document.getElementById('clear-history');
+const historyBtn = /** @type {HTMLButtonElement} */ (document.getElementById('history'));
+const clearHistoryBtn = /** @type {HTMLButtonElement} */ (document.getElementById('clear-history'));
 const feedback = document.getElementById('action-feedback');
 const usageCard = document.getElementById('usage-card');
 const usagePrimary = document.getElementById('usage-primary');
 const usageSecondary = document.getElementById('usage-secondary');
 const versionEl = document.getElementById('version');
-const themeOptions = document.querySelectorAll('.theme-option');
+const themeOptions = /** @type {NodeListOf<HTMLElement>} */ (document.querySelectorAll('.theme-option'));
+/** @type {ThemeMode} */
 let themeMode = 'auto';
+/** @type {MediaQueryList | null} */
 let colorSchemeQuery = null;
 
+/** @returns {string} */
 function getUtcDay() {
   return new Date().toISOString().split('T')[0];
 }
 
+/** @param {unknown} value */
 function applyTheme(value) {
   themeMode = normalizeThemeMode(value);
   const resolvedTheme = resolveTheme(themeMode);
@@ -41,6 +55,11 @@ function getResetTimeLabel() {
   return reset.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
 }
 
+/**
+ * @param {HTMLInputElement} input
+ * @param {HTMLElement} stateEl
+ * @param {boolean} enabled
+ */
 function setSwitchState(input, stateEl, enabled) {
   input.checked = enabled;
   stateEl.textContent = enabled ? 'On' : 'Off';
@@ -48,10 +67,12 @@ function setSwitchState(input, stateEl, enabled) {
   stateEl.classList.toggle('off', !enabled);
 }
 
+/** @param {string} message */
 function setFeedback(message) {
   feedback.textContent = message || '';
 }
 
+/** @param {UsageState | undefined} rawUsage */
 function todayUsage(rawUsage) {
   if (!rawUsage || rawUsage.day !== getUtcDay()) {
     return {
@@ -64,6 +85,7 @@ function todayUsage(rawUsage) {
   return rawUsage;
 }
 
+/** @param {Pick<StorageState, 'userApiKey' | 'dobbyUsage'>} state */
 function renderUsage({ userApiKey, dobbyUsage }) {
   const usage = todayUsage(dobbyUsage);
   usageCard.classList.remove('ok', 'warning', 'danger');
@@ -93,6 +115,7 @@ function renderUsage({ userApiKey, dobbyUsage }) {
   usageSecondary.textContent = `Resets around ${getResetTimeLabel()}. Today: ${usage.chatRequests || 0} chats, ${usage.autosuggestRequests || 0} suggestions, ${usage.screenshotRequests || 0} screenshots.`;
 }
 
+/** @param {HistoryEntry[]} history */
 function setHistoryState(history) {
   const hasHistory = Array.isArray(history) && history.length > 0;
   historyBtn.disabled = !hasHistory;
@@ -100,7 +123,7 @@ function setHistoryState(history) {
 }
 
 function loadPopupState() {
-  chrome.storage.local.get([
+  getLocalStorage([
     'dobbyEnabled',
     'screenshotEnabled',
     'autosuggestEnabled',
@@ -119,14 +142,16 @@ function loadPopupState() {
   });
 }
 
+/** @param {ContentRuntimeMessage} message */
 function broadcastToContent(message) {
   chrome.tabs.query({ url: ['http://*/*', 'https://*/*'] }, (tabs) => {
     tabs.forEach((tab) => {
-      chrome.tabs.sendMessage(tab.id, message).catch(() => {});
+      chrome.tabs.sendMessage(/** @type {number} */ (tab.id), message).catch(() => {});
     });
   });
 }
 
+/** @param {ThemeMode} value */
 function setActiveThemeOption(value) {
   themeOptions.forEach((btn) => {
     const isActive = btn.dataset.theme === value;
@@ -143,21 +168,21 @@ loadPopupState();
 
 toggle.addEventListener('change', () => {
   const enabled = toggle.checked;
-  chrome.storage.local.set({ dobbyEnabled: enabled });
+  setLocalStorage({ dobbyEnabled: enabled });
   setSwitchState(toggle, status, enabled);
   broadcastToContent({ type: 'DOBBY_TOGGLE', enabled });
 });
 
 screenshotToggle.addEventListener('change', () => {
   const enabled = screenshotToggle.checked;
-  chrome.storage.local.set({ screenshotEnabled: enabled });
+  setLocalStorage({ screenshotEnabled: enabled });
   setSwitchState(screenshotToggle, screenshotStatus, enabled);
   broadcastToContent({ type: 'SCREENSHOT_TOGGLE', enabled });
 });
 
 autosuggestToggle.addEventListener('change', () => {
   const enabled = autosuggestToggle.checked;
-  chrome.storage.local.set({ autosuggestEnabled: enabled });
+  setLocalStorage({ autosuggestEnabled: enabled });
   setSwitchState(autosuggestToggle, autosuggestStatus, enabled);
   broadcastToContent({ type: 'AUTOSUGGEST_TOGGLE', enabled });
 });
@@ -174,14 +199,14 @@ historyBtn.addEventListener('click', () => {
       setFeedback('Open a regular webpage to show history.');
       return;
     }
-    chrome.tabs.sendMessage(tabId, { type: 'SHOW_HISTORY' })
+    chrome.tabs.sendMessage(tabId, SHOW_HISTORY_MESSAGE)
       .then(() => setFeedback('History opened on this page.'))
       .catch(() => setFeedback('Open a regular webpage to show history.'));
   });
 });
 
 clearHistoryBtn.addEventListener('click', () => {
-  chrome.storage.local.set({ chatHistory: [] }, () => {
+  setLocalStorage({ chatHistory: [] }, () => {
     setHistoryState([]);
     setFeedback('History cleared.');
   });
@@ -190,7 +215,8 @@ clearHistoryBtn.addEventListener('click', () => {
 themeOptions.forEach((btn) => {
   btn.addEventListener('click', () => {
     const value = btn.dataset.theme;
-    chrome.storage.local.set({ theme: value });
+    if (value !== 'auto' && value !== 'light' && value !== 'dark') return;
+    setLocalStorage({ theme: value });
     setActiveThemeOption(value);
     applyTheme(value);
   });

--- a/src/shared/runtime-messages.ts
+++ b/src/shared/runtime-messages.ts
@@ -1,0 +1,25 @@
+import type {
+  CaptureScreenshotMessage,
+  OpenOptionsMessage,
+  ShowHistoryMessage,
+  ValidateApiKeyMessage,
+} from './types';
+
+export const CAPTURE_SCREENSHOT_MESSAGE: CaptureScreenshotMessage = {
+  type: 'CAPTURE_SCREENSHOT',
+};
+
+export const OPEN_OPTIONS_MESSAGE: OpenOptionsMessage = {
+  type: 'OPEN_OPTIONS',
+};
+
+export const SHOW_HISTORY_MESSAGE: ShowHistoryMessage = {
+  type: 'SHOW_HISTORY',
+};
+
+export function createValidateApiKeyMessage(apiKey: string): ValidateApiKeyMessage {
+  return {
+    type: 'VALIDATE_API_KEY',
+    apiKey,
+  };
+}

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -1,0 +1,43 @@
+import type { StorageKey, StorageState } from './types';
+
+type StoredValues<K extends StorageKey> = Pick<StorageState, K>;
+
+export function getLocalStorage<K extends StorageKey>(
+  keys: K | K[],
+  callback: (values: StoredValues<K>) => void,
+): void;
+export function getLocalStorage<K extends StorageKey>(
+  keys: K | K[],
+): Promise<StoredValues<K>>;
+export function getLocalStorage<K extends StorageKey>(
+  keys: K | K[],
+  callback?: (values: StoredValues<K>) => void,
+): Promise<StoredValues<K>> | void {
+  if (callback) {
+    chrome.storage.local.get(keys, callback as (items: Record<string, unknown>) => void);
+    return;
+  }
+  return chrome.storage.local.get(keys) as Promise<StoredValues<K>>;
+}
+
+export function setLocalStorage(
+  values: StorageState,
+  callback?: () => void,
+): Promise<void> | void {
+  if (callback) {
+    chrome.storage.local.set(values, callback);
+    return;
+  }
+  return chrome.storage.local.set(values);
+}
+
+export function removeLocalStorage(
+  keys: StorageKey | StorageKey[],
+  callback?: () => void,
+): Promise<void> | void {
+  if (callback) {
+    chrome.storage.local.remove(keys, callback);
+    return;
+  }
+  return chrome.storage.local.remove(keys);
+}

--- a/src/shared/theme.ts
+++ b/src/shared/theme.ts
@@ -1,4 +1,5 @@
 import type { ResolvedTheme, ThemeMode } from './types';
+import { getLocalStorage } from './storage';
 
 export const COLOR_SCHEME_QUERY = '(prefers-color-scheme: dark)';
 
@@ -25,7 +26,7 @@ export function detectTheme(): Promise<ResolvedTheme> {
       return;
     }
 
-    chrome.storage.local.get('theme', (data) => {
+    getLocalStorage('theme', (data) => {
       resolve(resolveTheme(data?.theme));
     });
   });
@@ -54,7 +55,7 @@ export function watchThemeChanges(applyTheme: (theme: ResolvedTheme) => void): (
   };
 
   if (typeof chrome !== 'undefined' && chrome.storage?.local?.get) {
-    chrome.storage.local.get('theme', (data) => {
+    getLocalStorage('theme', (data) => {
       mode = normalizeThemeMode(data?.theme);
     });
   }

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -116,3 +116,44 @@ export type AutosuggestStreamResponse =
   | StreamErrorMessage
   | AutosuggestStreamDoneMessage
   | AutosuggestRateLimitedMessage;
+
+export type StreamErrorCode = number | 'RATE_LIMITED' | 'DISCONNECTED';
+
+export type ChatErrorDetails = {
+  remaining: number;
+  resetAt?: string | number;
+};
+
+export type ChatTokenHandler = (text: string) => void;
+export type ChatDoneHandler = (usage: {
+  remaining: number | null;
+  usingOwnKey: boolean;
+}) => void;
+export type ChatErrorHandler = (
+  code: StreamErrorCode,
+  message: string,
+  details?: ChatErrorDetails,
+) => void;
+
+export type AutosuggestDoneHandler = () => void;
+export type AutosuggestErrorHandler = (
+  code: StreamErrorCode,
+  message: string,
+) => void;
+
+export type PortMessageEvent<T> = Omit<chrome.events.Event<(message: T) => void>, 'addListener'> & {
+  addListener(callback: (message: T) => void): void;
+};
+
+export type TypedStreamPort<Request, Response> =
+  Omit<chrome.runtime.Port, 'postMessage' | 'onMessage'> & {
+    postMessage(message: Request): void;
+    onMessage: PortMessageEvent<Response>;
+  };
+
+export type ChatStreamPort = TypedStreamPort<ChatStreamRequest, ChatStreamResponse>;
+export type AutosuggestStreamPort =
+  TypedStreamPort<AutosuggestStreamRequest, AutosuggestStreamResponse>;
+export type ChatBackgroundPort = TypedStreamPort<ChatStreamResponse, ChatStreamRequest>;
+export type AutosuggestBackgroundPort =
+  TypedStreamPort<AutosuggestStreamResponse, AutosuggestStreamRequest>;

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const get = vi.fn();
+const set = vi.fn();
+const remove = vi.fn();
+
+global.chrome = {
+  storage: {
+    local: { get, set, remove },
+  },
+};
+
+const {
+  getLocalStorage,
+  removeLocalStorage,
+  setLocalStorage,
+} = await import('../src/shared/storage.js');
+
+describe('typed local storage boundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('preserves callback-style reads', () => {
+    const callback = vi.fn();
+    get.mockImplementation((keys, done) => done({ theme: 'dark' }));
+
+    getLocalStorage('theme', callback);
+
+    expect(get).toHaveBeenCalledWith('theme', callback);
+    expect(callback).toHaveBeenCalledWith({ theme: 'dark' });
+  });
+
+  it('preserves promise-style reads', async () => {
+    get.mockResolvedValue({ userApiKey: 'sk-test' });
+
+    await expect(getLocalStorage('userApiKey')).resolves.toEqual({
+      userApiKey: 'sk-test',
+    });
+  });
+
+  it('preserves callback-style writes', () => {
+    const callback = vi.fn();
+
+    setLocalStorage({ dobbyEnabled: true }, callback);
+
+    expect(set).toHaveBeenCalledWith({ dobbyEnabled: true }, callback);
+  });
+
+  it('preserves promise-style writes', async () => {
+    set.mockResolvedValue(undefined);
+
+    await expect(setLocalStorage({ theme: 'auto' })).resolves.toBeUndefined();
+  });
+
+  it('preserves callback-style removals', () => {
+    const callback = vi.fn();
+
+    removeLocalStorage('userApiKey', callback);
+
+    expect(remove).toHaveBeenCalledWith('userApiKey', callback);
+  });
+});


### PR DESCRIPTION
## Summary

- migrate `src/content/api.js` to TypeScript and type chat/autosuggest stream callbacks
- share typed request/response contracts across content and background stream ports
- add typed runtime-message constants/factories for screenshot, options, history, and API-key validation
- centralize all `chrome.storage.local` reads/writes/removals behind a typed adapter
- enable scoped checking for background, content entry, popup, and options message/storage boundaries

Closes #167

## Compatibility

- preserves every existing runtime message string and payload shape
- preserves callback-style and Promise-style Chrome storage behavior
- preserves storage keys and requires no persisted-data migration
- preserves port streaming, disconnect, error, and rate-limit behavior
- no DOM, CSS, manifest, or product behavior changes

## Verification

- `npm run typecheck`
- `npm run build`
- `npm test` (620 passed, including 5 new storage adapter tests)
- `npm run test:e2e` (24 passed)
- `git diff --check`