### PR TITLE
chore: type shared content state for strict mode

### DIFF
--- a/src/content/autosuggest/debounce.ts
+++ b/src/content/autosuggest/debounce.ts
@@ -7,7 +7,7 @@ import {
   setAutosuggestPendingRequest,
 } from '../shared/state.js';
 
-export function debouncedSuggest(text, callback) {
+export function debouncedSuggest(text: string, callback: (text: string) => void) {
   cancelPending();
   if (text.length < AUTOSUGGEST.MIN_CHARS) return;
   const timer = setTimeout(() => {

--- a/src/content/autosuggest/ghost-text.ts
+++ b/src/content/autosuggest/ghost-text.ts
@@ -6,7 +6,7 @@ import {
 } from '../shared/state.js';
 import { getGhostTextStyles } from './styles.js';
 
-export function showGhostText(textarea, suggestion) {
+export function showGhostText(textarea: HTMLTextAreaElement, suggestion: string) {
   setAutosuggestCurrentSuggestion(suggestion);
 
   // Remove existing overlay if any
@@ -91,14 +91,14 @@ export function hideGhostText() {
   setAutosuggestCurrentSuggestion('');
 }
 
-export function acceptSuggestion(textarea) {
+export function acceptSuggestion(textarea: HTMLTextAreaElement) {
   const host = autosuggestOverlayHost;
   if (!host) return;
 
-  const ghost = host.shadowRoot.querySelector('.ghost-text');
+  const ghost = host.shadowRoot!.querySelector('.ghost-text');
   if (!ghost) return;
 
-  const suggestion = ghost.textContent;
+  const suggestion = ghost.textContent!;
   const pos = textarea.selectionStart;
 
   // Insert suggestion at cursor position

--- a/src/content/autosuggest/index.ts
+++ b/src/content/autosuggest/index.ts
@@ -11,18 +11,18 @@ import { buildCompletionMessages, gatherPageContext } from './context.js';
 import { showGhostText, hideGhostText, acceptSuggestion } from './ghost-text.js';
 import { requestAutosuggest } from '../api.js';
 
-let focusinHandler = null;
-let focusoutHandler = null;
+let focusinHandler: ((event: FocusEvent) => void) | null = null;
+let focusoutHandler: ((event: FocusEvent) => void) | null = null;
 
 export function initAutosuggest() {
   if (!autosuggestEnabled) return;
   if (focusinHandler || focusoutHandler) return;
 
-  focusinHandler = (e) => {
-    if (e.target.tagName === 'TEXTAREA') attachToTextarea(e.target);
+  focusinHandler = (e: FocusEvent) => {
+    if ((e.target as HTMLElement).tagName === 'TEXTAREA') attachToTextarea(e.target as HTMLTextAreaElement);
   };
 
-  focusoutHandler = (e) => {
+  focusoutHandler = (e: FocusEvent) => {
     if (e.target === autosuggestActiveTextarea) detachFromTextarea();
   };
 
@@ -42,7 +42,7 @@ export function destroyAutosuggest() {
   }
 }
 
-function attachToTextarea(textarea) {
+function attachToTextarea(textarea: HTMLTextAreaElement) {
   if (autosuggestActiveTextarea) detachFromTextarea();
   setAutosuggestActiveTextarea(textarea);
   textarea.addEventListener('input', handleInput);
@@ -60,22 +60,22 @@ function detachFromTextarea() {
   setAutosuggestActiveTextarea(null);
 }
 
-function handleInput(e) {
+function handleInput(e: Event) {
   hideGhostText();
-  const text = e.target.value;
-  debouncedSuggest(text, (t) => requestSuggestionFromAPI(t, e.target));
+  const text = (e.target as HTMLTextAreaElement).value;
+  debouncedSuggest(text, (t) => requestSuggestionFromAPI(t, e.target as HTMLTextAreaElement));
 }
 
-function handleKeydown(e) {
+function handleKeydown(e: KeyboardEvent) {
   if (e.key === 'Tab' && autosuggestCurrentSuggestion) {
     e.preventDefault();
-    acceptSuggestion(autosuggestActiveTextarea);
+    acceptSuggestion(autosuggestActiveTextarea!);
   } else if (e.key === 'Escape' && autosuggestCurrentSuggestion) {
     hideGhostText();
   }
 }
 
-function requestSuggestionFromAPI(text, textarea) {
+function requestSuggestionFromAPI(text: string, textarea: HTMLTextAreaElement) {
   const messages = buildCompletionMessages(text, gatherPageContext(textarea));
 
   let accumulated = '';

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -105,7 +105,7 @@ chrome.runtime.onMessage.addListener((/** @type {ContentRuntimeMessage} */ msg) 
 setTimeout(() => {
   document.addEventListener('mousedown', (e) => {
     const bubble = getBubbleContainer();
-    if (bubble && !bubble.contains(e.target)) {
+    if (bubble && !bubble.contains(e.target as Node | null)) {
       if (isClickInsideUI(e.target, getBubbleContainer)) return;
       if (bubble._isPinned) return;
       hideBubble();

--- a/src/content/shared/dom-utils.ts
+++ b/src/content/shared/dom-utils.ts
@@ -1,10 +1,10 @@
 // src/content/shared/dom-utils.js — Shared DOM utility functions
 
-export function removeElement(el) {
+export function removeElement(el: Node | null) {
   if (el?.parentNode) el.parentNode.removeChild(el);
 }
 
-export function stopShadowRootKeyboardEventPropagation(shadowRoot) {
+export function stopShadowRootKeyboardEventPropagation(shadowRoot: ShadowRoot) {
   for (const eventType of ['keydown', 'keypress', 'keyup']) {
     shadowRoot.addEventListener(eventType, (event) => {
       // Keep composed keyboard events from reaching host-page bubble listeners.
@@ -13,26 +13,26 @@ export function stopShadowRootKeyboardEventPropagation(shadowRoot) {
   }
 }
 
-export function isClickInsideUI(target, getBubbleContainer) {
+export function isClickInsideUI(target: EventTarget | null, getBubbleContainer: () => HTMLElement | null) {
   const trigger = document.getElementById('dobby-ai-trigger');
-  if (trigger?.contains(target)) return true;
+  if (trigger?.contains(target as Node | null)) return true;
   const toolbarHost = document.getElementById('dobby-ai-toolbar-host');
-  if (toolbarHost?.contains(target)) return true;
+  if (toolbarHost?.contains(target as Node | null)) return true;
   if (typeof getBubbleContainer === 'function') {
     const bc = getBubbleContainer();
-    if (bc?.contains(target)) return true;
+    if (bc?.contains(target as Node | null)) return true;
   }
   return false;
 }
 
-export function getSelectedText() {
-  return window.getSelection().toString().trim();
+export function getSelectedText(): string {
+  return window.getSelection()!.toString().trim();
 }
 
-export function getSelectionRect() {
+export function getSelectionRect(): DOMRect | { top: number; right: number; bottom: number; left: number } {
   const selection = window.getSelection();
-  if (selection.rangeCount > 0) {
-    return selection.getRangeAt(0).getBoundingClientRect();
+  if (selection!.rangeCount > 0) {
+    return selection!.getRangeAt(0).getBoundingClientRect();
   }
   return { top: 180, right: 300, bottom: 200, left: 100 };
 }

--- a/src/content/shared/state.ts
+++ b/src/content/shared/state.ts
@@ -1,44 +1,53 @@
 // src/content/shared/state.js — Central mutable state for content scripts
+import type {
+  BubbleHost,
+  ChatMessage,
+  LongPressState,
+  ScreenshotState,
+  StreamRequestHandle,
+  ToolbarHost,
+  ToolbarState,
+} from '../../shared/types';
 
 // Bubble state
-export let bubbleHost = null;
-export let currentMessages = [];
+export let bubbleHost: BubbleHost | null = null;
+export let currentMessages: ChatMessage[] = [];
 export let responseText = '';
-export let currentRequest = null;
-export let renderTimer = null;
+export let currentRequest: StreamRequestHandle | null = null;
+export let renderTimer: ReturnType<typeof setTimeout> | null = null;
 
-export function setBubbleHost(v) { bubbleHost = v; }
-export function setCurrentMessages(v) { currentMessages = v; }
-export function setResponseText(v) { responseText = v; }
-export function appendResponseText(v) { responseText += v; }
-export function setCurrentRequest(v) { currentRequest = v; }
-export function setRenderTimer(v) { renderTimer = v; }
+export function setBubbleHost(v: BubbleHost | null) { bubbleHost = v; }
+export function setCurrentMessages(v: ChatMessage[]) { currentMessages = v; }
+export function setResponseText(v: string) { responseText = v; }
+export function appendResponseText(v: string) { responseText += v; }
+export function setCurrentRequest(v: StreamRequestHandle | null) { currentRequest = v; }
+export function setRenderTimer(v: ReturnType<typeof setTimeout> | null) { renderTimer = v; }
 
 // Raw AI response tracking (for copy button)
-export let rawResponses = [];
-export function pushRawResponse(text) { rawResponses.push(text); return rawResponses.length - 1; }
+export let rawResponses: string[] = [];
+export function pushRawResponse(text: string) { rawResponses.push(text); return rawResponses.length - 1; }
 export function clearRawResponses() { rawResponses.length = 0; }
 
 // Trigger state
-export let triggerButton = null;
+export let triggerButton: ToolbarHost | null = null;
 export let dobbyEnabled = true;
 
-export function setTriggerButton(v) { triggerButton = v; }
-export function setDobbyEnabled(v) { dobbyEnabled = v; }
+export function setTriggerButton(v: ToolbarHost | null) { triggerButton = v; }
+export function setDobbyEnabled(v: boolean) { dobbyEnabled = v; }
 
 // Toolbar state
-export let toolbarHost = null;
-export let toolbarState = 'collapsed'; // 'collapsed' | 'expanded' | 'input' | 'morphed'
+export let toolbarHost: ToolbarHost | null = null;
+export let toolbarState: ToolbarState = 'collapsed';
 
-export function setToolbarHost(host) { toolbarHost = host; }
-export function setToolbarState(state) { toolbarState = state; }
+export function setToolbarHost(host: ToolbarHost | null) { toolbarHost = host; }
+export function setToolbarState(state: ToolbarState) { toolbarState = state; }
 
 // Screenshot mode toggle
 export let screenshotEnabled = true;
-export function setScreenshotEnabled(v) { screenshotEnabled = v; }
+export function setScreenshotEnabled(v: boolean) { screenshotEnabled = v; }
 
 // Screenshot state
-export const screenshotState = {
+export const screenshotState: ScreenshotState = {
   overlay: null,
   startX: 0,
   startY: 0,
@@ -55,7 +64,7 @@ export function resetScreenshotState() {
 }
 
 // Long-press state
-export const longPressState = {
+export const longPressState: LongPressState = {
   timer: null,
   startX: 0,
   startY: 0,
@@ -64,26 +73,26 @@ export const longPressState = {
 };
 
 // Timer state (for selection/scroll debounce)
-export let selectionChangeTimer = null;
-export let scrollTimer = null;
+export let selectionChangeTimer: ReturnType<typeof setTimeout> | null = null;
+export let scrollTimer: ReturnType<typeof setTimeout> | null = null;
 
-export function setSelectionChangeTimer(v) { selectionChangeTimer = v; }
-export function setScrollTimer(v) { scrollTimer = v; }
+export function setSelectionChangeTimer(v: ReturnType<typeof setTimeout> | null) { selectionChangeTimer = v; }
+export function setScrollTimer(v: ReturnType<typeof setTimeout> | null) { scrollTimer = v; }
 
 // Autosuggest state
 export let autosuggestEnabled = false;
-export let autosuggestActiveTextarea = null;
+export let autosuggestActiveTextarea: HTMLTextAreaElement | null = null;
 export let autosuggestCurrentSuggestion = '';
-export let autosuggestOverlayHost = null;
-export let autosuggestPendingRequest = null;
-export let autosuggestDebounceTimer = null;
+export let autosuggestOverlayHost: HTMLDivElement | null = null;
+export let autosuggestPendingRequest: StreamRequestHandle | null = null;
+export let autosuggestDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
-export function setAutosuggestEnabled(v) { autosuggestEnabled = v; }
-export function setAutosuggestActiveTextarea(v) { autosuggestActiveTextarea = v; }
-export function setAutosuggestCurrentSuggestion(v) { autosuggestCurrentSuggestion = v; }
-export function setAutosuggestOverlayHost(v) { autosuggestOverlayHost = v; }
-export function setAutosuggestPendingRequest(v) { autosuggestPendingRequest = v; }
-export function setAutosuggestDebounceTimer(v) { autosuggestDebounceTimer = v; }
+export function setAutosuggestEnabled(v: boolean) { autosuggestEnabled = v; }
+export function setAutosuggestActiveTextarea(v: HTMLTextAreaElement | null) { autosuggestActiveTextarea = v; }
+export function setAutosuggestCurrentSuggestion(v: string) { autosuggestCurrentSuggestion = v; }
+export function setAutosuggestOverlayHost(v: HTMLDivElement | null) { autosuggestOverlayHost = v; }
+export function setAutosuggestPendingRequest(v: StreamRequestHandle | null) { autosuggestPendingRequest = v; }
+export function setAutosuggestDebounceTimer(v: ReturnType<typeof setTimeout> | null) { autosuggestDebounceTimer = v; }
 
 export function resetAutosuggestState() {
   autosuggestEnabled = false;


### PR DESCRIPTION
Part of #171

## What changed
- Add explicit types to shared content-script state and setter APIs.
- Type shared DOM helpers and autosuggest lifecycle/helpers.
- Add compile-time assertions at existing DOM event boundaries.

## Compatibility
- Generated `dist/content.js` is byte-for-byte identical to `main`.
- No runtime behavior, DOM, messages, storage, or public exports changed.

## Validation
- Focused strict check for `src/content/shared/*` and `src/content/autosuggest/*`: no errors
- `npm run typecheck`
- `npm run build`
- `npm test` (620 tests)
- `npm run test:e2e` (24 Chromium extension tests)
- `git diff --check`
- Byte-for-byte content bundle comparison against `main`