### PR TITLE
chore: type selection and screenshot for strict mode

### DIFF
--- a/src/content/trigger/screenshot.ts
+++ b/src/content/trigger/screenshot.ts
@@ -7,16 +7,17 @@ import { _removeProgressRing } from './progress-ring.js';
 import { showBubbleWithPresets } from '../bubble/core.js';
 import { captureScreenshot } from '../image-capture.js';
 import { getColorPalette } from '../../shared/color-palette.js';
+import type { CaptureRect, ScreenshotOverlay } from '../../shared/types';
 
 const colors = getColorPalette('light');
 
-export function startScreenshotMode() {
+export function startScreenshotMode(): void {
   if (longPressState.ringTimer) { clearTimeout(longPressState.ringTimer); longPressState.ringTimer = null; }
   _removeProgressRing();
   longPressState.timer = null;
 
   screenshotState.overlay = document.createElement('div');
-  Object.assign(screenshotState.overlay.style, {
+  Object.assign(screenshotState.overlay!.style, {
     position: 'fixed',
     inset: '0',
     zIndex: String(Z_INDEX.SCREENSHOT_OVERLAY),
@@ -44,7 +45,7 @@ export function startScreenshotMode() {
     letterSpacing: '0.3px',
   });
   banner.textContent = 'Drag to select a region \u2022 ESC to cancel';
-  screenshotState.overlay.appendChild(banner);
+  screenshotState.overlay!.appendChild(banner);
 
   // Visual border around the viewport
   const border = document.createElement('div');
@@ -55,31 +56,31 @@ export function startScreenshotMode() {
     pointerEvents: 'none',
     zIndex: String(Z_INDEX.TRIGGER),
   });
-  screenshotState.overlay.appendChild(border);
+  screenshotState.overlay!.appendChild(border);
 
   screenshotState.rect = document.createElement('div');
-  Object.assign(screenshotState.rect.style, {
+  Object.assign(screenshotState.rect!.style, {
     position: 'fixed',
     border: '2px dashed ' + colors.accent,
     background: colors.accentBackground,
     display: 'none',
     zIndex: String(Z_INDEX.TRIGGER),
   });
-  screenshotState.overlay.appendChild(screenshotState.rect);
+  screenshotState.overlay!.appendChild(screenshotState.rect!);
 
   screenshotState.dragStarted = false;
 
-  screenshotState.overlay.addEventListener('mousedown', (e) => {
+  screenshotState.overlay!.addEventListener('mousedown', (e) => {
     e.preventDefault();
     e.stopPropagation();
     // Clear existing toolbar if user re-drags on overlay
-    const existingToolbar = screenshotState.overlay.querySelector('[data-screenshot-toolbar]');
+    const existingToolbar = screenshotState.overlay!.querySelector('[data-screenshot-toolbar]');
     if (existingToolbar) existingToolbar.remove();
     screenshotState.dragStarted = true;
     screenshotState.startX = e.clientX;
     screenshotState.startY = e.clientY;
-    screenshotState.rect.style.display = 'block';
-    Object.assign(screenshotState.rect.style, {
+    screenshotState.rect!.style.display = 'block';
+    Object.assign(screenshotState.rect!.style, {
       left: e.clientX + 'px',
       top: e.clientY + 'px',
       width: '0px',
@@ -87,7 +88,7 @@ export function startScreenshotMode() {
     });
   });
 
-  screenshotState.overlay.addEventListener('mouseup', (e) => {
+  screenshotState.overlay!.addEventListener('mouseup', (e) => {
     // Ignore the mouseup from the long-press release (no drag started yet)
     if (!screenshotState.dragStarted) return;
 
@@ -98,7 +99,7 @@ export function startScreenshotMode() {
 
     // Too small — reset selection and let user try again
     if (w < 10 || h < 10) {
-      screenshotState.rect.style.display = 'none';
+      screenshotState.rect!.style.display = 'none';
       screenshotState.dragStarted = false;
       return;
     }
@@ -107,28 +108,28 @@ export function startScreenshotMode() {
     screenshotState.dragStarted = false;
 
     // Lock the selection rectangle with solid border
-    Object.assign(screenshotState.rect.style, {
+    Object.assign(screenshotState.rect!.style, {
       border: '2px solid ' + colors.accent,
     });
 
 
     // Show confirmation toolbar below the selection
-    _showConfirmToolbar(screenshotState.overlay, banner, { x, y, width: w, height: h });
+    _showConfirmToolbar(screenshotState.overlay!, banner, { x, y, width: w, height: h });
   });
 
-  const escHandler = (e) => {
+  const escHandler = (e: KeyboardEvent) => {
     if (e.key === 'Escape') {
       cancelScreenshotMode();
       document.removeEventListener('keydown', escHandler);
     }
   };
   document.addEventListener('keydown', escHandler);
-  screenshotState.overlay._escHandler = escHandler;
+  screenshotState.overlay!._escHandler = escHandler;
 
-  document.body.appendChild(screenshotState.overlay);
+  document.body.appendChild(screenshotState.overlay!);
 }
 
-function _showConfirmToolbar(overlay, banner, rect) {
+function _showConfirmToolbar(overlay: ScreenshotOverlay, banner: HTMLDivElement, rect: CaptureRect): void {
   // Remove existing toolbar if any
   const existing = overlay.querySelector('[data-screenshot-toolbar]');
   if (existing) existing.remove();
@@ -204,7 +205,7 @@ function _showConfirmToolbar(overlay, banner, rect) {
   reselectBtn.addEventListener('click', (e) => {
     e.stopPropagation();
     toolbar.remove();
-    Object.assign(screenshotState.rect.style, {
+    Object.assign(screenshotState.rect!.style, {
       display: 'none',
       border: '2px dashed ' + colors.accent,
       width: '0px',
@@ -238,7 +239,7 @@ function _showConfirmToolbar(overlay, banner, rect) {
   });
 }
 
-export function cancelScreenshotMode() {
+export function cancelScreenshotMode(): void {
   if (screenshotState.overlay) {
     if (screenshotState.overlay._escHandler) {
       document.removeEventListener('keydown', screenshotState.overlay._escHandler);

--- a/src/content/trigger/selection.ts
+++ b/src/content/trigger/selection.ts
@@ -24,7 +24,7 @@ const INTERACTIVE_TAGS = new Set([
   'INPUT', 'TEXTAREA', 'SELECT', 'BUTTON', 'A', 'VIDEO', 'AUDIO', 'LABEL', 'OPTION',
 ]);
 
-function isInteractiveElement(el) {
+function isInteractiveElement(el: HTMLElement | null): boolean {
   if (!el || !el.tagName) return false;
   if (INTERACTIVE_TAGS.has(el.tagName)) return true;
   if (el.isContentEditable) return true;
@@ -32,12 +32,12 @@ function isInteractiveElement(el) {
   return false;
 }
 
-function isScrollbarClick(e) {
+function isScrollbarClick(e: MouseEvent): boolean {
   // Page-level scrollbars
   if (e.clientX >= document.documentElement.clientWidth ||
     e.clientY >= document.documentElement.clientHeight) return true;
   // Element-level scrollbars (e.g. scrollable divs)
-  const el = e.target;
+  const el = e.target as HTMLElement | null;
   if (el && el.getBoundingClientRect) {
     const rect = el.getBoundingClientRect();
     const clickOffsetX = e.clientX - rect.left;
@@ -48,7 +48,7 @@ function isScrollbarClick(e) {
   return false;
 }
 
-export function registerListeners() {
+export function registerListeners(): void {
   // Listen for text selection
   document.addEventListener('mouseup', (e) => {
     if (isClickInsideUI(e.target, getBubbleContainer)) return;
@@ -59,7 +59,7 @@ export function registerListeners() {
       const text = getSelectedText();
 
       if (text.length >= 3 && dobbyEnabled) {
-        const sel = window.getSelection();
+        const sel = window.getSelection()!;
         const anchorNode = sel.anchorNode || null;
         showTrigger(cursorX, cursorY, { text, anchorNode, selection: sel }).catch(() => {});
       } else {
@@ -70,10 +70,10 @@ export function registerListeners() {
 
   // Fallback: selectionchange fires even when sites (Gmail, etc.) capture mouseup
   document.addEventListener('selectionchange', () => {
-    clearTimeout(selectionChangeTimer);
+    clearTimeout(selectionChangeTimer!);
     setSelectionChangeTimer(setTimeout(() => {
       const text = getSelectedText();
-      const selection = window.getSelection();
+      const selection = window.getSelection()!;
       if (text.length >= 3 && dobbyEnabled && selection.rangeCount > 0) {
         // Only show if trigger isn't already visible
         if (!triggerButton || triggerButton.style.display === 'none') {
@@ -88,10 +88,10 @@ export function registerListeners() {
   // Hide trigger on scroll, re-show after scroll stops
   window.addEventListener('scroll', () => {
     hideTrigger();
-    clearTimeout(scrollTimer);
+    clearTimeout(scrollTimer!);
     setScrollTimer(setTimeout(() => {
       const text = getSelectedText();
-      const selection = window.getSelection();
+      const selection = window.getSelection()!;
       if (text.length >= 3 && dobbyEnabled && selection.rangeCount > 0) {
         const anchorNode = selection.anchorNode || null;
         const rect = getSelectionRect();
@@ -109,7 +109,7 @@ export function registerListeners() {
   // Long-press mousedown handler
   document.addEventListener('mousedown', (e) => {
     if (e.button !== 0) return; // left click only
-    if (isInteractiveElement(e.target)) return;
+    if (isInteractiveElement(e.target as HTMLElement | null)) return;
     if (isScrollbarClick(e)) return;
     if (isClickInsideUI(e.target, getBubbleContainer)) return;
     if (screenshotState.overlay) return;
@@ -169,7 +169,7 @@ export function registerListeners() {
 
 }
 
-export function _resetTriggerForTesting() {
+export function _resetTriggerForTesting(): void {
   removeElement(triggerButton);
   setTriggerButton(null);
   setDobbyEnabled(true);
@@ -181,4 +181,4 @@ export function _resetTriggerForTesting() {
   cancelScreenshotMode();
 }
 
-export function _setDobbyEnabled(val) { setDobbyEnabled(val); }
+export function _setDobbyEnabled(val: boolean): void { setDobbyEnabled(val); }


### PR DESCRIPTION
Part of #171.

## What changed
- Add strict event, selection, screenshot overlay, and capture-rectangle contracts
- Preserve existing nullable state assumptions with erased non-null assertions

## Compatibility
- Built extension output is byte-identical to the main-branch baseline
- No runtime behavior, DOM structure, message shape, or storage shape changes
- Strict error count drops from 139 to 119

## Verification
- `npx tsc --noEmit --strict --pretty false` (119 remaining errors, none in touched modules)
- `npm run typecheck`
- `npm run build`
- `npm test` (620 passed)
- `npm run test:e2e` (24 passed)
- `diff -rq` against baseline `dist/` (no differences)