### PR TITLE
[codex] Migrate background worker and proxy to TypeScript

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -32,7 +32,7 @@ async function build() {
   if (isWatch) {
     const contexts = await Promise.all([
       esbuild.context({ ...sharedConfig, entryPoints: ['src/content/index.js'], outfile: `${DIST}/content.js` }),
-      esbuild.context({ ...sharedConfig, entryPoints: ['src/background/index.js'], outfile: `${DIST}/background.js` }),
+      esbuild.context({ ...sharedConfig, entryPoints: ['src/background/index.ts'], outfile: `${DIST}/background.js` }),
       esbuild.context({ ...sharedConfig, entryPoints: ['src/popup.js', 'src/options.js'], outdir: DIST }),
     ]);
     copyStaticAssets();
@@ -40,7 +40,7 @@ async function build() {
     console.log('Watching for changes...');
   } else {
     await esbuild.build({ ...sharedConfig, entryPoints: ['src/content/index.js'], outfile: `${DIST}/content.js` });
-    await esbuild.build({ ...sharedConfig, entryPoints: ['src/background/index.js'], outfile: `${DIST}/background.js` });
+    await esbuild.build({ ...sharedConfig, entryPoints: ['src/background/index.ts'], outfile: `${DIST}/background.js` });
     await esbuild.build({ ...sharedConfig, entryPoints: ['src/popup.js', 'src/options.js'], outdir: DIST });
     copyStaticAssets();
     console.log('Build complete → dist/');

--- a/proxy/src/index.ts
+++ b/proxy/src/index.ts
@@ -1,12 +1,14 @@
-// proxy/src/index.js
+// proxy/src/index.ts
 import { validatePayload, verifyHmac } from './validate.js';
 import { checkRateLimit, incrementCounters } from './rate-limit.js';
 import { createChatStream } from './openai.js';
 import { AUTOSUGGEST_MAX_SUGGESTION_TOKENS } from '../../src/shared/autosuggest-limits.js';
+import type { ProxyPurpose } from '../../src/shared/types';
+import type { ProxyEnv, ValidProxyPayload } from './types';
 
 const MAX_BODY_SIZE = 2097152; // 2MB
 
-function getCorsHeaders(request, env) {
+function getCorsHeaders(request: Request, env: ProxyEnv): Record<string, string> {
   const origin = request.headers.get('Origin') || '';
   const allowed = (env.ALLOWED_ORIGINS || '').split(',').map(s => s.trim());
   const allowOrigin = allowed.includes(origin) ? origin : '';
@@ -18,11 +20,16 @@ function getCorsHeaders(request, env) {
   };
 }
 
-function corsResponse(request, env) {
+function corsResponse(request: Request, env: ProxyEnv): Response {
   return new Response(null, { status: 204, headers: getCorsHeaders(request, env) });
 }
 
-function jsonResponse(data, status = 200, corsHeaders = {}, extraHeaders = {}) {
+function jsonResponse(
+  data: unknown,
+  status = 200,
+  corsHeaders: Record<string, string> = {},
+  extraHeaders: Record<string, string> = {},
+): Response {
   return new Response(JSON.stringify(data), {
     status,
     headers: { 'Content-Type': 'application/json', ...corsHeaders, ...extraHeaders },
@@ -30,7 +37,7 @@ function jsonResponse(data, status = 200, corsHeaders = {}, extraHeaders = {}) {
 }
 
 export default {
-  async fetch(request, env) {
+  async fetch(request: Request, env: ProxyEnv): Promise<Response> {
     const corsHeaders = getCorsHeaders(request, env);
 
     if (request.method === 'OPTIONS') {
@@ -52,7 +59,7 @@ export default {
     }
 
     // Read body as text and check size (Content-Length header is optional and can be omitted)
-    let bodyText;
+    let bodyText: string;
     try {
       bodyText = await request.text();
     } catch {
@@ -63,7 +70,7 @@ export default {
       return jsonResponse({ error: 'Request body too large (max 2MB)' }, 413, corsHeaders);
     }
 
-    let body;
+    let body: unknown;
     try {
       body = JSON.parse(bodyText);
     } catch {
@@ -72,15 +79,15 @@ export default {
 
     const validation = validatePayload(body);
     if (!validation.valid) {
-      return jsonResponse({ error: validation.error }, 400, corsHeaders);
+      return jsonResponse({ error: (validation as { valid: false; error: string }).error }, 400, corsHeaders);
     }
 
-    const hmacValid = await verifyHmac(body, env.HMAC_SECRET);
+    const hmacValid = await verifyHmac(body as ValidProxyPayload, env.HMAC_SECRET);
     if (!hmacValid) {
       return jsonResponse({ error: 'Invalid signature' }, 403, corsHeaders);
     }
 
-    const purpose = body.purpose || 'chat';
+    const purpose: ProxyPurpose = (body as ValidProxyPayload).purpose || 'chat';
     const ip = request.headers.get('CF-Connecting-IP') || 'unknown';
     const devBypass = env.DEV_BYPASS_TOKEN
       && request.headers.get('X-Dev-Token') === env.DEV_BYPASS_TOKEN;
@@ -99,7 +106,7 @@ export default {
     if (!devBypass) await incrementCounters(ip, env.RATE_LIMIT_KV, purpose);
 
     const maxTokens = purpose === 'autosuggest' ? AUTOSUGGEST_MAX_SUGGESTION_TOKENS : undefined;
-    const openaiResponse = await createChatStream(body.messages, env.OPENAI_API_KEY, undefined, maxTokens);
+    const openaiResponse = await createChatStream((body as ValidProxyPayload).messages, env.OPENAI_API_KEY, undefined, maxTokens);
 
     if (!openaiResponse.ok) {
       return jsonResponse({ error: 'Upstream error' }, 502, corsHeaders);

--- a/proxy/src/openai.ts
+++ b/proxy/src/openai.ts
@@ -1,9 +1,16 @@
-// proxy/src/openai.js
+// proxy/src/openai.ts
+import type { ChatMessage } from '../../src/shared/types';
+
 const OPENAI_URL = 'https://api.openai.com/v1/chat/completions';
 const MODEL = 'gpt-4.1-mini';
 const DEFAULT_MAX_TOKENS = 1000;
 
-export async function createChatStream(messages, apiKey, signal, maxTokens) {
+export async function createChatStream(
+  messages: ChatMessage[],
+  apiKey: string,
+  signal?: AbortSignal,
+  maxTokens?: number,
+): Promise<Response> {
   return fetch(OPENAI_URL, {
     method: 'POST',
     headers: {

--- a/proxy/src/rate-limit.ts
+++ b/proxy/src/rate-limit.ts
@@ -1,4 +1,7 @@
-// proxy/src/rate-limit.js
+// proxy/src/rate-limit.ts
+import type { ProxyPurpose } from '../../src/shared/types';
+import type { KVNamespaceLike, RateLimitResult } from './types';
+
 const LIMITS = {
   perMinute: 5,
   perDay: 30,
@@ -10,23 +13,27 @@ const AUTOSUGGEST_LIMITS = {
   perDay: 200,
 };
 
-function minuteBucket() {
+function minuteBucket(): number {
   return Math.floor(Date.now() / 60000);
 }
 
-function dayBucket() {
+function dayBucket(): string {
   return new Date().toISOString().split('T')[0];
 }
 
-function tenSecBucket() {
+function tenSecBucket(): number {
   return Math.floor(Date.now() / 10000);
 }
 
-function keyPrefix(purpose) {
+function keyPrefix(purpose: ProxyPurpose): string {
   return purpose === 'autosuggest' ? 'as' : 'rl';
 }
 
-export async function checkRateLimit(ip, kv, purpose = 'chat') {
+export async function checkRateLimit(
+  ip: string,
+  kv: KVNamespaceLike,
+  purpose: ProxyPurpose = 'chat',
+): Promise<RateLimitResult> {
   // Check block list first (shared across both purposes)
   const blocked = await kv.get(`blocked:${ip}`);
   if (blocked) {
@@ -61,7 +68,11 @@ export async function checkRateLimit(ip, kv, purpose = 'chat') {
   return { allowed: true, remaining: limits.perDay - dayCount - 1 };
 }
 
-export async function incrementCounters(ip, kv, purpose = 'chat') {
+export async function incrementCounters(
+  ip: string,
+  kv: KVNamespaceLike,
+  purpose: ProxyPurpose = 'chat',
+): Promise<void> {
   const prefix = keyPrefix(purpose);
 
   const minKey = `${prefix}:min:${ip}:${minuteBucket()}`;

--- a/proxy/src/types.ts
+++ b/proxy/src/types.ts
@@ -1,0 +1,34 @@
+import type { ProxyChatPayload, ProxyPurpose } from '../../src/shared/types';
+
+export type ProxyEnv = {
+  OPENAI_API_KEY: string;
+  HMAC_SECRET: string;
+  ENABLED?: string;
+  ALLOWED_ORIGINS?: string;
+  DEV_BYPASS_TOKEN?: string;
+  RATE_LIMIT_KV: KVNamespaceLike;
+};
+
+export type KVPutOptions = {
+  expirationTtl?: number;
+};
+
+export type KVNamespaceLike = {
+  get(key: string): Promise<string | null>;
+  put(key: string, value: string, options?: KVPutOptions): Promise<void>;
+};
+
+export type ValidationResult =
+  | { valid: true }
+  | { valid: false; error: string };
+
+export type RateLimitResult = {
+  allowed: boolean;
+  remaining?: number | null;
+  reason?: string;
+  retryAfter?: number;
+};
+
+export type ValidProxyPayload = ProxyChatPayload & {
+  purpose?: ProxyPurpose;
+};

--- a/proxy/src/validate.ts
+++ b/proxy/src/validate.ts
@@ -1,36 +1,55 @@
-// proxy/src/validate.js
+// proxy/src/validate.ts
+import type { ChatMessage, ProxyChatPayload } from '../../src/shared/types';
+import type { ValidationResult } from './types';
+
 const MAX_MESSAGES = 20;
 const MAX_TOTAL_CHARS = 6000;
 const TIMESTAMP_WINDOW_SECONDS = 300; // 5 minutes
 
-const validRoles = ['system', 'user', 'assistant'];
+const validRoles = ['system', 'user', 'assistant'] as const;
 
 const MAX_IMAGES_PER_MESSAGE = 2;
 
-function validateContentItem(item) {
-  if (!item || typeof item !== 'object' || !item.type) {
+type UncheckedContentItem = {
+  type?: string;
+  text?: unknown;
+  image_url?: {
+    url?: unknown;
+  };
+};
+
+type UncheckedMessage = {
+  role?: string;
+  content?: unknown;
+};
+
+function validateContentItem(item: unknown): ValidationResult {
+  if (!item || typeof item !== 'object' || !(item as UncheckedContentItem).type) {
     return { valid: false, error: 'Invalid content item' };
   }
-  if (item.type === 'text') {
-    if (typeof item.text !== 'string') {
+  if ((item as UncheckedContentItem).type === 'text') {
+    if (typeof (item as UncheckedContentItem).text !== 'string') {
       return { valid: false, error: 'Content item text must be a string' };
     }
     return { valid: true };
   }
-  if (item.type === 'image_url') {
-    if (!item.image_url || typeof item.image_url.url !== 'string') {
+  if ((item as UncheckedContentItem).type === 'image_url') {
+    if (
+      !(item as UncheckedContentItem).image_url
+      || typeof (item as UncheckedContentItem).image_url!.url !== 'string'
+    ) {
       return { valid: false, error: 'Invalid image_url item' };
     }
-    const url = item.image_url.url;
+    const url = (item as UncheckedContentItem).image_url!.url as string;
     if (!url.startsWith('https:') && !url.startsWith('data:image/')) {
       return { valid: false, error: 'Image URL must start with https: or data:image/' };
     }
     return { valid: true };
   }
-  return { valid: false, error: `Unknown content type: ${item.type}` };
+  return { valid: false, error: `Unknown content type: ${(item as UncheckedContentItem).type}` };
 }
 
-function validateContent(content) {
+function validateContent(content: unknown): ValidationResult {
   if (typeof content === 'string') {
     return { valid: true };
   }
@@ -52,7 +71,7 @@ function validateContent(content) {
   return { valid: false, error: 'Message content must be a string or array' };
 }
 
-function getContentChars(messages) {
+function getContentChars(messages: ChatMessage[]): number {
   let total = 0;
   for (const m of messages) {
     if (typeof m.content === 'string') {
@@ -68,12 +87,12 @@ function getContentChars(messages) {
   return total;
 }
 
-export function validatePayload(body) {
+export function validatePayload(body: unknown): ValidationResult {
   if (!body || typeof body !== 'object') {
     return { valid: false, error: 'Invalid request body' };
   }
 
-  const { messages, signature, timestamp } = body;
+  const { messages, signature, timestamp } = body as Record<string, unknown>;
 
   if (!Array.isArray(messages) || messages.length === 0) {
     return { valid: false, error: 'Missing or empty messages array' };
@@ -84,16 +103,16 @@ export function validatePayload(body) {
   }
 
   for (const m of messages) {
-    if (!validRoles.includes(m.role)) {
-      return { valid: false, error: `Invalid role: ${m.role}` };
+    if (!validRoles.includes((m as UncheckedMessage).role as typeof validRoles[number])) {
+      return { valid: false, error: `Invalid role: ${(m as UncheckedMessage).role}` };
     }
-    const contentResult = validateContent(m.content);
+    const contentResult = validateContent((m as UncheckedMessage).content);
     if (!contentResult.valid) {
       return contentResult;
     }
   }
 
-  const totalChars = getContentChars(messages);
+  const totalChars = getContentChars(messages as ChatMessage[]);
   if (totalChars > MAX_TOTAL_CHARS) {
     return { valid: false, error: `Content too long (max ${MAX_TOTAL_CHARS} chars)` };
   }
@@ -109,7 +128,7 @@ export function validatePayload(body) {
   return { valid: true };
 }
 
-export async function computeHmac(message, secret) {
+export async function computeHmac(message: string, secret: string): Promise<string> {
   const encoder = new TextEncoder();
   const key = await crypto.subtle.importKey(
     'raw',
@@ -124,7 +143,7 @@ export async function computeHmac(message, secret) {
     .join('');
 }
 
-function timingSafeEqual(a, b) {
+function timingSafeEqual(a: string, b: string): boolean {
   if (a.length !== b.length) return false;
   let result = 0;
   for (let i = 0; i < a.length; i++) {
@@ -133,7 +152,7 @@ function timingSafeEqual(a, b) {
   return result === 0;
 }
 
-export async function verifyHmac(body, secret) {
+export async function verifyHmac(body: ProxyChatPayload, secret: string): Promise<boolean> {
   const { messages, signature, timestamp } = body;
   const now = Math.floor(Date.now() / 1000);
 

--- a/proxy/wrangler.toml
+++ b/proxy/wrangler.toml
@@ -1,5 +1,5 @@
 name = "dobby-ai-proxy"
-main = "src/index.js"
+main = "src/index.ts"
 compatibility_date = "2024-01-01"
 
 # Create KV namespace: wrangler kv namespace create RATE_LIMIT_KV

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,24 +1,24 @@
-// @ts-check
-
-// src/background/index.js — Dobby AI API relay + streaming hub
+// src/background/index.ts — Dobby AI API relay + streaming hub
 // All API calls from content scripts route through here (MV3 cross-origin constraint)
 
 import { AUTOSUGGEST_MAX_SUGGESTION_TOKENS } from '../shared/autosuggest-limits.js';
 import { getLocalStorage, setLocalStorage } from '../shared/storage.js';
 
-/** @typedef {import('../shared/types').AutosuggestBackgroundPort} AutosuggestBackgroundPort */
-/** @typedef {import('../shared/types').AutosuggestStreamRequest} AutosuggestStreamRequest */
-/** @typedef {import('../shared/types').BackgroundRuntimeMessage} BackgroundRuntimeMessage */
-/** @typedef {import('../shared/types').CaptureScreenshotResponse} CaptureScreenshotResponse */
-/** @typedef {import('../shared/types').ChatMessage} ChatMessage */
-/** @typedef {import('../shared/types').ChatBackgroundPort} ChatBackgroundPort */
-/** @typedef {import('../shared/types').ChatStreamRequest} ChatStreamRequest */
-/** @typedef {import('../shared/types').ContentRuntimeMessage} ContentRuntimeMessage */
-/** @typedef {import('../shared/types').ToggleMessageType} ToggleMessageType */
-/** @typedef {import('../shared/types').UsageRequestKind} UsageRequestKind */
-/** @typedef {import('../shared/types').UsageState} UsageState */
-/** @typedef {import('../shared/types').UsageUpdateDetails} UsageUpdateDetails */
-/** @typedef {import('../shared/types').ValidateApiKeyResponse} ValidateApiKeyResponse */
+import type {
+  AutosuggestBackgroundPort,
+  AutosuggestStreamRequest,
+  BackgroundRuntimeMessage,
+  CaptureScreenshotResponse,
+  ChatBackgroundPort,
+  ChatMessage,
+  ChatStreamRequest,
+  ContentRuntimeMessage,
+  ToggleMessageType,
+  UsageRequestKind,
+  UsageState,
+  UsageUpdateDetails,
+  ValidateApiKeyResponse,
+} from '../shared/types';
 
 const PROXY_URL = 'https://dobby-ai-proxy.zhongnansu.workers.dev/chat';
 const USAGE_STORAGE_KEY = 'dobbyUsage';
@@ -28,13 +28,11 @@ const HMAC_SECRET = 'dobby-ai-v2-hmac-key-change-in-production';
 // Set to your dev token to bypass rate limits during development; leave empty for normal user behavior
 const DEV_BYPASS_TOKEN = '';
 
-/** @returns {string} */
-function getUtcDay() {
+function getUtcDay(): string {
   return new Date().toISOString().split('T')[0];
 }
 
-/** @returns {UsageState} */
-function createEmptyUsage() {
+function createEmptyUsage(): UsageState {
   return {
     day: getUtcDay(),
     chatRequests: 0,
@@ -46,11 +44,7 @@ function createEmptyUsage() {
   };
 }
 
-/**
- * @param {UsageRequestKind} kind
- * @param {UsageUpdateDetails} [details]
- */
-async function recordUsage(kind, details = {}) {
+async function recordUsage(kind: UsageRequestKind, details: UsageUpdateDetails = {}): Promise<void> {
   try {
     const stored = await getLocalStorage(USAGE_STORAGE_KEY);
     const current = stored[USAGE_STORAGE_KEY];
@@ -121,16 +115,11 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
 
 // --- Keyboard Commands ---
 
-/**
- * @param {number | undefined} tabId
- * @param {ContentRuntimeMessage} message
- */
-function sendContentMessage(tabId, message) {
-  return chrome.tabs.sendMessage(/** @type {number} */ (tabId), message);
+function sendContentMessage(tabId: number | undefined, message: ContentRuntimeMessage): Promise<unknown> {
+  return chrome.tabs.sendMessage(tabId as number, message);
 }
 
-/** @param {ContentRuntimeMessage} message */
-function notifyActiveTab(message) {
+function notifyActiveTab(message: ContentRuntimeMessage): void {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     const tabId = tabs?.[0]?.id;
     if (!tabId) return;
@@ -145,11 +134,10 @@ function notifyActiveTab(message) {
   });
 }
 
-/**
- * @param {'dobbyEnabled' | 'screenshotEnabled'} storageKey
- * @param {ToggleMessageType} messageType
- */
-function toggleStoredSetting(storageKey, messageType) {
+function toggleStoredSetting(
+  storageKey: 'dobbyEnabled' | 'screenshotEnabled',
+  messageType: ToggleMessageType,
+): void {
   getLocalStorage(storageKey, (data) => {
     const current = data[storageKey] !== false;
     const enabled = !current;
@@ -170,13 +158,11 @@ chrome.commands.onCommand.addListener((command) => {
 
 // --- HMAC Signing ---
 
-/**
- * @param {ChatMessage[]} messages
- * @param {number} timestamp
- * @param {string} secret
- * @returns {Promise<string>}
- */
-export async function generateSignature(messages, timestamp, secret) {
+export async function generateSignature(
+  messages: ChatMessage[],
+  timestamp: number,
+  secret: string,
+): Promise<string> {
   const payload = `${timestamp}${JSON.stringify(messages)}`;
   const encoder = new TextEncoder();
   const key = await crypto.subtle.importKey(
@@ -194,11 +180,9 @@ export async function generateSignature(messages, timestamp, secret) {
 
 // --- SSE Stream Parsing ---
 
-/**
- * @param {ReadableStreamDefaultReader<Uint8Array<ArrayBuffer>>} reader
- * @returns {AsyncGenerator<string>}
- */
-export async function* parseSSEStream(reader) {
+export async function* parseSSEStream(
+  reader: ReadableStreamDefaultReader<Uint8Array<ArrayBuffer>>,
+): AsyncGenerator<string> {
   const decoder = new TextDecoder();
   let buffer = '';
 
@@ -231,10 +215,10 @@ export async function* parseSSEStream(reader) {
 chrome.runtime.onConnect.addListener((port) => {
   if (port.name !== 'chat-stream') return;
 
-  const chatPort = /** @type {ChatBackgroundPort} */ (port);
-  let abortController = null;
+  const chatPort = port as ChatBackgroundPort;
+  let abortController: AbortController | null = null;
 
-  chatPort.onMessage.addListener(async (/** @type {ChatStreamRequest} */ msg) => {
+  chatPort.onMessage.addListener(async (msg: ChatStreamRequest) => {
     if (msg.type !== 'CHAT_REQUEST') return;
 
     abortController = new AbortController();
@@ -245,7 +229,7 @@ chrome.runtime.onConnect.addListener((port) => {
 
     try {
       const stored = await getLocalStorage('userApiKey');
-      let response;
+      let response: Response;
 
       if (stored.userApiKey) {
         // Direct to OpenAI with user's own key
@@ -267,7 +251,7 @@ chrome.runtime.onConnect.addListener((port) => {
         // Via proxy with HMAC signing
         const timestamp = Math.floor(Date.now() / 1000);
         const signature = await generateSignature(messages, timestamp, HMAC_SECRET);
-        const headers = { 'Content-Type': 'application/json' };
+        const headers: Record<string, string> = { 'Content-Type': 'application/json' };
         if (DEV_BYPASS_TOKEN) headers['X-Dev-Token'] = DEV_BYPASS_TOKEN;
         response = await fetch(PROXY_URL, {
           method: 'POST',
@@ -278,7 +262,7 @@ chrome.runtime.onConnect.addListener((port) => {
       }
 
       if (response.status === 429) {
-        let data;
+        let data: { remaining?: number; resetAt?: string | number };
         try { data = await response.json(); } catch (e) { console.warn('[Dobby AI] Failed to parse rate limit response'); data = { remaining: 0 }; }
         await recordUsage('chat', { remaining: data.remaining ?? 0, usingOwnKey: false, rateLimited: true });
         try { chatPort.postMessage({ type: 'rate_limited', remaining: data.remaining ?? 0, resetAt: data.resetAt }); } catch (e) { console.warn('[Dobby AI] port.postMessage failed:', e.message); }
@@ -324,10 +308,10 @@ chrome.runtime.onConnect.addListener((port) => {
 chrome.runtime.onConnect.addListener((port) => {
   if (port.name !== 'autosuggest-stream') return;
 
-  const autosuggestPort = /** @type {AutosuggestBackgroundPort} */ (port);
-  let abortController = null;
+  const autosuggestPort = port as AutosuggestBackgroundPort;
+  let abortController: AbortController | null = null;
 
-  autosuggestPort.onMessage.addListener(async (/** @type {AutosuggestStreamRequest} */ msg) => {
+  autosuggestPort.onMessage.addListener(async (msg: AutosuggestStreamRequest) => {
     if (msg.type !== 'AUTOSUGGEST_REQUEST') return;
 
     abortController = new AbortController();
@@ -338,7 +322,7 @@ chrome.runtime.onConnect.addListener((port) => {
 
     try {
       const stored = await getLocalStorage('userApiKey');
-      let response;
+      let response: Response;
 
       if (stored.userApiKey) {
         // Direct to OpenAI with user's own key
@@ -360,7 +344,7 @@ chrome.runtime.onConnect.addListener((port) => {
         // Via proxy with HMAC signing — include purpose for rate limiting
         const timestamp = Math.floor(Date.now() / 1000);
         const signature = await generateSignature(messages, timestamp, HMAC_SECRET);
-        const headers = { 'Content-Type': 'application/json' };
+        const headers: Record<string, string> = { 'Content-Type': 'application/json' };
         if (DEV_BYPASS_TOKEN) headers['X-Dev-Token'] = DEV_BYPASS_TOKEN;
         response = await fetch(PROXY_URL, {
           method: 'POST',
@@ -371,7 +355,7 @@ chrome.runtime.onConnect.addListener((port) => {
       }
 
       if (response.status === 429) {
-        let data;
+        let data: { remaining?: number };
         try { data = await response.json(); } catch (e) { data = { remaining: 0 }; }
         await recordUsage('autosuggest', { usingOwnKey: false, rateLimited: true });
         try { autosuggestPort.postMessage({ type: 'rate_limited', remaining: data.remaining ?? 0 }); } catch (e) { /* port closed */ }
@@ -409,9 +393,9 @@ chrome.runtime.onConnect.addListener((port) => {
 // --- API Key Validation ---
 
 chrome.runtime.onMessage.addListener((
-  /** @type {BackgroundRuntimeMessage} */ msg,
+  msg: BackgroundRuntimeMessage,
   sender,
-  /** @type {(response: CaptureScreenshotResponse | ValidateApiKeyResponse) => void} */ sendResponse,
+  sendResponse: (response: CaptureScreenshotResponse | ValidateApiKeyResponse) => void,
 ) => {
   if (msg.type === 'CAPTURE_SCREENSHOT') {
     chrome.tabs.captureVisibleTab(null, { format: 'png' }, (dataUrl) => {


### PR DESCRIPTION
## Summary

- migrate the background service worker entry to TypeScript
- migrate all Cloudflare proxy production modules to TypeScript
- define explicit Worker environment, KV, validation, and rate-limit contracts
- update esbuild and Wrangler source entry points while preserving output entry names

Closes #168

## Compatibility

- extension still emits `dist/background.js`; Chrome manifest entries are unchanged
- Wrangler Worker bundle is executable-code identical to the JavaScript baseline; only source filename comments differ
- background bundle differences are limited to source filename comments and erased JSDoc assertions
- proxy request/response bodies, HTTP statuses, headers, SSE framing, errors, and limits are unchanged

## Verification

- `npm run typecheck`
- `npm run build`
- `npm test` (620 passed)
- `npm run test:e2e` (24 passed)
- `npm test` in `proxy/` (75 passed)
- `wrangler deploy --dry-run` (passed; 11.65 KiB / gzip 3.47 KiB, matching baseline)
- `git diff --check`