### PR TITLE
refactor: render bubble responses with React

### DIFF
--- a/src/content/bubble/core.tsx
+++ b/src/content/bubble/core.tsx
@@ -12,10 +12,9 @@ import { removeElement, stopShadowRootKeyboardEventPropagation } from '../shared
 import { detectTheme, watchThemeChanges } from '../../shared/theme.js';
 import { mountReactRoot } from '../../shared/react-root.js';
 import { getStyles } from './styles.js';
-import { renderMarkdown } from './markdown.js';
 import { BubbleShell, type BubblePresetSelection } from './shell.js';
 import { startStreaming, handleFollowUp } from './stream.js';
-import { showHistoryPanel } from './history.js';
+import { clearHistoryPanel, restoreHistoryEntry, showHistoryPanel } from './history.js';
 import { detectContentType } from '../detection.js';
 import { getSuggestedPresetsForType } from '../presets.js';
 import { buildChatMessages } from '../prompt.js';
@@ -28,6 +27,15 @@ import type {
   Preset,
   SelectionRect,
 } from '../../shared/types';
+import {
+  activateBubbleResponse,
+  getBubbleViewState,
+  resetBubbleView,
+  setAssistantResponse,
+  setBubblePreviewLabel,
+  setBubbleViewStatus,
+  startAssistantResponse,
+} from './view-model.js';
 
 export { detectTheme };
 
@@ -120,16 +128,6 @@ function wireCommonEvents(shadow: ShadowRoot): void {
       document.removeEventListener('mouseup', onMouseUp);
     };
   });
