### PR TITLE
refactor: render bubble shell with React

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -24,6 +24,9 @@ const sharedConfig = {
   target: 'chrome115',
   minify: false,
   tsconfig: 'tsconfig.build.json',
+  define: {
+    'process.env.NODE_ENV': '"production"',
+  },
 };
 
 async function build() {

--- a/src/content/bubble/core.tsx
+++ b/src/content/bubble/core.tsx
@@ -10,20 +10,22 @@ import {
 import { Z_INDEX, TIMING } from '../shared/constants.js';
 import { removeElement, stopShadowRootKeyboardEventPropagation } from '../shared/dom-utils.js';
 import { detectTheme, watchThemeChanges } from '../../shared/theme.js';
+import { mountReactRoot } from '../../shared/react-root.js';
 import { getStyles } from './styles.js';
-import { renderMarkdown, escapeHtml } from './markdown.js';
+import { renderMarkdown } from './markdown.js';
+import { BubbleShell, type BubblePresetSelection } from './shell.js';
 import { startStreaming, handleFollowUp } from './stream.js';
 import { showHistoryPanel } from './history.js';
 import { detectContentType } from '../detection.js';
 import { getSuggestedPresetsForType } from '../presets.js';
 import { buildChatMessages } from '../prompt.js';
 import { recordPresetUsage, buildTypeKey } from '../shared/preset-usage.js';
-import { BRAND_MARK_DATA_URI, BRAND_NAME } from '../../shared/brand.js';
 import type {
   BubbleHost,
   ChatMessage,
   DetectionResult,
   ImageContentPart,
+  Preset,
   SelectionRect,
 } from '../../shared/types';
 
@@ -61,64 +63,6 @@ function createBubbleHost(selectionRect: SelectionRect): BubbleHost {
 
   setBubbleHost(host);
   return host;
-}
-
-function buildBubbleHTML(
-  previewText: string,
-  previewLabel: string,
-  showPresets: boolean,
-  images?: ImageContentPart[] | null,
-): string {
-  const hasPreview = previewText || (images && images.length > 0);
-  let previewHtml = '';
-  if (hasPreview) {
-    let imgHtml = '';
-    if (images && images.length > 0) {
-      imgHtml = '<div class="image-preview">' +
-        images.map((img) => {
-          const url = img.image_url ? img.image_url.url : '';
-          return `<img src="${escapeHtml(url)}" alt="Preview" onerror="this.style.display='none'">`;
-        }).join('') + '</div>';
-    }
-    previewHtml = `<div class="selected-text-preview">
-      <div class="label">${escapeHtml(previewLabel || (images && images.length > 0 ? 'Image' : 'Selected text'))}</div>
-      ${imgHtml}
-      ${previewText ? `<div class="text">${escapeHtml(previewText)}</div>` : ''}
-    </div>`;
-  }
-  return `
-    <div class="bubble-header">
-      <span class="bubble-logo">
-        <img class="bubble-logo-mark" src="${BRAND_MARK_DATA_URI}" alt="" aria-hidden="true">
-        <span>${BRAND_NAME}</span>
-      </span>
-      <span class="bubble-status"></span>
-      <button class="pin-btn" title="Pin">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M12 17v5"/><path d="M9 11V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v7"/><path d="M5 15h14l-1.5-4H6.5L5 15z"/>
-        </svg>
-      </button>
-      <button class="close-btn" title="Close">\u2715</button>
-    </div>
-    ${previewHtml}
-    ${showPresets ? '<div class="presets-section"></div>' : ''}
-    <div class="response-section">
-      <div class="bubble-body">
-        <div class="response-text"></div>
-        <span class="cursor blink"></span>
-      </div>
-      <div class="bubble-footer">
-        <input class="follow-up-input" placeholder="Ask a follow-up..." disabled />
-        <button class="action-btn history-btn" title="History">\ud83d\udd50</button>
-      </div>
-    </div>
-    <div class="resize-handle" title="Drag to resize">
-      <svg width="12" height="12" viewBox="0 0 12 12">
-        <line x1="8" y1="4" x2="4" y2="8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-        <line x1="10" y1="8" x2="8" y2="10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-      </svg>
-    </div>
-  `;
 }
 
 function wireCommonEvents(shadow: ShadowRoot): void {
@@ -262,8 +206,8 @@ async function initBubble(
   selectionRect: SelectionRect,
   selectedText: string,
   previewLabel: string,
-  showPresets: boolean,
   images?: ImageContentPart[] | null,
+  presets?: BubblePresetSelection,
 ): Promise<ShadowRoot> {
   hideBubble();
   setResponseText('');
@@ -276,14 +220,17 @@ async function initBubble(
     if ((e as KeyboardEvent).key === 'Escape') hideBubble();
   });
 
-  const style = document.createElement('style');
-  style.textContent = getStyles(await detectTheme());
-  shadow.appendChild(style);
-
-  const bubble = document.createElement('div');
-  bubble.className = 'bubble';
-  bubble.innerHTML = buildBubbleHTML(truncatePreview(selectedText), previewLabel, showPresets, images);
-  shadow.appendChild(bubble);
+  const reactRoot = mountReactRoot(
+    shadow,
+    <BubbleShell
+      styles={getStyles(await detectTheme())}
+      previewText={truncatePreview(selectedText)}
+      previewLabel={previewLabel}
+      images={images}
+      presets={presets}
+    />,
+  );
+  bubbleHost!._reactCleanup = reactRoot.unmount;
 
   wireCommonEvents(shadow);
   document.body.appendChild(bubbleHost!);
@@ -315,9 +262,6 @@ export async function showBubbleWithPresets(
 ): Promise<void> {
   const hasImages = images && images.length > 0;
   const isImageOnly = hasImages && !selectedText.trim();
-  const previewLabel = isImageOnly ? 'Image' : 'Selected text';
-  const shadow = await initBubble(selectionRect, selectedText, previewLabel, true, images);
-
   // Detect content type and populate presets
   let detected: DetectionResult;
   if (isImageOnly) {
@@ -327,45 +271,26 @@ export async function showBubbleWithPresets(
   }
 
   const presets = getSuggestedPresetsForType(detected.type, detected.subType);
-
-  const presetsSection = shadow.querySelector<HTMLElement>('.presets-section')!;
-
-  // Detection badge
-  if (detected.type !== 'default') {
-    const badge = document.createElement('div');
-    badge.className = 'detection-badge';
-    badge.textContent = isImageOnly ? 'image' : `${detected.subType || detected.type} detected`;
-    presetsSection.appendChild(badge);
-  }
-
-  // Preset chips
-  const chipsRow = document.createElement('div');
-  chipsRow.className = 'preset-chips';
-  presets.slice(0, 4).forEach((preset) => {
-    const chip = document.createElement('div');
-    chip.className = 'preset-chip';
-    chip.textContent = preset.label;
-    chip.addEventListener('mousedown', (e) => {
-      e.preventDefault();
-      e.stopPropagation();
+  const previewLabel = isImageOnly ? 'Image' : 'Selected text';
+  let shadow: ShadowRoot;
+  const presetSelection: BubblePresetSelection = {
+    detectionLabel: detected.type === 'default'
+      ? undefined
+      : (isImageOnly ? 'image' : `${detected.subType || detected.type} detected`),
+    presets,
+    customPlaceholder: isImageOnly
+      ? 'Or ask something about this image...'
+      : 'Or type a custom prompt...',
+    onPreset: (preset: Preset) => {
       recordPresetUsage(buildTypeKey(detected.type, detected.subType), preset.label);
       launchFromPreset(shadow, selectedText, preset.instruction, images);
-    });
-    chipsRow.appendChild(chip);
-  });
-  presetsSection.appendChild(chipsRow);
-
-  // Custom input
-  const customInput = document.createElement('input');
-  customInput.className = 'preset-input';
-  customInput.placeholder = isImageOnly ? 'Or ask something about this image...' : 'Or type a custom prompt...';
-  customInput.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter' && customInput.value.trim()) {
-      launchFromPreset(shadow, selectedText, customInput.value.trim(), images);
-    }
-    if (e.key === 'Escape') hideBubble();
-  });
-  presetsSection.appendChild(customInput);
+    },
+    onCustom: (instruction: string) => {
+      launchFromPreset(shadow, selectedText, instruction, images);
+    },
+    onEscape: hideBubble,
+  };
+  shadow = await initBubble(selectionRect, selectedText, previewLabel, images, presetSelection);
 }
 
 // Direct bubble (used by context menu — no preset selection needed)
@@ -377,12 +302,12 @@ export async function showBubble(
   images?: ImageContentPart[] | null,
 ): Promise<void> {
   setCurrentMessages(messages);
-  const shadow = await initBubble(selectionRect, selectedText, instruction || 'Selected text', false, images);
+  const shadow = await initBubble(selectionRect, selectedText, instruction || 'Selected text', images);
   activateResponseSection(shadow, messages);
 }
 
 export async function showHistoryBubble(selectionRect: SelectionRect): Promise<void> {
-  const shadow = await initBubble(selectionRect, '', 'History', false, null);
+  const shadow = await initBubble(selectionRect, '', 'History', null);
   const responseSection = shadow.querySelector('.response-section');
   if (responseSection) responseSection.classList.add('active');
   const status = shadow.querySelector('.bubble-status');
@@ -406,6 +331,9 @@ export function hideBubble(): void {
     if (bubbleHost._escHandler) document.removeEventListener('keydown', bubbleHost._escHandler);
     if (bubbleHost._themeCleanup) {
       bubbleHost._themeCleanup();
+    }
+    if (bubbleHost._reactCleanup) {
+      bubbleHost._reactCleanup();
     }
     removeElement(bubbleHost);
   }

--- a/src/content/bubble/shell.tsx
+++ b/src/content/bubble/shell.tsx
@@ -1,0 +1,161 @@
+import type { KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent } from 'react';
+import { BRAND_MARK_DATA_URI, BRAND_NAME } from '../../shared/brand.js';
+import type { ImageContentPart, Preset } from '../../shared/types';
+
+export type BubblePresetSelection = {
+  detectionLabel?: string;
+  presets: Preset[];
+  customPlaceholder: string;
+  onPreset: (preset: Preset) => void;
+  onCustom: (instruction: string) => void;
+  onEscape: () => void;
+};
+
+export type BubbleShellProps = {
+  styles: string;
+  previewText: string;
+  previewLabel: string;
+  images?: ImageContentPart[] | null;
+  presets?: BubblePresetSelection;
+};
+
+function PinIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M12 17v5" />
+      <path d="M9 11V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v7" />
+      <path d="M5 15h14l-1.5-4H6.5L5 15z" />
+    </svg>
+  );
+}
+
+function ResizeIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12">
+      <line x1="8" y1="4" x2="4" y2="8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      <line x1="10" y1="8" x2="8" y2="10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function Preview({
+  previewText,
+  previewLabel,
+  images,
+}: Pick<BubbleShellProps, 'previewText' | 'previewLabel' | 'images'>) {
+  if (!previewText && !images?.length) return null;
+
+  return (
+    <div className="selected-text-preview">
+      <div className="label">{previewLabel || (images?.length ? 'Image' : 'Selected text')}</div>
+      {images?.length ? (
+        <div className="image-preview">
+          {images.map((image, index) => (
+            <img
+              key={`${image.image_url.url}-${index}`}
+              src={image.image_url.url}
+              alt="Preview"
+              onError={(event) => {
+                event.currentTarget.style.display = 'none';
+              }}
+            />
+          ))}
+        </div>
+      ) : null}
+      {previewText ? <div className="text">{previewText}</div> : null}
+    </div>
+  );
+}
+
+function PresetSelection({ selection }: { selection: BubblePresetSelection }) {
+  const handlePresetMouseDown = (
+    event: ReactMouseEvent<HTMLDivElement>,
+    preset: Preset,
+  ) => {
+    event.preventDefault();
+    event.stopPropagation();
+    selection.onPreset(preset);
+  };
+
+  const handleCustomKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter' && event.currentTarget.value.trim()) {
+      selection.onCustom(event.currentTarget.value.trim());
+    }
+    if (event.key === 'Escape') selection.onEscape();
+  };
+
+  return (
+    <div className="presets-section">
+      {selection.detectionLabel ? (
+        <div className="detection-badge">{selection.detectionLabel}</div>
+      ) : null}
+      <div className="preset-chips">
+        {selection.presets.slice(0, 4).map((preset) => (
+          <div
+            className="preset-chip"
+            key={`${preset.label}-${preset.instruction}`}
+            onMouseDown={(event) => handlePresetMouseDown(event, preset)}
+          >
+            {preset.label}
+          </div>
+        ))}
+      </div>
+      <input
+        className="preset-input"
+        placeholder={selection.customPlaceholder}
+        onKeyDown={handleCustomKeyDown}
+      />
+    </div>
+  );
+}
+
+export function BubbleShell({
+  styles,
+  previewText,
+  previewLabel,
+  images,
+  presets,
+}: BubbleShellProps) {
+  return (
+    <>
+      <style>{styles}</style>
+      <div className="bubble">
+        <div className="bubble-header">
+          <span className="bubble-logo">
+            <img className="bubble-logo-mark" src={BRAND_MARK_DATA_URI} alt="" aria-hidden="true" />
+            <span>{BRAND_NAME}</span>
+          </span>
+          <span className="bubble-status" />
+          <button className="pin-btn" title="Pin">
+            <PinIcon />
+          </button>
+          <button className="close-btn" title="Close">✕</button>
+        </div>
+        <Preview previewText={previewText} previewLabel={previewLabel} images={images} />
+        {presets ? <PresetSelection selection={presets} /> : null}
+        <div className="response-section">
+          <div className="bubble-body">
+            <div className="response-text" />
+            <span className="cursor blink" />
+          </div>
+          <div className="bubble-footer">
+            <input className="follow-up-input" placeholder="Ask a follow-up..." disabled />
+            <button className="action-btn history-btn" title="History">🕐</button>
+          </div>
+        </div>
+        <div className="resize-handle" title="Drag to resize">
+          <ResizeIcon />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/shared/react-root.tsx
+++ b/src/shared/react-root.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
+import { flushSync } from 'react-dom';
 
 export type ReactRootHandle = {
   render: (node: ReactNode) => void;
@@ -13,18 +14,18 @@ export function mountReactRoot(
   const root: Root = createRoot(container);
   let mounted = true;
 
-  root.render(node);
+  flushSync(() => root.render(node));
 
   return {
     render(nextNode) {
       if (!mounted) {
         throw new Error('Cannot render into an unmounted React root');
       }
-      root.render(nextNode);
+      flushSync(() => root.render(nextNode));
     },
     unmount() {
       if (!mounted) return;
-      root.unmount();
+      flushSync(() => root.unmount());
       mounted = false;
     },
   };

--- a/src/shared/types/ui.ts
+++ b/src/shared/types/ui.ts
@@ -33,6 +33,7 @@ export interface BubbleHost extends HTMLDivElement {
   _isPinned?: boolean;
   _escHandler?: (event: KeyboardEvent) => void;
   _themeCleanup?: Cleanup;
+  _reactCleanup?: Cleanup;
   _dragCleanup?: Cleanup;
   _resizeCleanup?: Cleanup;
 }

--- a/tests/bubble.test.js
+++ b/tests/bubble.test.js
@@ -33,6 +33,7 @@ vi.mock('../src/content/presets.js', () => ({
 
 const {
   showBubble,
+  showBubbleWithPresets,
   hideBubble,
   appendToken,
   setBubbleStatus,
@@ -89,6 +90,94 @@ describe('bubble.js', () => {
       const container = _getBubbleContainer();
       const header = container.shadowRoot.querySelector('.bubble-header');
       expect(header.textContent).toContain('Dobby AI');
+    });
+  });
+
+  describe('React bubble shell', () => {
+    it('renders the stable shell and preview DOM through the React root', async () => {
+      await showBubble(
+        { bottom: 100, left: 50, right: 250 },
+        [],
+        'selected text',
+        'Explain',
+        [{ type: 'image_url', image_url: { url: 'https://example.com/preview.png' } }],
+      );
+      const shadow = _getBubbleContainer().shadowRoot;
+
+      expect(shadow.querySelector('.bubble-header')).not.toBeNull();
+      expect(shadow.querySelector('.selected-text-preview .label').textContent).toBe('Explain');
+      expect(shadow.querySelector('.selected-text-preview .text').textContent).toBe('selected text');
+      expect(shadow.querySelector('.image-preview img').src).toBe('https://example.com/preview.png');
+      expect(shadow.querySelector('.response-text')).not.toBeNull();
+      expect(shadow.querySelector('.follow-up-input')).not.toBeNull();
+    });
+
+    it('renders preset selection and launches a preset through React events', async () => {
+      await showBubbleWithPresets(
+        { bottom: 100, left: 50, right: 250 },
+        'selected text',
+        null,
+      );
+      const shadow = _getBubbleContainer().shadowRoot;
+      const chip = shadow.querySelector('.preset-chip');
+
+      expect(chip.textContent).toBe('Explain this');
+      chip.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, composed: true }));
+
+      expect(promptModule.buildChatMessages).toHaveBeenCalledWith(
+        'selected text',
+        'Explain the following',
+        true,
+        undefined,
+      );
+      expect(shadow.querySelector('.presets-section').classList.contains('collapsed')).toBe(true);
+    });
+
+    it('launches a custom preset prompt through React keyboard events', async () => {
+      await showBubbleWithPresets(
+        { bottom: 100, left: 50, right: 250 },
+        'selected text',
+        null,
+      );
+      const input = _getBubbleContainer().shadowRoot.querySelector('.preset-input');
+      input.value = 'Custom instruction';
+      input.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Enter',
+        bubbles: true,
+        composed: true,
+      }));
+
+      expect(promptModule.buildChatMessages).toHaveBeenCalledWith(
+        'selected text',
+        'Custom instruction',
+        true,
+        undefined,
+      );
+    });
+
+    it('closes the bubble from the React preset input on Escape', async () => {
+      await showBubbleWithPresets(
+        { bottom: 100, left: 50, right: 250 },
+        'selected text',
+        null,
+      );
+      const input = _getBubbleContainer().shadowRoot.querySelector('.preset-input');
+      input.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        composed: true,
+      }));
+
+      expect(_getBubbleContainer()).toBeNull();
+    });
+
+    it('unmounts the React root during hideBubble cleanup', async () => {
+      await showBubble({ bottom: 100, left: 50, right: 250 }, []);
+      const shadow = _getBubbleContainer().shadowRoot;
+
+      hideBubble();
+
+      expect(shadow.childNodes).toHaveLength(0);
     });
   });
 


### PR DESCRIPTION
Closes #192.

## What changed
- Render the bubble shell, preview, and preset-selection surface through a typed React component
- Preserve the existing imperative response, streaming, history, follow-up, pin, drag, resize, and public bubble integrations
- Mount synchronously into the existing ShadowRoot so legacy DOM wiring remains stable
- Explicitly unmount the React root during `hideBubble()` cleanup
- Build extension bundles with the React production runtime
- Add focused coverage for shell DOM, preset/custom events, Escape cleanup, and React unmounting

## Compatibility
- Preserves the existing Shadow DOM host, element ordering, CSS classes, styles, exported bubble functions, messages, storage, and manifest behavior
- Existing imperative streaming/history modules continue targeting the same DOM nodes
- React is added only to `content.js`; background, popup, and options behavior remain unchanged
- Production `content.js` is approximately 764 KB unminified versus 152 KB before this production React slice

## Verification
- `npm run typecheck`
- `npm run build`
- `npm test` (629 passed)
- `npm run test:e2e` (24 passed, rerun serially after identifying a concurrent-build test race)
- `npm audit --omit=dev --audit-level=critical` (0 vulnerabilities)
- Production bundle scan found no React development runtime, `eval`, `new Function`, or unresolved `process.env` references