### PR TITLE
chore: add React Shadow DOM mount adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,21 @@
 {
   "name": "dobby-ai",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dobby-ai",
-      "version": "1.2.2",
+      "version": "1.2.3",
+      "dependencies": {
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7"
+      },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
         "@types/chrome": "^0.1.43",
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
         "@vitest/coverage-v8": "^3.2.4",
         "esbuild": "^0.27.4",
         "jsdom": "^28.1.0",
@@ -1246,6 +1252,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
     "node_modules/@vitest/coverage-v8": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
@@ -1594,6 +1620,13 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
@@ -2336,6 +2369,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -2403,6 +2457,12 @@
       "engines": {
         "node": ">=v12.22.7"
       }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.4",

--- a/package.json
+++ b/package.json
@@ -14,11 +14,17 @@
   "devDependencies": {
     "@playwright/test": "^1.58.2",
     "@types/chrome": "^0.1.43",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
     "@vitest/coverage-v8": "^3.2.4",
     "esbuild": "^0.27.4",
     "jsdom": "^28.1.0",
     "playwright": "^1.58.2",
     "typescript": "^6.0.3",
     "vitest": "^3.0.0"
+  },
+  "dependencies": {
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
   }
 }

--- a/src/shared/react-root.tsx
+++ b/src/shared/react-root.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+export type ReactRootHandle = {
+  render: (node: ReactNode) => void;
+  unmount: () => void;
+};
+
+export function mountReactRoot(
+  container: Element | DocumentFragment,
+  node: ReactNode,
+): ReactRootHandle {
+  const root: Root = createRoot(container);
+  let mounted = true;
+
+  root.render(node);
+
+  return {
+    render(nextNode) {
+      if (!mounted) {
+        throw new Error('Cannot render into an unmounted React root');
+      }
+      root.render(nextNode);
+    },
+    unmount() {
+      if (!mounted) return;
+      root.unmount();
+      mounted = false;
+    },
+  };
+}

--- a/tests/react-root.test.js
+++ b/tests/react-root.test.js
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mountReactRoot } from '../src/shared/react-root.js';
+
+let handle;
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  document.body.innerHTML = '';
+  handle = null;
+});
+
+afterEach(async () => {
+  if (handle) {
+    await act(async () => handle.unmount());
+  }
+  globalThis.IS_REACT_ACT_ENVIRONMENT = false;
+});
+
+function createShadowRoot() {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  return host.attachShadow({ mode: 'open' });
+}
+
+describe('mountReactRoot', () => {
+  it('mounts a React node inside an existing ShadowRoot', async () => {
+    const shadow = createShadowRoot();
+
+    await act(async () => {
+      handle = mountReactRoot(shadow, createElement('span', { className: 'value' }, 'first'));
+    });
+
+    expect(shadow.querySelector('.value')?.textContent).toBe('first');
+  });
+
+  it('rerenders through the same root handle', async () => {
+    const shadow = createShadowRoot();
+
+    await act(async () => {
+      handle = mountReactRoot(shadow, createElement('span', null, 'first'));
+    });
+    await act(async () => {
+      handle.render(createElement('span', null, 'second'));
+    });
+
+    expect(shadow.textContent).toBe('second');
+  });
+
+  it('unmounts cleanly and allows repeated cleanup', async () => {
+    const shadow = createShadowRoot();
+
+    await act(async () => {
+      handle = mountReactRoot(shadow, createElement('span', null, 'mounted'));
+    });
+    await act(async () => handle.unmount());
+    await act(async () => handle.unmount());
+
+    expect(shadow.textContent).toBe('');
+    handle = null;
+  });
+
+  it('rejects rerendering after cleanup', async () => {
+    const shadow = createShadowRoot();
+
+    await act(async () => {
+      handle = mountReactRoot(shadow, createElement('span', null, 'mounted'));
+    });
+    await act(async () => handle.unmount());
+
+    expect(() => handle.render(createElement('span', null, 'late'))).toThrow(
+      'Cannot render into an unmounted React root',
+    );
+    handle = null;
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
     "lib": ["ES2022", "DOM", "DOM.Iterable", "WebWorker"],
     "types": ["chrome"],
     "allowJs": true,
@@ -15,6 +16,7 @@
   "include": [
     "src/**/*.js",
     "src/**/*.ts",
+    "src/**/*.tsx",
     "proxy/src/**/*.js",
     "proxy/src/**/*.ts"
   ]

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -7,7 +7,7 @@ export default defineConfig({
     include: ['tests/**/*.test.js', 'proxy/tests/**/*.test.js'],
     coverage: {
       include: [
-        'src/**/*.{js,ts}',
+        'src/**/*.{js,ts,tsx}',
         'proxy/src/**/*.{js,ts}',
       ],
       exclude: [


### PR DESCRIPTION
Closes #178.

## What changed
- Add React and React DOM 19.2.7 with current TypeScript types
- Enable strict `.tsx` compilation and include TSX modules in coverage
- Add a typed React root adapter for existing Element or ShadowRoot containers
- Define mount, rerender, idempotent unmount, and post-unmount misuse behavior
- Add focused adapter tests

## Compatibility
- No production entry point imports React or the adapter yet
- Existing `content.js`, `background.js`, `popup.js`, and `options.js` outputs are byte-identical to the main-branch baseline
- No production UI, DOM structure, CSS class, runtime message, storage shape, or manifest changes

## Verification
- `npm run typecheck`
- `npm run build`
- `npm test` (624 passed, including 4 new adapter tests)
- `npm run test:e2e` (24 passed)
- `diff -rq` against baseline `dist/` (no differences)