### PR TITLE
[codex] Migrate popup and options pages to TypeScript

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -33,7 +33,7 @@ async function build() {
     const contexts = await Promise.all([
       esbuild.context({ ...sharedConfig, entryPoints: ['src/content/index.js'], outfile: `${DIST}/content.js` }),
       esbuild.context({ ...sharedConfig, entryPoints: ['src/background/index.ts'], outfile: `${DIST}/background.js` }),
-      esbuild.context({ ...sharedConfig, entryPoints: ['src/popup.js', 'src/options.js'], outdir: DIST }),
+      esbuild.context({ ...sharedConfig, entryPoints: ['src/popup.ts', 'src/options.ts'], outdir: DIST }),
     ]);
     copyStaticAssets();
     await Promise.all(contexts.map(ctx => ctx.watch()));
@@ -41,7 +41,7 @@ async function build() {
   } else {
     await esbuild.build({ ...sharedConfig, entryPoints: ['src/content/index.js'], outfile: `${DIST}/content.js` });
     await esbuild.build({ ...sharedConfig, entryPoints: ['src/background/index.ts'], outfile: `${DIST}/background.js` });
-    await esbuild.build({ ...sharedConfig, entryPoints: ['src/popup.js', 'src/options.js'], outdir: DIST });
+    await esbuild.build({ ...sharedConfig, entryPoints: ['src/popup.ts', 'src/options.ts'], outdir: DIST });
     copyStaticAssets();
     console.log('Build complete → dist/');
   }

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,32 +1,31 @@
-// @ts-check
-
-// options.js — Dobby AI settings page
+// options.ts — Dobby AI settings page
 import { applyColorVariables } from './shared/color-palette.js';
 import { COLOR_SCHEME_QUERY, normalizeThemeMode, resolveTheme } from './shared/theme.js';
 import { getLocalStorage, removeLocalStorage } from './shared/storage.js';
 import { createValidateApiKeyMessage } from './shared/runtime-messages.js';
+import type { ThemeMode, ValidateApiKeyResponse } from './shared/types';
 
-/** @typedef {import('./shared/types').StorageState} StorageState */
-/** @typedef {import('./shared/types').ThemeMode} ThemeMode */
-/** @typedef {import('./shared/types').ValidateApiKeyResponse} ValidateApiKeyResponse */
+function requiredElement<T extends HTMLElement>(id: string): T {
+  const element = document.getElementById(id);
+  if (!element) throw new Error(`Missing required options element: ${id}`);
+  return element as T;
+}
 
-const apiKeyInput = /** @type {HTMLInputElement} */ (document.getElementById('api-key-input'));
-const saveBtn = /** @type {HTMLButtonElement} */ (document.getElementById('save-btn'));
-const removeBtn = document.getElementById('remove-btn');
-const keyStatus = document.getElementById('key-status');
-const hasKeySection = document.getElementById('has-key');
-const noKeySection = document.getElementById('no-key');
-const keyDisplay = document.getElementById('key-display');
+const apiKeyInput = requiredElement<HTMLInputElement>('api-key-input');
+const saveBtn = requiredElement<HTMLButtonElement>('save-btn');
+const removeBtn = requiredElement<HTMLButtonElement>('remove-btn');
+const keyStatus = requiredElement<HTMLElement>('key-status');
+const hasKeySection = requiredElement<HTMLElement>('has-key');
+const noKeySection = requiredElement<HTMLElement>('no-key');
+const keyDisplay = requiredElement<HTMLElement>('key-display');
 const versionEl = document.getElementById('extension-version');
-/** @type {ThemeMode} */
-let themeMode = 'auto';
+let themeMode: ThemeMode = 'auto';
 
 if (versionEl && chrome.runtime.getManifest) {
   versionEl.textContent = `v${chrome.runtime.getManifest().version}`;
 }
 
-/** @param {unknown} value */
-function applyTheme(value) {
+function applyTheme(value: unknown): void {
   themeMode = normalizeThemeMode(value);
   const resolvedTheme = resolveTheme(themeMode);
   applyColorVariables(document.documentElement, resolvedTheme);
@@ -35,20 +34,18 @@ function applyTheme(value) {
   document.documentElement.style.colorScheme = resolvedTheme;
 }
 
-/** @param {string} key */
-function maskKey(key) {
+function maskKey(key: string): string {
   if (!key || key.length < 12) return '••••••••';
   return key.substring(0, 7) + '••••' + key.substring(key.length - 4);
 }
 
-/** @param {string} key */
-function showHasKey(key) {
+function showHasKey(key: string): void {
   hasKeySection.style.display = 'block';
   noKeySection.style.display = 'none';
   keyDisplay.textContent = maskKey(key);
 }
 
-function showNoKey() {
+function showNoKey(): void {
   hasKeySection.style.display = 'none';
   noKeySection.style.display = 'block';
   apiKeyInput.value = '';
@@ -104,7 +101,7 @@ saveBtn.addEventListener('click', async () => {
   keyStatus.textContent = 'Validating...';
   keyStatus.className = 'status info';
 
-  chrome.runtime.sendMessage(createValidateApiKeyMessage(key), (/** @type {ValidateApiKeyResponse} */ response) => {
+  chrome.runtime.sendMessage(createValidateApiKeyMessage(key), (response: ValidateApiKeyResponse) => {
     saveBtn.disabled = false;
     if (response && response.valid) {
       keyStatus.textContent = '';
@@ -129,11 +126,11 @@ removeBtn.addEventListener('click', () => {
 });
 
 // Provider tab switching
-/** @type {NodeListOf<HTMLElement>} */ (document.querySelectorAll('.provider-tab')).forEach((tab) => {
+document.querySelectorAll<HTMLElement>('.provider-tab').forEach((tab) => {
   tab.addEventListener('click', () => {
     document.querySelectorAll('.provider-tab').forEach((t) => t.classList.remove('active'));
     document.querySelectorAll('.provider-panel').forEach((p) => p.classList.remove('active'));
     tab.classList.add('active');
-    document.getElementById(`panel-${tab.dataset.provider}`).classList.add('active');
+    requiredElement<HTMLElement>(`panel-${tab.dataset.provider}`).classList.add('active');
   });
 });

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -1,46 +1,47 @@
-// @ts-check
-
 import { applyColorVariables } from './shared/color-palette.js';
 import { COLOR_SCHEME_QUERY, normalizeThemeMode, resolveTheme } from './shared/theme.js';
 import { getLocalStorage, setLocalStorage } from './shared/storage.js';
 import { SHOW_HISTORY_MESSAGE } from './shared/runtime-messages.js';
-
-/** @typedef {import('./shared/types').ContentRuntimeMessage} ContentRuntimeMessage */
-/** @typedef {import('./shared/types').HistoryEntry} HistoryEntry */
-/** @typedef {import('./shared/types').StorageState} StorageState */
-/** @typedef {import('./shared/types').ThemeMode} ThemeMode */
-/** @typedef {import('./shared/types').UsageState} UsageState */
+import type {
+  ContentRuntimeMessage,
+  HistoryEntry,
+  StorageState,
+  ThemeMode,
+  UsageState,
+} from './shared/types';
 
 const FREE_CHAT_LIMIT = 30;
 const LOW_QUOTA_THRESHOLD = 5;
 
-const toggle = /** @type {HTMLInputElement} */ (document.getElementById('enabled'));
-const status = document.getElementById('status');
-const screenshotToggle = /** @type {HTMLInputElement} */ (document.getElementById('screenshot-enabled'));
-const screenshotStatus = document.getElementById('screenshot-status');
-const autosuggestToggle = /** @type {HTMLInputElement} */ (document.getElementById('autosuggest-enabled'));
-const autosuggestStatus = document.getElementById('autosuggest-status');
-const settingsBtn = document.getElementById('settings');
-const historyBtn = /** @type {HTMLButtonElement} */ (document.getElementById('history'));
-const clearHistoryBtn = /** @type {HTMLButtonElement} */ (document.getElementById('clear-history'));
-const feedback = document.getElementById('action-feedback');
-const usageCard = document.getElementById('usage-card');
-const usagePrimary = document.getElementById('usage-primary');
-const usageSecondary = document.getElementById('usage-secondary');
-const versionEl = document.getElementById('version');
-const themeOptions = /** @type {NodeListOf<HTMLElement>} */ (document.querySelectorAll('.theme-option'));
-/** @type {ThemeMode} */
-let themeMode = 'auto';
-/** @type {MediaQueryList | null} */
-let colorSchemeQuery = null;
+function requiredElement<T extends HTMLElement>(id: string): T {
+  const element = document.getElementById(id);
+  if (!element) throw new Error(`Missing required popup element: ${id}`);
+  return element as T;
+}
 
-/** @returns {string} */
-function getUtcDay() {
+const toggle = requiredElement<HTMLInputElement>('enabled');
+const status = requiredElement<HTMLElement>('status');
+const screenshotToggle = requiredElement<HTMLInputElement>('screenshot-enabled');
+const screenshotStatus = requiredElement<HTMLElement>('screenshot-status');
+const autosuggestToggle = requiredElement<HTMLInputElement>('autosuggest-enabled');
+const autosuggestStatus = requiredElement<HTMLElement>('autosuggest-status');
+const settingsBtn = requiredElement<HTMLButtonElement>('settings');
+const historyBtn = requiredElement<HTMLButtonElement>('history');
+const clearHistoryBtn = requiredElement<HTMLButtonElement>('clear-history');
+const feedback = requiredElement<HTMLElement>('action-feedback');
+const usageCard = requiredElement<HTMLElement>('usage-card');
+const usagePrimary = requiredElement<HTMLElement>('usage-primary');
+const usageSecondary = requiredElement<HTMLElement>('usage-secondary');
+const versionEl = document.getElementById('version');
+const themeOptions = document.querySelectorAll<HTMLElement>('.theme-option');
+let themeMode: ThemeMode = 'auto';
+let colorSchemeQuery: MediaQueryList | null = null;
+
+function getUtcDay(): string {
   return new Date().toISOString().split('T')[0];
 }
 
-/** @param {unknown} value */
-function applyTheme(value) {
+function applyTheme(value: unknown): void {
   themeMode = normalizeThemeMode(value);
   const resolvedTheme = resolveTheme(themeMode);
   applyColorVariables(document.documentElement, resolvedTheme);
@@ -49,31 +50,29 @@ function applyTheme(value) {
   document.documentElement.style.colorScheme = resolvedTheme;
 }
 
-function getResetTimeLabel() {
+function getResetTimeLabel(): string {
   const reset = new Date();
   reset.setUTCHours(24, 0, 0, 0);
   return reset.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
 }
 
-/**
- * @param {HTMLInputElement} input
- * @param {HTMLElement} stateEl
- * @param {boolean} enabled
- */
-function setSwitchState(input, stateEl, enabled) {
+function setSwitchState(input: HTMLInputElement, stateEl: HTMLElement, enabled: boolean): void {
   input.checked = enabled;
   stateEl.textContent = enabled ? 'On' : 'Off';
   stateEl.classList.toggle('on', enabled);
   stateEl.classList.toggle('off', !enabled);
 }
 
-/** @param {string} message */
-function setFeedback(message) {
+function setFeedback(message: string): void {
   feedback.textContent = message || '';
 }
 
-/** @param {UsageState | undefined} rawUsage */
-function todayUsage(rawUsage) {
+type UsageSummary = Pick<
+  UsageState,
+  'chatRequests' | 'autosuggestRequests' | 'screenshotRequests' | 'freeChatRemaining'
+>;
+
+function todayUsage(rawUsage: UsageState | undefined): UsageSummary {
   if (!rawUsage || rawUsage.day !== getUtcDay()) {
     return {
       chatRequests: 0,
@@ -85,8 +84,7 @@ function todayUsage(rawUsage) {
   return rawUsage;
 }
 
-/** @param {Pick<StorageState, 'userApiKey' | 'dobbyUsage'>} state */
-function renderUsage({ userApiKey, dobbyUsage }) {
+function renderUsage({ userApiKey, dobbyUsage }: Pick<StorageState, 'userApiKey' | 'dobbyUsage'>): void {
   const usage = todayUsage(dobbyUsage);
   usageCard.classList.remove('ok', 'warning', 'danger');
 
@@ -115,14 +113,13 @@ function renderUsage({ userApiKey, dobbyUsage }) {
   usageSecondary.textContent = `Resets around ${getResetTimeLabel()}. Today: ${usage.chatRequests || 0} chats, ${usage.autosuggestRequests || 0} suggestions, ${usage.screenshotRequests || 0} screenshots.`;
 }
 
-/** @param {HistoryEntry[]} history */
-function setHistoryState(history) {
+function setHistoryState(history: HistoryEntry[]): void {
   const hasHistory = Array.isArray(history) && history.length > 0;
   historyBtn.disabled = !hasHistory;
   clearHistoryBtn.disabled = !hasHistory;
 }
 
-function loadPopupState() {
+function loadPopupState(): void {
   getLocalStorage([
     'dobbyEnabled',
     'screenshotEnabled',
@@ -142,17 +139,15 @@ function loadPopupState() {
   });
 }
 
-/** @param {ContentRuntimeMessage} message */
-function broadcastToContent(message) {
+function broadcastToContent(message: ContentRuntimeMessage): void {
   chrome.tabs.query({ url: ['http://*/*', 'https://*/*'] }, (tabs) => {
     tabs.forEach((tab) => {
-      chrome.tabs.sendMessage(/** @type {number} */ (tab.id), message).catch(() => {});
+      chrome.tabs.sendMessage(tab.id as number, message).catch(() => {});
     });
   });
 }
 
-/** @param {ThemeMode} value */
-function setActiveThemeOption(value) {
+function setActiveThemeOption(value: ThemeMode): void {
   themeOptions.forEach((btn) => {
     const isActive = btn.dataset.theme === value;
     btn.classList.toggle('active', isActive);


### PR DESCRIPTION
## Summary

- migrate popup and options production entries from JavaScript to TypeScript
- replace JSDoc casts with explicit DOM, storage, message, theme, and usage types
- add required-element guards for required page markup while preserving optional version elements
- update esbuild source entry points while preserving `dist/popup.js` and `dist/options.js`

Closes #169

## Compatibility

- existing HTML, IDs, CSS classes, labels, accessibility attributes, and output script names are unchanged
- storage keys, runtime messages, interactions, and rendered behavior are unchanged
- no React adoption or UI redesign is included

## Verification

- `npm run typecheck`
- `npm run build`
- `npm test` (620 passed)
- `npm run test:e2e` (24 passed)
- `git diff --check`