### PR TITLE
chore: type pure content modules for strict mode

### DIFF
--- a/src/content/bubble/markdown.ts
+++ b/src/content/bubble/markdown.ts
@@ -1,11 +1,13 @@
 // src/content/bubble/markdown.js — Pure markdown rendering functions
 
-export function escapeHtml(text) {
+type MarkdownImage = { alt: string; url: string };
+
+export function escapeHtml(text: string): string {
   return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 }
 
-function isValidImageUrl(url) {
+function isValidImageUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
     return parsed.protocol === 'https:';
@@ -14,16 +16,16 @@ function isValidImageUrl(url) {
   }
 }
 
-export function renderMarkdown(text) {
+export function renderMarkdown(text: string): string {
   // Extract code blocks first so their contents are not processed
-  const codeBlocks = [];
+  const codeBlocks: string[] = [];
   let processed = text.replace(/```([\s\S]*?)```/g, (_, code) => {
     codeBlocks.push(code);
     return `%%CODEBLOCK_${codeBlocks.length - 1}%%`;
   });
 
   // Extract images before escaping (they need real <img> tags)
-  const images = [];
+  const images: MarkdownImage[] = [];
   processed = processed.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (_, alt, url) => {
     if (isValidImageUrl(url)) {
       images.push({ alt: escapeHtml(alt), url: escapeHtml(url) });

--- a/src/content/bubble/styles.ts
+++ b/src/content/bubble/styles.ts
@@ -1,8 +1,9 @@
 // src/content/bubble/styles.js — CSS-in-JS styles for Dobby AI chat bubble (Shadow DOM)
 import { FONT_STACK } from '../shared/constants.js';
 import { getColorPalette } from '../../shared/color-palette.js';
+import type { ResolvedTheme } from '../../shared/types';
 
-export function getStyles(theme) {
+export function getStyles(theme: ResolvedTheme): string {
   const colors = getColorPalette(theme);
   const accent = colors.accent;
   const accentInteractive = colors.accentInteractive;

--- a/src/content/detection.ts
+++ b/src/content/detection.ts
@@ -1,5 +1,8 @@
 // Content type detection — determines smart presets based on selected text
 // Enhanced in v1.1: rich detection objects with sub-type, confidence, and metadata
+import type { CodeSubtype, DetectionResult, ForeignSubtype } from '../shared/types';
+
+type ConfidenceResult = { confidence: number };
 
 /**
  * Detect the content type of selected text.
@@ -7,13 +10,13 @@
  * @param {Node|null} anchorNode - The DOM node where selection starts
  * @returns {{ type: string, subType: string|null, confidence: number, wordCount: number, charCount: number }}
  */
-export function detectContentType(text, anchorNode) {
+export function detectContentType(text: string, anchorNode: Node | null): DetectionResult {
   const charCount = text.length;
   const wordCount = text.trim() === '' ? 0 : text.trim().split(/\s+/).length;
 
   // --- Priority 1: Code in <pre> or <code> DOM node ---
   if (anchorNode) {
-    let node = anchorNode;
+    let node: Node | null = anchorNode;
     while (node) {
       const tag = node.nodeName?.toLowerCase();
       if (tag === 'pre' || tag === 'code') {
@@ -72,7 +75,7 @@ export function detectContentType(text, anchorNode) {
 
 // ─── Code heuristics ────────────────────────────────────────────────────────
 
-function detectCodeHeuristics(text) {
+function detectCodeHeuristics(text: string): ConfidenceResult | null {
   const hasBraces = /[{}]/.test(text);
   const hasSemicolons = /;/.test(text);
   const hasIndentation = /^\s{2,}/m.test(text);
@@ -99,8 +102,8 @@ function detectCodeHeuristics(text) {
 
 // ─── Programming language sub-type detection ────────────────────────────────
 
-export function detectCodeLanguage(text) {
-  const scores = {
+export function detectCodeLanguage(text: string): CodeSubtype | null {
+  const scores: Record<CodeSubtype, number> = {
     javascript: 0,
     python: 0,
     rust: 0,
@@ -181,12 +184,12 @@ export function detectCodeLanguage(text) {
   if (/\b(function\s+\w+|class\s+\w+)\b/.test(text) && /\$\w+/.test(text)) scores.php += 2;
 
   // Find the highest scoring language
-  let best = null;
+  let best: CodeSubtype | null = null;
   let bestScore = 0;
   for (const [lang, score] of Object.entries(scores)) {
     if (score > bestScore) {
       bestScore = score;
-      best = lang;
+      best = lang as CodeSubtype;
     }
   }
 
@@ -196,7 +199,7 @@ export function detectCodeLanguage(text) {
 
 // ─── Error / stack trace detection ──────────────────────────────────────────
 
-export function detectError(text) {
+export function detectError(text: string): ConfidenceResult | null {
   let signals = 0;
 
   if (/\b(Error|Exception|TypeError|ReferenceError|SyntaxError|RangeError|ValueError|KeyError|RuntimeError|NullPointerException|IndexOutOfBoundsException)\b/.test(text)) signals += 2;
@@ -216,7 +219,7 @@ export function detectError(text) {
 
 // ─── Math / formula detection ───────────────────────────────────────────────
 
-export function detectMath(text) {
+export function detectMath(text: string): ConfidenceResult | null {
   let signals = 0;
 
   // LaTeX patterns
@@ -245,7 +248,7 @@ export function detectMath(text) {
 
 // ─── List / structured data detection ───────────────────────────────────────
 
-export function detectData(text) {
+export function detectData(text: string): ConfidenceResult | null {
   let signals = 0;
 
   // JSON-like structure
@@ -281,7 +284,7 @@ export function detectData(text) {
 
 // ─── Email / message detection ──────────────────────────────────────────────
 
-export function detectEmail(text) {
+export function detectEmail(text: string): ConfidenceResult | null {
   let signals = 0;
 
   if (/^(Subject|From|To|Cc|Bcc|Date):\s/m.test(text)) signals += 3;
@@ -297,13 +300,13 @@ export function detectEmail(text) {
   return null;
 }
 
-function wordCount(text) {
+function wordCount(text: string): number {
   return text.trim() === '' ? 0 : text.trim().split(/\s+/).length;
 }
 
 // ─── Foreign language detection + sub-type ──────────────────────────────────
 
-export function detectForeign(text) {
+export function detectForeign(text: string): { subType: ForeignSubtype | null; confidence: number } | null {
   if (text.length === 0) return null;
 
   const nonLatinChars = (text.match(/[\u0400-\u04FF\u0600-\u06FF\u0900-\u097F\u0E00-\u0E7F\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF\uAC00-\uD7AF]/g) || []).length;
@@ -314,7 +317,7 @@ export function detectForeign(text) {
   return { subType, confidence };
 }
 
-export function detectNaturalLanguage(text) {
+export function detectNaturalLanguage(text: string): ForeignSubtype | null {
   // Count characters in each script range
   const counts = {
     japanese: (text.match(/[\u3040-\u309F\u30A0-\u30FF]/g) || []).length,
@@ -330,13 +333,13 @@ export function detectNaturalLanguage(text) {
   if (counts.japanese > 0) return 'japanese';
 
   // Find highest count among remaining
-  let best = null;
+  let best: ForeignSubtype | null = null;
   let bestCount = 0;
   for (const [lang, count] of Object.entries(counts)) {
     if (lang === 'japanese') continue;
     if (count > bestCount) {
       bestCount = count;
-      best = lang;
+      best = lang as ForeignSubtype;
     }
   }
 

--- a/src/content/presets.ts
+++ b/src/content/presets.ts
@@ -2,6 +2,14 @@
 // Enhanced in v1.1: sub-type-specific instructions + new content types
 
 import { getReorderedPresets, buildTypeKey } from './shared/preset-usage.js';
+import type {
+  CodeSubtype,
+  ContentSubtype,
+  ContentType,
+  ForeignSubtype,
+  Preset,
+  PresetGroup,
+} from '../shared/types';
 
 /**
  * PRESETS - Maps content type to suggested and additional presets
@@ -11,7 +19,7 @@ import { getReorderedPresets, buildTypeKey } from './shared/preset-usage.js';
  */
 
 // Sub-type specific preset overrides for code
-export const CODE_SUBTYPE_PRESETS = {
+export const CODE_SUBTYPE_PRESETS: Record<CodeSubtype, PresetGroup> = {
   javascript: {
     suggested: [
       { label: 'Explain this JavaScript', instruction: 'Explain the following JavaScript code' },
@@ -119,7 +127,7 @@ export const CODE_SUBTYPE_PRESETS = {
 // Presets prioritize native-language actions (summarize, explain) over translation,
 // since users selecting text in their own language usually want responses in that language.
 // The system prompt instructs the AI to respond in the same language as the selected text.
-function buildForeignPresets(language: string, label?: string) {
+function buildForeignPresets(language: string, label?: string): PresetGroup {
   return {
     suggested: [
       { label: 'Summarize', instruction: 'Summarize the following' },
@@ -129,7 +137,7 @@ function buildForeignPresets(language: string, label?: string) {
   };
 }
 
-export const FOREIGN_SUBTYPE_PRESETS = {
+export const FOREIGN_SUBTYPE_PRESETS: Record<ForeignSubtype, PresetGroup> = {
   japanese: buildForeignPresets('Japanese'),
   chinese: buildForeignPresets('Chinese'),
   korean: buildForeignPresets('Korean'),
@@ -139,7 +147,7 @@ export const FOREIGN_SUBTYPE_PRESETS = {
   thai: buildForeignPresets('Thai'),
 };
 
-export const PRESETS = {
+export const PRESETS: Record<ContentType, PresetGroup> = {
   code: {
     suggested: [
       { label: 'Explain code', instruction: 'Explain the following code' },
@@ -223,7 +231,7 @@ export const PRESETS = {
   }
 };
 
-export const COMMON_PRESETS = [
+export const COMMON_PRESETS: Preset[] = [
   { label: 'Summarize', instruction: 'Summarize the following' },
   { label: 'Explain', instruction: 'Explain the following' },
   { label: 'Translate', instruction: 'Translate the following to English' },
@@ -238,12 +246,12 @@ export const COMMON_PRESETS = [
  * @param {string|null} subType
  * @returns {Array<{label: string, instruction: string}>}
  */
-export function getSuggestedPresetsForType(contentType, subType) {
-  let presets;
-  if (subType && contentType === 'code' && CODE_SUBTYPE_PRESETS[subType]) {
-    presets = CODE_SUBTYPE_PRESETS[subType].suggested;
-  } else if (subType && contentType === 'foreign' && FOREIGN_SUBTYPE_PRESETS[subType]) {
-    presets = FOREIGN_SUBTYPE_PRESETS[subType].suggested;
+export function getSuggestedPresetsForType(contentType: ContentType, subType: ContentSubtype): Preset[] {
+  let presets: Preset[];
+  if (subType && contentType === 'code' && CODE_SUBTYPE_PRESETS[subType as CodeSubtype]) {
+    presets = CODE_SUBTYPE_PRESETS[subType as CodeSubtype].suggested;
+  } else if (subType && contentType === 'foreign' && FOREIGN_SUBTYPE_PRESETS[subType as ForeignSubtype]) {
+    presets = FOREIGN_SUBTYPE_PRESETS[subType as ForeignSubtype].suggested;
   } else {
     presets = (PRESETS[contentType] || PRESETS['default']).suggested;
   }
@@ -257,12 +265,12 @@ export function getSuggestedPresetsForType(contentType, subType) {
  * @param {string|null} [subType]
  * @returns {Array<{label: string, instruction: string}>}
  */
-export function getAllPresetsForType(contentType, subType) {
+export function getAllPresetsForType(contentType: ContentType, subType: ContentSubtype = null): Preset[] {
   const suggested = getSuggestedPresetsForType(contentType, subType || null);
 
-  let typeAll;
-  if (subType && contentType === 'code' && CODE_SUBTYPE_PRESETS[subType]) {
-    typeAll = CODE_SUBTYPE_PRESETS[subType].all || [];
+  let typeAll: Preset[];
+  if (subType && contentType === 'code' && CODE_SUBTYPE_PRESETS[subType as CodeSubtype]) {
+    typeAll = CODE_SUBTYPE_PRESETS[subType as CodeSubtype].all || [];
   } else {
     typeAll = PRESETS[contentType].all || [];
   }

--- a/src/content/trigger/styles.ts
+++ b/src/content/trigger/styles.ts
@@ -1,8 +1,9 @@
 // src/content/trigger/styles.js — CSS-in-JS styles for toolbar (Shadow DOM)
 import { FONT_STACK } from '../shared/constants.js';
 import { getColorPalette } from '../../shared/color-palette.js';
+import type { ResolvedTheme } from '../../shared/types';
 
-export function getToolbarStyles(theme) {
+export function getToolbarStyles(theme: ResolvedTheme): string {
   const colors = getColorPalette(theme);
   const accent = colors.accent;
   const fontStack = FONT_STACK;


### PR DESCRIPTION
Part of #171

## What changed
- Add explicit strict-compatible contracts to content detection and preset selection.
- Type the pure markdown renderer and bubble/toolbar style generators.
- Remove 45 strict-mode errors without changing runtime behavior.

## Compatibility
- Generated `dist/content.js` is byte-for-byte identical to `main`.
- No runtime behavior, DOM, styles, messages, storage, or exports changed.

## Validation
- Focused strict check for changed modules: no errors
- Remaining strict errors reduced from 245 to 200 across the migration
- `npm run typecheck`
- `npm run build`
- `npm test` (620 tests)
- `npm run test:e2e` (24 Chromium extension tests)
- `git diff --check`
- Byte-for-byte content bundle comparison against `main`