-  shadow.querySelector<HTMLElement>('.history-btn')!.addEventListener('click', () => {
-    showHistoryPanel(shadow);
-  });
-  shadow.querySelector<HTMLInputElement>('.follow-up-input')!.addEventListener('keydown', (e: KeyboardEvent) => {
-    if (e.key === 'Enter' && (e.target as HTMLInputElement).value.trim()) {
-      const question = (e.target as HTMLInputElement).value.trim();
-      (e.target as HTMLInputElement).value = '';
-      handleFollowUp(shadow, question);
-    }
-  });
   // Image lightbox via event delegation
   shadow.querySelector<HTMLElement>('.bubble-body')!.addEventListener('click', (e: MouseEvent) => {
     if ((e.target as HTMLElement).classList.contains('response-img')) {
@@ -194,11 +192,7 @@ function wireCommonEvents(shadow: ShadowRoot): void {
 }
 
 function activateResponseSection(shadow: ShadowRoot, messages: ChatMessage[]): void {
-  const presetsSection = shadow.querySelector('.presets-section');
-  if (presetsSection) presetsSection.classList.add('collapsed');
-  const responseSection = shadow.querySelector<HTMLElement>('.response-section')!;
-  responseSection.classList.add('active');
-  shadow.querySelector<HTMLElement>('.bubble-status')!.textContent = 'thinking...';
+  activateBubbleResponse();
   startStreaming(shadow, messages);
 }
 
@@ -211,6 +205,7 @@ async function initBubble(
 ): Promise<ShadowRoot> {
   hideBubble();
   setResponseText('');
+  resetBubbleView();
 
   createBubbleHost(selectionRect);
   bubbleHost!._isPinned = false;
@@ -228,6 +223,10 @@ async function initBubble(
       previewLabel={previewLabel}
       images={images}
       presets={presets}
+      onFollowUp={(question) => handleFollowUp(shadow, question)}
+      onHistory={() => { void showHistoryPanel(shadow); }}
+      onHistoryEntry={restoreHistoryEntry}
+      onClearHistory={() => { void clearHistoryPanel(); }}
     />,
   );
   bubbleHost!._reactCleanup = reactRoot.unmount;
@@ -246,9 +245,7 @@ function launchFromPreset(
   const messages = buildChatMessages(selectedText, instruction, true, images as ImageContentPart[] | undefined);
   setCurrentMessages(messages);
 
-  // Update preview label to show chosen instruction
-  const label = shadow.querySelector('.selected-text-preview .label');
-  if (label) label.textContent = instruction;
+  setBubblePreviewLabel(instruction);
 
   activateResponseSection(shadow, messages);
 }
@@ -308,10 +305,8 @@ export async function showBubble(
 
 export async function showHistoryBubble(selectionRect: SelectionRect): Promise<void> {
   const shadow = await initBubble(selectionRect, '', 'History', null);
-  const responseSection = shadow.querySelector('.response-section');
-  if (responseSection) responseSection.classList.add('active');
-  const status = shadow.querySelector('.bubble-status');
-  if (status) status.textContent = 'history';
+  activateBubbleResponse();
+  setBubbleViewStatus('history');
   await showHistoryPanel(shadow);
 }
 
@@ -341,27 +336,21 @@ export function hideBubble(): void {
   setCurrentMessages([]);
   setResponseText('');
   clearRawResponses();
+  resetBubbleView();
 }
 
 export function appendToken(text: string): void {
   if (!bubbleHost) return;
-  const shadow = bubbleHost.shadowRoot!;
-  const responseEl = shadow.querySelector<HTMLElement>('.response-text')!;
   appendResponseText(text);
-  // Write into the latest .message-ai div to preserve previous messages
-  let aiMsg = responseEl.querySelector<HTMLElement>('.message-ai:last-child');
-  if (!aiMsg) {
-    aiMsg = document.createElement('div');
-    aiMsg.className = 'message-ai';
-    responseEl.appendChild(aiMsg);
-  }
-  aiMsg.innerHTML = renderMarkdown(responseText);
+  const messages = getBubbleViewState().messages;
+  const lastMessage = messages[messages.length - 1];
+  const responseId = lastMessage?.role === 'assistant' ? lastMessage.id : startAssistantResponse();
+  setAssistantResponse(responseId, responseText);
 }
 
 export function setBubbleStatus(status: string): void {
   if (!bubbleHost) return;
-  const el = bubbleHost.shadowRoot!.querySelector<HTMLElement>('.bubble-status');
-  if (el) el.textContent = status;
+  setBubbleViewStatus(status);
 }
 
 export function getBubbleContainer(): BubbleHost | null {

--- a/src/content/bubble/history.ts
+++ b/src/content/bubble/history.ts
@@ -1,86 +1,25 @@
 // src/content/bubble/history.js — History panel UI
 import { setCurrentMessages, setResponseText } from '../shared/state.js';
 import { getHistory, clearHistory } from '../history.js';
-import { renderMarkdown } from './markdown.js';
-import type { ChatMessage } from '../../shared/types';
-
-function getTimeAgo(timestamp: number): string {
-  const diff = Date.now() - timestamp;
-  const mins = Math.floor(diff / 60000);
-  if (mins < 1) return 'just now';
-  if (mins < 60) return `${mins}m ago`;
-  const hours = Math.floor(mins / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
-}
+import { showHistoryView, showRestoredHistoryResponse } from './view-model.js';
+import type { ChatMessage, HistoryEntry } from '../../shared/types';
 
 export async function showHistoryPanel(shadow: ShadowRoot): Promise<void> {
-  const body = shadow.querySelector<HTMLElement>('.bubble-body')!;
   const entries = await getHistory();
+  showHistoryView(entries);
+}
 
-  if (entries.length === 0) {
-    body.innerHTML = '<div class="history-panel"><p class="history-empty">No history yet</p></div>';
-    return;
-  }
+export function restoreHistoryEntry(entry: HistoryEntry): void {
+  const msgs: ChatMessage[] = [];
+  if (entry.instruction) msgs.push({ role: 'system', content: entry.instruction });
+  if (entry.text) msgs.push({ role: 'user', content: entry.text });
+  if (entry.response) msgs.push({ role: 'assistant', content: entry.response });
+  setCurrentMessages(msgs);
+  setResponseText(entry.response || '');
+  showRestoredHistoryResponse(entry.response || '');
+}
 
-  const panel = document.createElement('div');
-  panel.className = 'history-panel';
-
-  entries.forEach((entry) => {
-    const el = document.createElement('div');
-    el.className = 'history-entry';
-    const timeAgo = getTimeAgo(entry.timestamp);
-    const instrDiv = document.createElement('div');
-    instrDiv.className = 'history-instruction';
-    instrDiv.textContent = entry.text ? entry.text.substring(0, 60) : (entry.instruction || '').substring(0, 60);
-    const metaDiv = document.createElement('div');
-    metaDiv.className = 'history-meta';
-    metaDiv.textContent = `${entry.pageTitle || 'Unknown page'} \u00b7 ${timeAgo}`;
-    el.appendChild(instrDiv);
-    el.appendChild(metaDiv);
-    el.addEventListener('click', () => {
-      body.innerHTML = '';
-      const responseEl = document.createElement('div');
-      responseEl.className = 'response-text';
-      responseEl.innerHTML = renderMarkdown(entry.response);
-      body.appendChild(responseEl);
-      const cursor = document.createElement('span');
-      cursor.className = 'cursor hidden';
-      body.appendChild(cursor);
-
-      // Show response section and hide presets
-      const presetsSection = shadow.querySelector('.presets-section');
-      if (presetsSection) presetsSection.classList.add('collapsed');
-      const responseSection = shadow.querySelector('.response-section');
-      if (responseSection) responseSection.classList.add('active');
-
-      // Restore conversation state so follow-up works
-      const msgs: ChatMessage[] = [];
-      if (entry.instruction) msgs.push({ role: 'system', content: entry.instruction });
-      if (entry.text) msgs.push({ role: 'user', content: entry.text });
-      if (entry.response) msgs.push({ role: 'assistant', content: entry.response });
-      setCurrentMessages(msgs);
-      setResponseText(entry.response || '');
-
-      const followUpInput = shadow.querySelector<HTMLInputElement>('.follow-up-input');
-      if (followUpInput) {
-        followUpInput.disabled = false;
-        followUpInput.focus();
-      }
-    });
-    panel.appendChild(el);
-  });
-
-  const clearLink = document.createElement('span');
-  clearLink.className = 'clear-link';
-  clearLink.textContent = 'Clear all history';
-  clearLink.addEventListener('click', async () => {
-    await clearHistory();
-    body.innerHTML = '<div class="history-panel"><p class="history-empty">History cleared</p></div>';
-  });
-  panel.appendChild(clearLink);
-
-  body.innerHTML = '';
-  body.appendChild(panel);
+export async function clearHistoryPanel(): Promise<void> {
+  await clearHistory();
+  showHistoryView([], 'History cleared');
 }

--- a/src/content/bubble/legacy-copy-button.ts
+++ b/src/content/bubble/legacy-copy-button.ts
@@ -1,0 +1,40 @@
+import { rawResponses } from '../shared/state.js';
+import { TIMING } from '../shared/constants.js';
+import { getColorPalette } from '../../shared/color-palette.js';
+
+const colors = getColorPalette('light');
+
+const COPY_ICON = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
+const CHECK_ICON = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>';
+
+// Retained for callers that use the pre-React copy-button helper.
+export function createCopyButton(aiMsg: HTMLElement, responseIdx: number): void {
+  const btn = document.createElement('button');
+  btn.className = 'copy-btn';
+  btn.title = 'Copy';
+  btn.setAttribute('aria-label', 'Copy response');
+  btn.dataset.responseIdx = String(responseIdx);
+  btn.innerHTML = COPY_ICON;
+  btn.addEventListener('click', async (e) => {
+    e.stopPropagation();
+    const text = rawResponses[responseIdx];
+    if (!text) return;
+    try {
+      await navigator.clipboard.writeText(text);
+      btn.classList.add('copied');
+      btn.innerHTML = CHECK_ICON;
+      setTimeout(() => {
+        btn.classList.remove('copied');
+        btn.innerHTML = COPY_ICON;
+      }, TIMING.COPY_FEEDBACK_DURATION);
+    } catch {
+      btn.title = 'Copy failed';
+      btn.style.color = colors.danger;
+      setTimeout(() => {
+        btn.title = 'Copy';
+        btn.style.color = '';
+      }, TIMING.COPY_FEEDBACK_DURATION);
+    }
+  });
+  aiMsg.appendChild(btn);
+}

--- a/src/content/bubble/shell.tsx
+++ b/src/content/bubble/shell.tsx
@@ -1,6 +1,18 @@
-import type { KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent } from 'react';
+import {
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+} from 'react';
 import { BRAND_MARK_DATA_URI, BRAND_NAME } from '../../shared/brand.js';
-import type { ImageContentPart, Preset } from '../../shared/types';
+import { getColorPalette } from '../../shared/color-palette.js';
+import { OPEN_OPTIONS_MESSAGE } from '../../shared/runtime-messages.js';
+import type { HistoryEntry, ImageContentPart, Preset } from '../../shared/types';
+import { rawResponses } from '../shared/state.js';
+import { TIMING } from '../shared/constants.js';
+import { renderMarkdown } from './markdown.js';
+import { useBubbleViewState, type BubbleViewMessage } from './view-model.js';
+
+const colors = getColorPalette('light');
 
 export type BubblePresetSelection = {
   detectionLabel?: string;
@@ -17,6 +29,10 @@ export type BubbleShellProps = {
   previewLabel: string;
   images?: ImageContentPart[] | null;
   presets?: BubblePresetSelection;
+  onFollowUp: (question: string) => void;
+  onHistory: () => void;
+  onHistoryEntry: (entry: HistoryEntry) => void;
+  onClearHistory: () => void;
 };
 
 function PinIcon() {
@@ -94,7 +110,7 @@ function PresetSelection({ selection }: { selection: BubblePresetSelection }) {
   };
 
   return (
-    <div className="presets-section">
+    <>
       {selection.detectionLabel ? (
         <div className="detection-badge">{selection.detectionLabel}</div>
       ) : null}
@@ -114,6 +130,167 @@ function PresetSelection({ selection }: { selection: BubblePresetSelection }) {
         placeholder={selection.customPlaceholder}
         onKeyDown={handleCustomKeyDown}
       />
+    </>
+  );
+}
+
+function CopyButton({ responseIdx }: { responseIdx: number }) {
+  const [copied, setCopied] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  const copy = async (event: ReactMouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    const text = rawResponses[responseIdx];
+    if (!text) return;
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), TIMING.COPY_FEEDBACK_DURATION);
+    } catch {
+      setFailed(true);
+      setTimeout(() => setFailed(false), TIMING.COPY_FEEDBACK_DURATION);
+    }
+  };
+
+  return (
+    <button
+      className={`copy-btn${copied ? ' copied' : ''}`}
+      title={failed ? 'Copy failed' : 'Copy'}
+      aria-label="Copy response"
+      data-response-idx={String(responseIdx)}
+      style={failed ? { color: colors.danger } : undefined}
+      onClick={copy}
+    >
+      {copied ? (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+      ) : (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+        </svg>
+      )}
+    </button>
+  );
+}
+
+function ConversationMessage({ message }: { message: BubbleViewMessage }) {
+  if (message.role === 'user') {
+    return <div className="message-user">{message.content}</div>;
+  }
+
+  return (
+    <div className="message-ai">
+      <div className="message-content" dangerouslySetInnerHTML={{ __html: renderMarkdown(message.content) }} />
+      {message.errorMessage ? (
+        <div className="error-msg">
+          {message.errorMessage}
+          <button className="retry-btn" onClick={message.onRetry}>Retry</button>
+        </div>
+      ) : null}
+      {message.responseIdx != null ? <CopyButton responseIdx={message.responseIdx} /> : null}
+    </div>
+  );
+}
+
+function getTimeAgo(timestamp: number): string {
+  const diff = Date.now() - timestamp;
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+function BubbleBody({
+  onHistoryEntry,
+  onClearHistory,
+}: Pick<BubbleShellProps, 'onHistoryEntry' | 'onClearHistory'>) {
+  const view = useBubbleViewState();
+
+  if (view.bodyMode === 'rate-limit') {
+    return (
+      <div className="bubble-body">
+        <div className="rate-limit-msg">
+          <p>You've used your 30 free questions today.</p>
+          <p style={{ marginTop: '8px' }}>Add your own API key in Settings for unlimited access.</p>
+          <span className="cta" onClick={() => chrome.runtime.sendMessage(OPEN_OPTIONS_MESSAGE)}>
+            Open Settings →
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  if (view.bodyMode === 'history') {
+    return (
+      <div className="bubble-body">
+        <div className="history-panel">
+          {view.historyMessage ? <p className="history-empty">{view.historyMessage}</p> : null}
+          {!view.historyMessage && view.historyEntries.length === 0 ? (
+            <p className="history-empty">No history yet</p>
+          ) : null}
+          {!view.historyMessage ? view.historyEntries.map((entry, index) => (
+            <div className="history-entry" key={entry.id || `${entry.timestamp}-${index}`} onClick={() => onHistoryEntry(entry)}>
+              <div className="history-instruction">
+                {(entry.text || entry.instruction || '').substring(0, 60)}
+              </div>
+              <div className="history-meta">
+                {entry.pageTitle || 'Unknown page'} · {getTimeAgo(entry.timestamp)}
+              </div>
+            </div>
+          )) : null}
+          {view.historyEntries.length > 0 && !view.historyMessage ? (
+            <span className="clear-link" onClick={onClearHistory}>Clear all history</span>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bubble-body">
+      {view.restoredResponse ? (
+        <div className="response-text" dangerouslySetInnerHTML={{ __html: renderMarkdown(view.restoredResponse) }} />
+      ) : (
+        <div className="response-text">
+          {view.messages.map((message) => <ConversationMessage key={message.id} message={message} />)}
+        </div>
+      )}
+      <span className={`cursor blink${view.cursorVisible ? '' : ' hidden'}`} />
+    </div>
+  );
+}
+
+function ResponseSection({
+  onFollowUp,
+  onHistory,
+  onHistoryEntry,
+  onClearHistory,
+}: Pick<BubbleShellProps, 'onFollowUp' | 'onHistory' | 'onHistoryEntry' | 'onClearHistory'>) {
+  const view = useBubbleViewState();
+
+  const handleFollowUpKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== 'Enter' || !event.currentTarget.value.trim()) return;
+    const question = event.currentTarget.value.trim();
+    event.currentTarget.value = '';
+    onFollowUp(question);
+  };
+
+  return (
+    <div className={`response-section${view.responseActive ? ' active' : ''}`}>
+      <BubbleBody onHistoryEntry={onHistoryEntry} onClearHistory={onClearHistory} />
+      <div className="bubble-footer">
+        <input
+          className="follow-up-input"
+          placeholder="Ask a follow-up..."
+          disabled={view.followUpDisabled}
+          onKeyDown={handleFollowUpKeyDown}
+        />
+        <button className="action-btn history-btn" title="History" onClick={onHistory}>🕐</button>
+      </div>
     </div>
   );
 }
@@ -124,7 +301,12 @@ export function BubbleShell({
   previewLabel,
   images,
   presets,
+  onFollowUp,
+  onHistory,
+  onHistoryEntry,
+  onClearHistory,
 }: BubbleShellProps) {
+  const view = useBubbleViewState();
   return (
     <>
       <style>{styles}</style>
@@ -134,24 +316,24 @@ export function BubbleShell({
             <img className="bubble-logo-mark" src={BRAND_MARK_DATA_URI} alt="" aria-hidden="true" />
             <span>{BRAND_NAME}</span>
           </span>
-          <span className="bubble-status" />
+          <span className="bubble-status">{view.status}</span>
           <button className="pin-btn" title="Pin">
             <PinIcon />
           </button>
           <button className="close-btn" title="Close">✕</button>
         </div>
-        <Preview previewText={previewText} previewLabel={previewLabel} images={images} />
-        {presets ? <PresetSelection selection={presets} /> : null}
-        <div className="response-section">
-          <div className="bubble-body">
-            <div className="response-text" />
-            <span className="cursor blink" />
+        <Preview previewText={previewText} previewLabel={view.previewLabel || previewLabel} images={images} />
+        {presets ? (
+          <div className={view.presetsCollapsed ? 'presets-section collapsed' : 'presets-section'}>
+            <PresetSelection selection={presets} />
           </div>
-          <div className="bubble-footer">
-            <input className="follow-up-input" placeholder="Ask a follow-up..." disabled />
-            <button className="action-btn history-btn" title="History">🕐</button>
-          </div>
-        </div>
+        ) : null}
+        <ResponseSection
+          onFollowUp={onFollowUp}
+          onHistory={onHistory}
+          onHistoryEntry={onHistoryEntry}
+          onClearHistory={onClearHistory}
+        />
         <div className="resize-handle" title="Drag to resize">
           <ResizeIcon />
         </div>

--- a/src/content/bubble/stream.ts
+++ b/src/content/bubble/stream.ts
@@ -4,68 +4,28 @@ import {
   currentMessages, setCurrentMessages,
   renderTimer, setRenderTimer,
   setCurrentRequest,
-  rawResponses, pushRawResponse,
+  pushRawResponse,
 } from '../shared/state.js';
 import { requestChat } from '../api.js';
 import { buildFollowUp } from '../prompt.js';
 import { saveConversation } from '../history.js';
-import { renderMarkdown } from './markdown.js';
 import { TIMING } from '../shared/constants.js';
-import { getColorPalette } from '../../shared/color-palette.js';
-import { OPEN_OPTIONS_MESSAGE } from '../../shared/runtime-messages.js';
 import type { ChatMessage } from '../../shared/types';
+import {
+  addUserResponse,
+  completeAssistantResponse,
+  failAssistantResponse,
+  removeBubbleMessage,
+  setAssistantResponse,
+  setBubbleViewStatus,
+  showRateLimitView,
+  startAssistantResponse,
+} from './view-model.js';
 
-const colors = getColorPalette('light');
-
-const COPY_ICON = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
-const CHECK_ICON = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>';
-
-export function createCopyButton(aiMsg: HTMLElement, responseIdx: number): void {
-  const btn = document.createElement('button');
-  btn.className = 'copy-btn';
-  btn.title = 'Copy';
-  btn.setAttribute('aria-label', 'Copy response');
-  btn.dataset.responseIdx = String(responseIdx);
-  btn.innerHTML = COPY_ICON;
-  btn.addEventListener('click', async (e) => {
-    e.stopPropagation();
-    const text = rawResponses[responseIdx];
-    if (!text) return;
-    try {
-      await navigator.clipboard.writeText(text);
-      btn.classList.add('copied');
-      btn.innerHTML = CHECK_ICON;
-      setTimeout(() => {
-        btn.classList.remove('copied');
-        btn.innerHTML = COPY_ICON;
-      }, TIMING.COPY_FEEDBACK_DURATION);
-    } catch (err) {
-      btn.title = 'Copy failed';
-      btn.style.color = colors.danger;
-      setTimeout(() => {
-        btn.title = 'Copy';
-        btn.style.color = '';
-      }, TIMING.COPY_FEEDBACK_DURATION);
-    }
-  });
-  aiMsg.appendChild(btn);
-}
+export { createCopyButton } from './legacy-copy-button.js';
 
 export function startStreaming(shadow: ShadowRoot, messages: ChatMessage[]): void {
-  const responseEl = shadow.querySelector<HTMLElement>('.response-text')!;
-  const cursorEl = shadow.querySelector<HTMLElement>('.cursor')!;
-  const statusEl = shadow.querySelector<HTMLElement>('.bubble-status')!;
-  const followUpInput = shadow.querySelector<HTMLInputElement>('.follow-up-input')!;
-
-  // Create a new AI message container for this response
-  const aiMsg = document.createElement('div');
-  aiMsg.className = 'message-ai';
-  responseEl.appendChild(aiMsg);
-
-  statusEl.textContent = 'thinking...';
-  cursorEl.classList.remove('hidden');
-  cursorEl.classList.add('blink');
-  followUpInput.disabled = true;
+  const responseId = startAssistantResponse();
 
   let firstToken = true;
 
@@ -73,7 +33,7 @@ export function startStreaming(shadow: ShadowRoot, messages: ChatMessage[]): voi
     messages,
     (token) => {
       if (firstToken) {
-        statusEl.textContent = 'typing...';
+        setBubbleViewStatus('typing...');
         firstToken = false;
       }
       appendResponseText(token);
@@ -81,7 +41,7 @@ export function startStreaming(shadow: ShadowRoot, messages: ChatMessage[]): voi
       if (!renderTimer) {
         setRenderTimer(setTimeout(() => {
           setRenderTimer(null);
-          aiMsg.innerHTML = renderMarkdown(responseText);
+          setAssistantResponse(responseId, responseText);
           const body = shadow.querySelector<HTMLElement>('.bubble-body')!;
           body.scrollTop = body.scrollHeight;
         }, TIMING.RENDER_DEBOUNCE));
@@ -90,22 +50,19 @@ export function startStreaming(shadow: ShadowRoot, messages: ChatMessage[]): voi
     (usageInfo) => {
       // Flush any pending render
       if (renderTimer) { clearTimeout(renderTimer); setRenderTimer(null); }
-      aiMsg.innerHTML = renderMarkdown(responseText);
-      if (usageInfo && usageInfo.usingOwnKey) {
-        statusEl.textContent = 'your API key';
-      } else if (usageInfo && usageInfo.remaining != null) {
-        statusEl.textContent = `${usageInfo.remaining}/30 free`;
-      } else {
-        statusEl.textContent = '';
-      }
-      cursorEl.classList.add('hidden');
-      // Store raw markdown and add copy button
+      let responseIdx: number | undefined;
       if (responseText) {
-        const idx = pushRawResponse(responseText);
-        createCopyButton(aiMsg, idx);
+        responseIdx = pushRawResponse(responseText);
       }
-      followUpInput.disabled = false;
-      followUpInput.focus();
+      completeAssistantResponse(responseId, responseText, responseIdx);
+      if (usageInfo && usageInfo.usingOwnKey) {
+        setBubbleViewStatus('your API key');
+      } else if (usageInfo && usageInfo.remaining != null) {
+        setBubbleViewStatus(`${usageInfo.remaining}/30 free`);
+      } else {
+        setBubbleViewStatus('');
+      }
+      shadow.querySelector<HTMLInputElement>('.follow-up-input')?.focus();
       setCurrentMessages([...currentMessages, { role: 'assistant', content: responseText }]);
 
       // Save to history — extract text from multimodal content arrays
@@ -131,39 +88,21 @@ export function startStreaming(shadow: ShadowRoot, messages: ChatMessage[]): voi
       });
     },
     (code, message, data) => {
-      cursorEl.classList.add('hidden');
-
       if (code === 'RATE_LIMITED') {
         showRateLimitUI(shadow);
       } else {
-        statusEl.textContent = '';
-        const errorDiv = document.createElement('div');
-        errorDiv.className = 'error-msg';
-        errorDiv.textContent = message || 'Something went wrong.';
-        const retryBtn = document.createElement('button');
-        retryBtn.className = 'retry-btn';
-        retryBtn.textContent = 'Retry';
-        retryBtn.addEventListener('click', () => {
-          errorDiv.remove();
-          aiMsg.remove();
+        failAssistantResponse(responseId, message || 'Something went wrong.', () => {
+          removeBubbleMessage(responseId);
           setResponseText('');
           startStreaming(shadow, messages);
         });
-        errorDiv.appendChild(retryBtn);
-        aiMsg.appendChild(errorDiv);
       }
     }
   ));
 }
 
 export function handleFollowUp(shadow: ShadowRoot, question: string): void {
-  const responseEl = shadow.querySelector<HTMLElement>('.response-text')!;
-
-  // Add user message bubble
-  const userMsg = document.createElement('div');
-  userMsg.className = 'message-user';
-  userMsg.textContent = question;
-  responseEl.appendChild(userMsg);
+  addUserResponse(question);
 
   // Scroll to show the user message
   const body = shadow.querySelector<HTMLElement>('.bubble-body')!;
@@ -177,16 +116,5 @@ export function handleFollowUp(shadow: ShadowRoot, question: string): void {
 }
 
 export function showRateLimitUI(shadow: ShadowRoot): void {
-  const body = shadow.querySelector<HTMLElement>('.bubble-body')!;
-  body.innerHTML = `
-    <div class="rate-limit-msg">
-      <p>You've used your 30 free questions today.</p>
-      <p style="margin-top:8px">Add your own API key in Settings for unlimited access.</p>
-      <span class="cta">Open Settings \u2192</span>
-    </div>
-  `;
-
-  shadow.querySelector<HTMLElement>('.cta')!.addEventListener('click', () => {
-    chrome.runtime.sendMessage(OPEN_OPTIONS_MESSAGE);
-  });
+  showRateLimitView();
 }

--- a/src/content/bubble/view-model.ts
+++ b/src/content/bubble/view-model.ts
@@ -1,0 +1,168 @@
+import { useSyncExternalStore } from 'react';
+import { flushSync } from 'react-dom';
+import type { HistoryEntry } from '../../shared/types';
+
+export type BubbleViewMessage = {
+  id: number;
+  role: 'user' | 'assistant';
+  content: string;
+  responseIdx?: number;
+  errorMessage?: string;
+  onRetry?: () => void;
+};
+
+export type BubbleBodyMode = 'conversation' | 'history' | 'rate-limit';
+
+export type BubbleViewState = {
+  status: string;
+  previewLabel: string | null;
+  responseActive: boolean;
+  presetsCollapsed: boolean;
+  messages: BubbleViewMessage[];
+  restoredResponse: string | null;
+  cursorVisible: boolean;
+  followUpDisabled: boolean;
+  bodyMode: BubbleBodyMode;
+  historyEntries: HistoryEntry[];
+  historyMessage: string | null;
+};
+
+const initialState: BubbleViewState = {
+  status: '',
+  previewLabel: null,
+  responseActive: false,
+  presetsCollapsed: false,
+  messages: [],
+  restoredResponse: null,
+  cursorVisible: true,
+  followUpDisabled: true,
+  bodyMode: 'conversation',
+  historyEntries: [],
+  historyMessage: null,
+};
+
+let state = initialState;
+let nextMessageId = 1;
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  flushSync(() => {
+    listeners.forEach((listener) => listener());
+  });
+}
+
+function update(patch: Partial<BubbleViewState>): void {
+  state = { ...state, ...patch };
+  emit();
+}
+
+function updateMessage(id: number, patch: Partial<BubbleViewMessage>): void {
+  update({
+    messages: state.messages.map((message) => (
+      message.id === id ? { ...message, ...patch } : message
+    )),
+  });
+}
+
+export function getBubbleViewState(): BubbleViewState {
+  return state;
+}
+
+export function subscribeBubbleView(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function useBubbleViewState(): BubbleViewState {
+  return useSyncExternalStore(subscribeBubbleView, getBubbleViewState, getBubbleViewState);
+}
+
+export function resetBubbleView(): void {
+  state = initialState;
+  nextMessageId = 1;
+  emit();
+}
+
+export function activateBubbleResponse(): void {
+  update({
+    responseActive: true,
+    presetsCollapsed: true,
+    bodyMode: 'conversation',
+    status: 'thinking...',
+  });
+}
+
+export function setBubbleViewStatus(status: string): void {
+  update({ status });
+}
+
+export function setBubblePreviewLabel(previewLabel: string): void {
+  update({ previewLabel });
+}
+
+export function startAssistantResponse(): number {
+  const id = nextMessageId++;
+  update({
+    bodyMode: 'conversation',
+    restoredResponse: null,
+    messages: [...state.messages, { id, role: 'assistant', content: '' }],
+    status: 'thinking...',
+    cursorVisible: true,
+    followUpDisabled: true,
+  });
+  return id;
+}
+
+export function setAssistantResponse(id: number, content: string): void {
+  updateMessage(id, { content });
+}
+
+export function completeAssistantResponse(id: number, content: string, responseIdx?: number): void {
+  updateMessage(id, { content, responseIdx, errorMessage: undefined, onRetry: undefined });
+  update({ cursorVisible: false, followUpDisabled: false });
+}
+
+export function failAssistantResponse(id: number, message: string, onRetry: () => void): void {
+  updateMessage(id, { errorMessage: message, onRetry });
+  update({ cursorVisible: false, status: '' });
+}
+
+export function removeBubbleMessage(id: number): void {
+  update({ messages: state.messages.filter((message) => message.id !== id) });
+}
+
+export function addUserResponse(content: string): void {
+  const restoredMessages = state.restoredResponse
+    ? [{ id: nextMessageId++, role: 'assistant' as const, content: state.restoredResponse }]
+    : state.messages;
+  const id = nextMessageId++;
+  update({
+    bodyMode: 'conversation',
+    restoredResponse: null,
+    messages: [...restoredMessages, { id, role: 'user', content }],
+  });
+}
+
+export function showRateLimitView(): void {
+  update({ bodyMode: 'rate-limit', cursorVisible: false });
+}
+
+export function showHistoryView(entries: HistoryEntry[], historyMessage: string | null = null): void {
+  update({
+    bodyMode: 'history',
+    historyEntries: entries,
+    historyMessage,
+  });
+}
+
+export function showRestoredHistoryResponse(response: string): void {
+  update({
+    bodyMode: 'conversation',
+    responseActive: true,
+    presetsCollapsed: true,
+    restoredResponse: response,
+    messages: [],
+    cursorVisible: false,
+    followUpDisabled: false,
+  });
+}

--- a/tests/bubble.test.js
+++ b/tests/bubble.test.js
@@ -46,6 +46,7 @@ const { renderMarkdown } = await import('../src/content/bubble/markdown.js');
 const historyModule = await import('../src/content/history.js');
 const promptModule = await import('../src/content/prompt.js');
 const apiModule = await import('../src/content/api.js');
+const viewModel = await import('../src/content/bubble/view-model.js');
 
 describe('bubble.js', () => {
   beforeEach(() => {
@@ -181,6 +182,80 @@ describe('bubble.js', () => {
     });
   });
 
+  describe('React response view', () => {
+    it('renders streamed assistant content and completion state', async () => {
+      let callbacks;
+      apiModule.requestChat.mockImplementation((messages, onToken, onDone, onError) => {
+        callbacks = { onToken, onDone, onError };
+        return { cancel: vi.fn() };
+      });
+      await showBubble({ bottom: 100, left: 50, right: 250 }, [{ role: 'user', content: 'hi' }]);
+
+      callbacks.onToken('Hello **world**');
+      callbacks.onDone({ remaining: 18, usingOwnKey: false });
+
+      const shadow = _getBubbleContainer().shadowRoot;
+      expect(shadow.querySelector('.message-ai').innerHTML).toContain('<strong>world</strong>');
+      expect(shadow.querySelector('.bubble-status').textContent).toBe('18/30 free');
+      expect(shadow.querySelector('.cursor').classList.contains('hidden')).toBe(true);
+      expect(shadow.querySelector('.follow-up-input').disabled).toBe(false);
+      expect(shadow.querySelector('.copy-btn')).not.toBeNull();
+    });
+
+    it('copies the completed raw response through the React copy control', async () => {
+      Object.assign(navigator, {
+        clipboard: {
+          writeText: vi.fn().mockResolvedValue(undefined),
+        },
+      });
+      let callbacks;
+      apiModule.requestChat.mockImplementation((messages, onToken, onDone, onError) => {
+        callbacks = { onToken, onDone, onError };
+        return { cancel: vi.fn() };
+      });
+      await showBubble({ bottom: 100, left: 50, right: 250 }, [{ role: 'user', content: 'hi' }]);
+      callbacks.onToken('Hello **world**');
+      callbacks.onDone(null);
+
+      _getBubbleContainer().shadowRoot.querySelector('.copy-btn').click();
+      await vi.waitFor(() => {
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith('Hello **world**');
+      });
+    });
+
+    it('renders retry errors through React and retries the request', async () => {
+      let callbacks;
+      apiModule.requestChat.mockImplementation((messages, onToken, onDone, onError) => {
+        callbacks = { onToken, onDone, onError };
+        return { cancel: vi.fn() };
+      });
+      await showBubble({ bottom: 100, left: 50, right: 250 }, [{ role: 'user', content: 'hi' }]);
+
+      callbacks.onError('NETWORK_ERROR', 'Network failed.');
+      const retry = _getBubbleContainer().shadowRoot.querySelector('.retry-btn');
+      expect(retry.parentElement.textContent).toContain('Network failed.');
+      retry.click();
+
+      expect(apiModule.requestChat).toHaveBeenCalledTimes(2);
+    });
+
+    it('renders the rate-limit CTA and opens settings', async () => {
+      let callbacks;
+      apiModule.requestChat.mockImplementation((messages, onToken, onDone, onError) => {
+        callbacks = { onToken, onDone, onError };
+        return { cancel: vi.fn() };
+      });
+      await showBubble({ bottom: 100, left: 50, right: 250 }, [{ role: 'user', content: 'hi' }]);
+
+      callbacks.onError('RATE_LIMITED', 'Daily limit reached');
+      const cta = _getBubbleContainer().shadowRoot.querySelector('.cta');
+      expect(cta.textContent).toContain('Open Settings');
+      cta.click();
+
+      expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ type: 'OPEN_OPTIONS' });
+    });
+  });
+
   describe('appendToken', () => {
     it('appends text to response area', async () => {
       await showBubble({ bottom: 100, left: 50, right: 250 }, []);
@@ -276,11 +351,11 @@ describe('bubble.js', () => {
   describe('follow-up input', () => {
     it('calls buildFollowUp and requestChat on Enter', async () => {
       await showBubble({ bottom: 100, left: 50, right: 250 }, [{ role: 'user', content: 'hi' }]);
+      viewModel.showRestoredHistoryResponse('');
       const container = _getBubbleContainer();
       const input = container.shadowRoot.querySelector('.follow-up-input');
-      input.disabled = false;
       input.value = 'tell me more';
-      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
       expect(promptModule.buildFollowUp).toHaveBeenCalled();
     });
 
@@ -386,10 +461,12 @@ describe('bubble.js', () => {
       const followUpInput = shadow.querySelector('.follow-up-input');
       followUpInput.disabled = false;
       followUpInput.value = 'tell me more';
-      followUpInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      followUpInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
 
       // requestChat should have been called (streaming started)
       expect(apiModule.requestChat).toHaveBeenCalled();
+      expect(shadow.querySelector('.response-text').textContent).toContain('AI response');
+      expect(shadow.querySelector('.message-user').textContent).toBe('tell me more');
     });
 
     it('falls back to instruction when text is empty', async () => {

--- a/tests/stream.test.js
+++ b/tests/stream.test.js
@@ -23,6 +23,7 @@ const apiModule = await import('../src/content/api.js');
 const promptModule = await import('../src/content/prompt.js');
 const { startStreaming, handleFollowUp, showRateLimitUI } = await import('../src/content/bubble/stream.js');
 const stateModule = await import('../src/content/shared/state.js');
+const viewModel = await import('../src/content/bubble/view-model.js');
 
 // Create a minimal shadow DOM with all elements stream.js needs
 function createTestShadow() {
@@ -60,6 +61,7 @@ describe('stream.js', () => {
     stateModule.setCurrentMessages([]);
     stateModule.setRenderTimer(null);
     stateModule.setCurrentRequest(null);
+    viewModel.resetBubbleView();
   });
 
   afterEach(() => {
@@ -69,24 +71,20 @@ describe('stream.js', () => {
   // ─── showRateLimitUI ──────────────────────────────────────────────────────
 
   describe('showRateLimitUI', () => {
-    it('replaces bubble-body content with rate-limit message', () => {
+    it('switches the bubble view to the rate-limit state', () => {
       showRateLimitUI(shadow);
-      const body = shadow.querySelector('.bubble-body');
-      expect(body.innerHTML).toContain("You've used your 30 free questions today.");
-      expect(body.innerHTML).toContain('Add your own API key in Settings');
+      expect(viewModel.getBubbleViewState().bodyMode).toBe('rate-limit');
     });
 
-    it('renders an "Open Settings" CTA span', () => {
+    it('hides the streaming cursor', () => {
       showRateLimitUI(shadow);
-      const cta = shadow.querySelector('.cta');
-      expect(cta).not.toBeNull();
-      expect(cta.textContent).toContain('Open Settings');
+      expect(viewModel.getBubbleViewState().cursorVisible).toBe(false);
     });
 
-    it('clicking the CTA sends OPEN_OPTIONS to chrome.runtime.sendMessage', () => {
+    it('does not mutate the legacy shadow DOM directly', () => {
+      const before = shadow.innerHTML;
       showRateLimitUI(shadow);
-      shadow.querySelector('.cta').click();
-      expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ type: 'OPEN_OPTIONS' });
+      expect(shadow.innerHTML).toBe(before);
     });
   });
 
@@ -97,26 +95,21 @@ describe('stream.js', () => {
       startStreaming(shadow, [{ role: 'user', content: 'hello' }]);
       lastCallbacks.onError('NETWORK_ERROR', 'Network failed.', {});
 
-      const errorDiv = shadow.querySelector('.error-msg');
-      expect(errorDiv).not.toBeNull();
-      expect(errorDiv.textContent).toContain('Network failed.');
+      expect(viewModel.getBubbleViewState().messages.at(-1).errorMessage).toBe('Network failed.');
     });
 
     it('falls back to default message when none is provided', () => {
       startStreaming(shadow, [{ role: 'user', content: 'hello' }]);
       lastCallbacks.onError('UNKNOWN', '', {});
 
-      const errorDiv = shadow.querySelector('.error-msg');
-      expect(errorDiv.textContent).toContain('Something went wrong.');
+      expect(viewModel.getBubbleViewState().messages.at(-1).errorMessage).toBe('Something went wrong.');
     });
 
     it('appends a retry button inside the error-msg div', () => {
       startStreaming(shadow, [{ role: 'user', content: 'hello' }]);
       lastCallbacks.onError('TIMEOUT', 'Request timed out.', {});
 
-      const retryBtn = shadow.querySelector('.retry-btn');
-      expect(retryBtn).not.toBeNull();
-      expect(retryBtn.textContent).toBe('Retry');
+      expect(viewModel.getBubbleViewState().messages.at(-1).onRetry).toBeTypeOf('function');
     });
 
     it('retry click removes error div, resets responseText, and re-calls startStreaming', () => {
@@ -124,12 +117,12 @@ describe('stream.js', () => {
       startStreaming(shadow, messages);
       lastCallbacks.onError('TIMEOUT', 'Timed out.', {});
 
-      expect(shadow.querySelector('.error-msg')).not.toBeNull();
+      expect(viewModel.getBubbleViewState().messages.at(-1).errorMessage).toBe('Timed out.');
       expect(apiModule.requestChat).toHaveBeenCalledTimes(1);
 
-      shadow.querySelector('.retry-btn').click();
+      viewModel.getBubbleViewState().messages.at(-1).onRetry();
 
-      expect(shadow.querySelector('.error-msg')).toBeNull();
+      expect(viewModel.getBubbleViewState().messages.at(-1).errorMessage).toBeUndefined();
       expect(apiModule.requestChat).toHaveBeenCalledTimes(2);
     });
 
@@ -137,8 +130,7 @@ describe('stream.js', () => {
       startStreaming(shadow, [{ role: 'user', content: 'hello' }]);
       lastCallbacks.onError('RATE_LIMITED', '', {});
 
-      const body = shadow.querySelector('.bubble-body');
-      expect(body.innerHTML).toContain("You've used your 30 free questions today.");
+      expect(viewModel.getBubbleViewState().bodyMode).toBe('rate-limit');
     });
 
     it('hides the cursor on non-RATE_LIMITED error', () => {
@@ -148,7 +140,7 @@ describe('stream.js', () => {
       startStreaming(shadow, [{ role: 'user', content: 'hello' }]);
       lastCallbacks.onError('SERVER_ERROR', 'Oops.', {});
 
-      expect(shadow.querySelector('.cursor').classList.contains('hidden')).toBe(true);
+      expect(viewModel.getBubbleViewState().cursorVisible).toBe(false);
     });
   });
 
@@ -158,9 +150,9 @@ describe('stream.js', () => {
     it('appends a .message-user bubble with the question text', () => {
       handleFollowUp(shadow, 'What does this mean?');
 
-      const userMsg = shadow.querySelector('.message-user');
-      expect(userMsg).not.toBeNull();
-      expect(userMsg.textContent).toBe('What does this mean?');
+      const userMsg = viewModel.getBubbleViewState().messages[0];
+      expect(userMsg.role).toBe('user');
+      expect(userMsg.content).toBe('What does this mean?');
     });
 
     it('calls buildFollowUp with existing messages and the new question', () => {
@@ -245,18 +237,18 @@ describe('stream.js', () => {
   describe('startStreaming — token callback', () => {
     it('sets status to "thinking..." initially', () => {
       startStreaming(shadow, [{ role: 'user', content: 'hi' }]);
-      expect(shadow.querySelector('.bubble-status').textContent).toBe('thinking...');
+      expect(viewModel.getBubbleViewState().status).toBe('thinking...');
     });
 
     it('updates status to "typing..." on first token', () => {
       startStreaming(shadow, [{ role: 'user', content: 'hi' }]);
       lastCallbacks.onToken('Hello');
-      expect(shadow.querySelector('.bubble-status').textContent).toBe('typing...');
+      expect(viewModel.getBubbleViewState().status).toBe('typing...');
     });
 
     it('disables the follow-up input while streaming', () => {
       startStreaming(shadow, [{ role: 'user', content: 'hi' }]);
-      expect(shadow.querySelector('.follow-up-input').disabled).toBe(true);
+      expect(viewModel.getBubbleViewState().followUpDisabled).toBe(true);
     });
   });
 
@@ -264,25 +256,25 @@ describe('stream.js', () => {
     it('re-enables follow-up input when streaming completes', () => {
       startStreaming(shadow, [{ role: 'user', content: 'hi' }]);
       lastCallbacks.onDone(null);
-      expect(shadow.querySelector('.follow-up-input').disabled).toBe(false);
+      expect(viewModel.getBubbleViewState().followUpDisabled).toBe(false);
     });
 
     it('shows remaining count in status when usageInfo.remaining is present', () => {
       startStreaming(shadow, [{ role: 'user', content: 'hi' }]);
       lastCallbacks.onDone({ remaining: 18 });
-      expect(shadow.querySelector('.bubble-status').textContent).toBe('18/30 free');
+      expect(viewModel.getBubbleViewState().status).toBe('18/30 free');
     });
 
     it('shows "your API key" when usageInfo.usingOwnKey is true', () => {
       startStreaming(shadow, [{ role: 'user', content: 'hi' }]);
       lastCallbacks.onDone({ usingOwnKey: true });
-      expect(shadow.querySelector('.bubble-status').textContent).toBe('your API key');
+      expect(viewModel.getBubbleViewState().status).toBe('your API key');
     });
 
     it('clears status text when usageInfo is null', () => {
       startStreaming(shadow, [{ role: 'user', content: 'hi' }]);
       lastCallbacks.onDone(null);
-      expect(shadow.querySelector('.bubble-status').textContent).toBe('');
+      expect(viewModel.getBubbleViewState().status).toBe('');
     });
   });
 });


### PR DESCRIPTION
Closes #194.

## What changed
- Add a typed external bubble view-model consumed through `useSyncExternalStore`
- Render response messages, streaming status/cursor, follow-up controls, copy controls, errors/retry, rate-limit UI, history panel, and restored history responses through React
- Replace production stream/history DOM mutation with view-model updates
- Preserve existing public bubble/stream/history function signatures and shared conversation state
- Isolate the old imperative copy-button helper as a legacy compatibility export
- Preserve history responses when users continue with a follow-up

## Compatibility
- Preserves existing classes, styles, runtime/storage contracts, markdown rendering, retry, copy, history, rate-limit, follow-up, pin, drag, resize, and lifecycle behavior
- `stream.ts` and `history.ts` no longer mutate React-owned DOM nodes
- Existing public exports remain available

## Verification
- `npm run typecheck`
- `npm run build`
- `npm test` (633 passed before the final focused compatibility addition)
- `npm run test:e2e` (24 passed)
- Final focused bubble/stream/copy suite (99 passed)
- `npm audit --omit=dev --audit-level=critical` (0 vulnerabilities)
- Production bundle scan found no React development runtime, `eval`, `new Function`, or unresolved `process.env` references