### PR TITLE
chore: type content utilities for strict mode

### DIFF
--- a/src/content/bubble/history.ts
+++ b/src/content/bubble/history.ts
@@ -2,8 +2,9 @@
 import { setCurrentMessages, setResponseText } from '../shared/state.js';
 import { getHistory, clearHistory } from '../history.js';
 import { renderMarkdown } from './markdown.js';
+import type { ChatMessage } from '../../shared/types';
 
-function getTimeAgo(timestamp) {
+function getTimeAgo(timestamp: number): string {
   const diff = Date.now() - timestamp;
   const mins = Math.floor(diff / 60000);
   if (mins < 1) return 'just now';
@@ -14,8 +15,8 @@ function getTimeAgo(timestamp) {
   return `${days}d ago`;
 }
 
-export async function showHistoryPanel(shadow) {
-  const body = shadow.querySelector('.bubble-body');
+export async function showHistoryPanel(shadow: ShadowRoot): Promise<void> {
+  const body = shadow.querySelector<HTMLElement>('.bubble-body')!;
   const entries = await getHistory();
 
   if (entries.length === 0) {
@@ -55,14 +56,14 @@ export async function showHistoryPanel(shadow) {
       if (responseSection) responseSection.classList.add('active');
 
       // Restore conversation state so follow-up works
-      const msgs = [];
+      const msgs: ChatMessage[] = [];
       if (entry.instruction) msgs.push({ role: 'system', content: entry.instruction });
       if (entry.text) msgs.push({ role: 'user', content: entry.text });
       if (entry.response) msgs.push({ role: 'assistant', content: entry.response });
       setCurrentMessages(msgs);
       setResponseText(entry.response || '');
 
-      const followUpInput = shadow.querySelector('.follow-up-input');
+      const followUpInput = shadow.querySelector<HTMLInputElement>('.follow-up-input');
       if (followUpInput) {
         followUpInput.disabled = false;
         followUpInput.focus();

--- a/src/content/bubble/stream.ts
+++ b/src/content/bubble/stream.ts
@@ -13,13 +13,14 @@ import { renderMarkdown } from './markdown.js';
 import { TIMING } from '../shared/constants.js';
 import { getColorPalette } from '../../shared/color-palette.js';
 import { OPEN_OPTIONS_MESSAGE } from '../../shared/runtime-messages.js';
+import type { ChatMessage } from '../../shared/types';
 
 const colors = getColorPalette('light');
 
 const COPY_ICON = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
 const CHECK_ICON = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>';
 
-export function createCopyButton(aiMsg, responseIdx) {
+export function createCopyButton(aiMsg: HTMLElement, responseIdx: number): void {
   const btn = document.createElement('button');
   btn.className = 'copy-btn';
   btn.title = 'Copy';
@@ -50,11 +51,11 @@ export function createCopyButton(aiMsg, responseIdx) {
   aiMsg.appendChild(btn);
 }
 
-export function startStreaming(shadow, messages) {
-  const responseEl = shadow.querySelector('.response-text');
-  const cursorEl = shadow.querySelector('.cursor');
-  const statusEl = shadow.querySelector('.bubble-status');
-  const followUpInput = shadow.querySelector('.follow-up-input');
+export function startStreaming(shadow: ShadowRoot, messages: ChatMessage[]): void {
+  const responseEl = shadow.querySelector<HTMLElement>('.response-text')!;
+  const cursorEl = shadow.querySelector<HTMLElement>('.cursor')!;
+  const statusEl = shadow.querySelector<HTMLElement>('.bubble-status')!;
+  const followUpInput = shadow.querySelector<HTMLInputElement>('.follow-up-input')!;
 
   // Create a new AI message container for this response
   const aiMsg = document.createElement('div');
@@ -81,7 +82,7 @@ export function startStreaming(shadow, messages) {
         setRenderTimer(setTimeout(() => {
           setRenderTimer(null);
           aiMsg.innerHTML = renderMarkdown(responseText);
-          const body = shadow.querySelector('.bubble-body');
+          const body = shadow.querySelector<HTMLElement>('.bubble-body')!;
           body.scrollTop = body.scrollHeight;
         }, TIMING.RENDER_DEBOUNCE));
       }
@@ -123,7 +124,7 @@ export function startStreaming(shadow, messages) {
       }
       saveConversation({
         text: historyText,
-        instruction: instruction?.content || '',
+        instruction: (instruction?.content as string) || '',
         response: responseText,
         pageUrl: window.location.href,
         pageTitle: document.title,
@@ -155,8 +156,8 @@ export function startStreaming(shadow, messages) {
   ));
 }
 
-export function handleFollowUp(shadow, question) {
-  const responseEl = shadow.querySelector('.response-text');
+export function handleFollowUp(shadow: ShadowRoot, question: string): void {
+  const responseEl = shadow.querySelector<HTMLElement>('.response-text')!;
 
   // Add user message bubble
   const userMsg = document.createElement('div');
@@ -165,7 +166,7 @@ export function handleFollowUp(shadow, question) {
   responseEl.appendChild(userMsg);
 
   // Scroll to show the user message
-  const body = shadow.querySelector('.bubble-body');
+  const body = shadow.querySelector<HTMLElement>('.bubble-body')!;
   body.scrollTop = body.scrollHeight;
 
   // Reset responseText for the new AI reply (previous messages stay in DOM)
@@ -175,8 +176,8 @@ export function handleFollowUp(shadow, question) {
   startStreaming(shadow, currentMessages);
 }
 
-export function showRateLimitUI(shadow) {
-  const body = shadow.querySelector('.bubble-body');
+export function showRateLimitUI(shadow: ShadowRoot): void {
+  const body = shadow.querySelector<HTMLElement>('.bubble-body')!;
   body.innerHTML = `
     <div class="rate-limit-msg">
       <p>You've used your 30 free questions today.</p>
@@ -185,7 +186,7 @@ export function showRateLimitUI(shadow) {
     </div>
   `;
 
-  shadow.querySelector('.cta').addEventListener('click', () => {
+  shadow.querySelector<HTMLElement>('.cta')!.addEventListener('click', () => {
     chrome.runtime.sendMessage(OPEN_OPTIONS_MESSAGE);
   });
 }

--- a/src/content/image-capture.ts
+++ b/src/content/image-capture.ts
@@ -4,6 +4,7 @@
 // - chrome.runtime.sendMessage (for screenshot capture via background.js)
 
 import { requestVisibleTabScreenshot } from './api.js';
+import type { CaptureRect, ImageContentPart } from '../shared/types';
 
 const MAX_BASE64_SIZE = 1048576; // 1MB
 const MAX_DOWNSCALE_ATTEMPTS = 2;
@@ -14,7 +15,7 @@ const MAX_DOWNSCALE_ATTEMPTS = 2;
  * @param {string|HTMLImageElement} source - Image URL string or <img> element
  * @returns {Promise<{type: string, image_url: {url: string}}|null>}
  */
-export async function captureImage(source) {
+export async function captureImage(source: string | HTMLImageElement): Promise<ImageContentPart | null> {
   if (source == null) return null;
 
   try {
@@ -50,7 +51,7 @@ export async function captureImage(source) {
 
     return null;
   } catch (e) {
-    console.warn('[Dobby AI] Image capture failed:', e.message);
+    console.warn('[Dobby AI] Image capture failed:', (e as Error).message);
     return null;
   }
 }
@@ -61,7 +62,7 @@ export async function captureImage(source) {
  * @param {{x: number, y: number, width: number, height: number}} rect
  * @returns {Promise<{type: string, image_url: {url: string}}|null>}
  */
-export async function captureScreenshot(rect) {
+export async function captureScreenshot(rect: CaptureRect): Promise<ImageContentPart | null> {
   try {
     const response = await requestVisibleTabScreenshot();
 
@@ -74,7 +75,7 @@ export async function captureScreenshot(rect) {
     if (sized) return { type: 'image_url', image_url: { url: sized } };
     return null;
   } catch (e) {
-    console.warn('[Dobby AI] Screenshot capture failed:', e.message);
+    console.warn('[Dobby AI] Screenshot capture failed:', (e as Error).message);
     return null;
   }
 }
@@ -84,7 +85,7 @@ export async function captureScreenshot(rect) {
  * @param {string} url
  * @returns {Promise<string|null>} base64 data URL or null
  */
-export function _corsRefetch(url) {
+export function _corsRefetch(url: string): Promise<string | null> {
   return new Promise((resolve) => {
     const img = new Image();
     img.crossOrigin = 'anonymous';
@@ -94,10 +95,10 @@ export function _corsRefetch(url) {
         canvas.width = img.naturalWidth;
         canvas.height = img.naturalHeight;
         const ctx = canvas.getContext('2d');
-        ctx.drawImage(img, 0, 0);
+        ctx!.drawImage(img, 0, 0);
         resolve(canvas.toDataURL('image/jpeg', 0.8));
       } catch (e) {
-        console.warn('[Dobby AI] Canvas operation failed:', e.message);
+        console.warn('[Dobby AI] Canvas operation failed:', (e as Error).message);
         resolve(null);
       }
     };
@@ -113,7 +114,7 @@ export function _corsRefetch(url) {
  * @param {{x: number, y: number, width: number, height: number}} rect
  * @returns {Promise<string|null>}
  */
-export function _cropImage(dataUrl, rect) {
+export function _cropImage(dataUrl: string, rect: CaptureRect): Promise<string | null> {
   return new Promise((resolve) => {
     const img = new Image();
     img.onload = () => {
@@ -123,7 +124,7 @@ export function _cropImage(dataUrl, rect) {
         canvas.width = rect.width * dpr;
         canvas.height = rect.height * dpr;
         const ctx = canvas.getContext('2d');
-        ctx.drawImage(
+        ctx!.drawImage(
           img,
           rect.x * dpr, rect.y * dpr,
           rect.width * dpr, rect.height * dpr,
@@ -132,7 +133,7 @@ export function _cropImage(dataUrl, rect) {
         );
         resolve(canvas.toDataURL('image/jpeg', 0.8));
       } catch (e) {
-        console.warn('[Dobby AI] Canvas operation failed:', e.message);
+        console.warn('[Dobby AI] Canvas operation failed:', (e as Error).message);
         resolve(null);
       }
     };
@@ -147,12 +148,12 @@ export function _cropImage(dataUrl, rect) {
  * @param {string} dataUrl
  * @returns {Promise<string|null>}
  */
-export async function _downsizeBase64(dataUrl) {
+export async function _downsizeBase64(dataUrl: string): Promise<string | null> {
   // Check size (base64 portion is after the comma)
   const base64Part = dataUrl.split(',')[1] || '';
   if (base64Part.length <= MAX_BASE64_SIZE) return dataUrl;
 
-  let current = dataUrl;
+  let current: string | null = dataUrl;
   for (let i = 0; i < MAX_DOWNSCALE_ATTEMPTS; i++) {
     current = await _scaleDown(current);
     if (!current) return null;
@@ -162,7 +163,7 @@ export async function _downsizeBase64(dataUrl) {
   return null; // Still too large
 }
 
-function _scaleDown(dataUrl) {
+function _scaleDown(dataUrl: string): Promise<string | null> {
   return new Promise((resolve) => {
     const img = new Image();
     img.onload = () => {
@@ -171,10 +172,10 @@ function _scaleDown(dataUrl) {
         canvas.width = Math.floor(img.naturalWidth / 2);
         canvas.height = Math.floor(img.naturalHeight / 2);
         const ctx = canvas.getContext('2d');
-        ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+        ctx!.drawImage(img, 0, 0, canvas.width, canvas.height);
         resolve(canvas.toDataURL('image/jpeg', 0.8));
       } catch (e) {
-        console.warn('[Dobby AI] Canvas operation failed:', e.message);
+        console.warn('[Dobby AI] Canvas operation failed:', (e as Error).message);
         resolve(null);
       }
     };

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -13,6 +13,7 @@ import { captureImage } from './image-capture.js';
 import { isClickInsideUI } from './shared/dom-utils.js';
 import { loadUsageData } from './shared/preset-usage.js';
 import { getLocalStorage } from '../shared/storage.js';
+import type { ImageContentPart } from '../shared/types';
 
 /** @typedef {import('../shared/types').ContentRuntimeMessage} ContentRuntimeMessage */
 
@@ -83,7 +84,7 @@ chrome.runtime.onMessage.addListener((/** @type {ContentRuntimeMessage} */ msg) 
 
     if (msg.image) {
       (async () => {
-        let images = [];
+        let images: ImageContentPart[] = [];
         const captured = await captureImage(msg.image);
         if (captured) images = [captured];
         if (images.length > 0) {

--- a/src/content/trigger/progress-ring.ts
+++ b/src/content/trigger/progress-ring.ts
@@ -28,7 +28,7 @@ function _ensureProgressRingStyles() {
   document.head.appendChild(style);
 }
 
-export function _showProgressRing(x, y) {
+export function _showProgressRing(x: number, y: number): void {
   _removeProgressRing();
   _ensureProgressRingStyles();
 
@@ -142,7 +142,7 @@ export function _showProgressRing(x, y) {
   longPressState.ring = container;
 }
 
-export function _removeProgressRing() {
+export function _removeProgressRing(): void {
   if (longPressState.ring) {
     removeElement(longPressState.ring);
     longPressState.ring = null;

--- a/src/shared/theme.ts
+++ b/src/shared/theme.ts
@@ -54,7 +54,7 @@ export function watchThemeChanges(applyTheme: (theme: ResolvedTheme) => void): (
     if (mode === 'auto') applyResolved();
   };
 
-  if (typeof chrome !== 'undefined' && chrome.storage?.local?.get) {
+  if (typeof chrome !== 'undefined' && (chrome.storage?.local?.get as unknown)) {
     getLocalStorage('theme', (data) => {
       mode = normalizeThemeMode(data?.theme);
     });


### PR DESCRIPTION
Part of #171.

## What changed
- Add strict TypeScript contracts to image capture, history, streaming, progress-ring, and content entry modules
- Preserve existing DOM assumptions with erased non-null/type assertions
- Clear the remaining strict error in shared theme detection

## Compatibility
- Built extension output is byte-identical to the main-branch baseline
- No runtime behavior, DOM structure, message shape, or storage shape changes
- Strict error count drops from 173 to 139

## Verification
- `npx tsc --noEmit --strict --pretty false` (139 remaining errors, none in touched modules)
- `npm run typecheck`
- `npm run build`
- `npm test` (620 passed)
- `npm run test:e2e` (24 passed)
- `diff -rq` against baseline `dist/` (no differences)