### PR TITLE
React migration 5/5: complete content UI audit

### DIFF
--- a/src/content/bubble/core.tsx
+++ b/src/content/bubble/core.tsx
@@ -128,25 +128,6 @@ function wireCommonEvents(shadow: ShadowRoot): void {
       document.removeEventListener('mouseup', onMouseUp);
     };
   });
-  // Image lightbox via event delegation
-  shadow.querySelector<HTMLElement>('.bubble-body')!.addEventListener('click', (e: MouseEvent) => {
-    if ((e.target as HTMLElement).classList.contains('response-img')) {
-      const overlay = document.createElement('div');
-      overlay.className = 'img-lightbox';
-      overlay.tabIndex = 0;
-      const img = document.createElement('img');
-      img.src = (e.target as HTMLImageElement).src;
-      img.alt = (e.target as HTMLImageElement).alt;
-      overlay.appendChild(img);
-      const dismiss = () => overlay.remove();
-      overlay.addEventListener('click', dismiss);
-      overlay.addEventListener('keydown', (ev) => {
-        if (ev.key === 'Escape') { ev.stopPropagation(); dismiss(); }
-      });
-      shadow.appendChild(overlay);
-      overlay.focus();
-    }
-  });
   // Resize handle
   const resizeHandle = shadow.querySelector<HTMLElement>('.resize-handle');
   if (resizeHandle) {
@@ -212,7 +193,12 @@ async function initBubble(
   const shadow = bubbleHost!.attachShadow({ mode: 'open' });
   stopShadowRootKeyboardEventPropagation(shadow);
   shadow.addEventListener('keydown', (e) => {
-    if ((e as KeyboardEvent).key === 'Escape') hideBubble();
+    if (
+      (e as KeyboardEvent).key === 'Escape'
+      && !(e.target as Element).closest?.('.img-lightbox')
+    ) {
+      hideBubble();
+    }
   });
 
   const reactRoot = mountReactRoot(

--- a/src/content/bubble/shell.tsx
+++ b/src/content/bubble/shell.tsx
@@ -1,8 +1,11 @@
 import {
+  useEffect,
+  useRef,
   useState,
   type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
 } from 'react';
+import { createPortal, flushSync } from 'react-dom';
 import { BRAND_MARK_DATA_URI, BRAND_NAME } from '../../shared/brand.js';
 import { getColorPalette } from '../../shared/color-palette.js';
 import { OPEN_OPTIONS_MESSAGE } from '../../shared/runtime-messages.js';
@@ -209,6 +212,20 @@ function BubbleBody({
   onClearHistory,
 }: Pick<BubbleShellProps, 'onHistoryEntry' | 'onClearHistory'>) {
   const view = useBubbleViewState();
+  const [lightbox, setLightbox] = useState<{ src: string; alt: string } | null>(null);
+  const bodyRef = useRef<HTMLDivElement>(null);
+  const lightboxRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    lightboxRef.current?.focus();
+  }, [lightbox]);
+
+  const openResponseImage = (event: ReactMouseEvent<HTMLDivElement>) => {
+    const target = event.target as HTMLElement;
+    if (!target.classList.contains('response-img')) return;
+    const image = target as HTMLImageElement;
+    flushSync(() => setLightbox({ src: image.src, alt: image.alt }));
+  };
 
   if (view.bodyMode === 'rate-limit') {
     return (
@@ -250,17 +267,40 @@ function BubbleBody({
     );
   }
 
+  const lightboxTarget = bodyRef.current?.getRootNode();
+  const lightboxView = lightbox && lightboxTarget instanceof ShadowRoot
+    ? createPortal(
+      <div
+        className="img-lightbox"
+        tabIndex={0}
+        ref={lightboxRef}
+        onClick={() => flushSync(() => setLightbox(null))}
+        onKeyDown={(event) => {
+          if (event.key !== 'Escape') return;
+          event.stopPropagation();
+          flushSync(() => setLightbox(null));
+        }}
+      >
+        <img src={lightbox.src} alt={lightbox.alt} />
+      </div>,
+      lightboxTarget,
+    )
+    : null;
+
   return (
-    <div className="bubble-body">
-      {view.restoredResponse ? (
-        <div className="response-text" dangerouslySetInnerHTML={{ __html: renderMarkdown(view.restoredResponse) }} />
-      ) : (
-        <div className="response-text">
-          {view.messages.map((message) => <ConversationMessage key={message.id} message={message} />)}
-        </div>
-      )}
-      <span className={`cursor blink${view.cursorVisible ? '' : ' hidden'}`} />
-    </div>
+    <>
+      <div className="bubble-body" ref={bodyRef} onClick={openResponseImage}>
+        {view.restoredResponse ? (
+          <div className="response-text" dangerouslySetInnerHTML={{ __html: renderMarkdown(view.restoredResponse) }} />
+        ) : (
+          <div className="response-text">
+            {view.messages.map((message) => <ConversationMessage key={message.id} message={message} />)}
+          </div>
+        )}
+        <span className={`cursor blink${view.cursorVisible ? '' : ' hidden'}`} />
+      </div>
+      {lightboxView}
+    </>
   );
 }
 

--- a/src/content/trigger/button.tsx
+++ b/src/content/trigger/button.tsx
@@ -5,24 +5,22 @@
 import { getToolbarStyles } from './styles.js';
 import { detectTheme, showBubble } from '../bubble/core.js';
 import { watchThemeChanges } from '../../shared/theme.js';
+import { mountReactRoot } from '../../shared/react-root.js';
 import { getColorPalette } from '../../shared/color-palette.js';
 import { buildChatMessages } from '../prompt.js';
 import { Z_INDEX, TIMING } from '../shared/constants.js';
 import {
-  setToolbarHost, setToolbarState, toolbarState,
-  triggerButton, setTriggerButton,
+  setToolbarHost, setToolbarState,
+  setTriggerButton,
 } from '../shared/state.js';
 import { detectContentType } from '../detection.js';
 import { getSuggestedPresetsForType } from '../presets.js';
 import { captureImage } from '../image-capture.js';
 import { recordPresetUsage, buildTypeKey } from '../shared/preset-usage.js';
-import { BRAND_MARK_DATA_URI, BRAND_NAME } from '../../shared/brand.js';
 import { stopShadowRootKeyboardEventPropagation } from '../shared/dom-utils.js';
-import type { ImageContentPart, PreservedSelection, SelectionData, ToolbarHost } from '../../shared/types';
+import { ToolbarShell } from './toolbar-shell.js';
+import type { ImageContentPart, PreservedSelection, Preset, SelectionData, ToolbarHost } from '../../shared/types';
 
-const pencilSvg = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/><path d="m15 5 4 4"/></svg>`;
-const closeSvg = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>`;
-const sendSvg = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>`;
 const SELECTION_IMAGE_WAIT_MS = 1000;
 const colors = getColorPalette('light');
 
@@ -43,8 +41,6 @@ function clearAutoHide(): void {
   }
 }
 
-// --- Active stream handle (isolated from shared state) ---
-
 // --- Toolbar creation ---
 
 async function createToolbar(): Promise<ToolbarHost> {
@@ -60,137 +56,47 @@ async function createToolbar(): Promise<ToolbarHost> {
   const shadow = host.attachShadow({ mode: 'open', delegatesFocus: true });
   stopShadowRootKeyboardEventPropagation(shadow);
 
-  // Inject styles
-  const style = document.createElement('style');
-  style.textContent = getToolbarStyles(await detectTheme());
-  shadow.appendChild(style);
+  const getPresets = () => {
+    const detected = detectContentType(host._selectedText || '', host._anchorNode || null);
+    host._detectedType = detected.type;
+    host._detectedSubType = detected.subType;
+    const presets = getSuggestedPresetsForType(detected.type, detected.subType);
+    return presets.length > 0
+      ? presets
+      : [
+        { label: 'Summarize', instruction: 'Summarize the following' },
+        { label: 'Explain', instruction: 'Explain the following in simple terms' },
+      ];
+  };
 
-  // Build toolbar DOM
-  const toolbar = document.createElement('div');
-  toolbar.className = 'toolbar';
+  const submitPreset = (preset: Preset) => {
+    recordPresetUsage(buildTypeKey(host._detectedType || 'default', host._detectedSubType || null), preset.label);
+    morphIntoBubble(host, shadow, preset.label, preset.instruction);
+  };
 
-  // --- Row: icon + expandable actions + morph header ---
-  const row = document.createElement('div');
-  row.className = 'toolbar-row';
+  const submitCustom = (instruction: string) => {
+    recordPresetUsage(buildTypeKey(host._detectedType || 'default', host._detectedSubType || null), 'Custom');
+    morphIntoBubble(host, shadow, 'Custom', instruction);
+  };
 
-  // Icon
-  const iconDiv = document.createElement('div');
-  iconDiv.className = 'toolbar-icon';
-  const img = document.createElement('img');
-  img.src = BRAND_MARK_DATA_URI;
-  img.alt = BRAND_NAME;
-  iconDiv.appendChild(img);
-  row.appendChild(iconDiv);
+  const renderToolbar = (styles: string) => (
+    <ToolbarShell
+      styles={styles}
+      host={host}
+      getPresets={getPresets}
+      onPreset={submitPreset}
+      onCustom={submitCustom}
+      onModeChange={setToolbarState}
+      onEnterInput={showSelectionHighlight}
+      onExitInput={removeSelectionHighlight}
+      onPauseAutoHide={clearAutoHide}
+      onResumeAutoHide={() => startAutoHide(host)}
+    />
+  );
 
-  // Expandable section (preset actions)
-  const expandSection = document.createElement('div');
-  expandSection.className = 'toolbar-expand';
-
-  const sep1 = document.createElement('div');
-  sep1.className = 'toolbar-sep';
-  expandSection.appendChild(sep1);
-
-  const actionsDiv = document.createElement('div');
-  actionsDiv.className = 'toolbar-actions';
-  expandSection.appendChild(actionsDiv);
-
-  const sep2 = document.createElement('div');
-  sep2.className = 'toolbar-sep';
-  expandSection.appendChild(sep2);
-
-  // Pencil / close toggle button
-  const pencilBtn = document.createElement('button');
-  pencilBtn.className = 'toolbar-pencil';
-  pencilBtn.innerHTML = pencilSvg;
-  pencilBtn.title = 'Custom prompt';
-  expandSection.appendChild(pencilBtn);
-
-  // Input mode section (hidden by default, overlays expand section)
-  const inputSection = document.createElement('div');
-  inputSection.className = 'toolbar-input-section';
-
-  const inputField = document.createElement('input');
-  inputField.className = 'toolbar-input-field';
-  inputField.type = 'text';
-  inputField.placeholder = 'Ask about this...';
-  inputSection.appendChild(inputField);
-
-  const sendBtn = document.createElement('button');
-  sendBtn.className = 'toolbar-send disabled';
-  sendBtn.innerHTML = sendSvg;
-  sendBtn.title = 'Send';
-  inputSection.appendChild(sendBtn);
-
-  row.appendChild(expandSection);
-  row.appendChild(inputSection);
-  toolbar.appendChild(row);
-
-  shadow.appendChild(toolbar);
-
-  host._themeCleanup = watchThemeChanges((theme) => {
-    style.textContent = getToolbarStyles(theme);
-  });
-
-  // --- Event handlers ---
-  toolbar.addEventListener('mouseenter', () => {
-    clearAutoHide();
-    if (toolbarState === 'collapsed') {
-      expandToolbar(host, shadow);
-    }
-  });
-
-  toolbar.addEventListener('mouseleave', () => {
-    if (toolbarState === 'expanded') {
-      collapseToolbar(shadow);
-      startAutoHide(host);
-    }
-    // If 'input' or 'morphed', do not collapse
-  });
-
-  // --- Input mode handlers ---
-  pencilBtn.addEventListener('click', (e) => {
-    e.stopPropagation();
-    if (toolbarState === 'input') {
-      exitInputMode(shadow, pencilBtn, inputField, sendBtn, host);
-    } else {
-      enterInputMode(shadow, pencilBtn, inputField, sendBtn, host);
-    }
-  });
-
-  inputField.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      const text = inputField.value.trim();
-      if (text) {
-        const detectedType = host._detectedType || 'default';
-        const detectedSubType = host._detectedSubType || null;
-        recordPresetUsage(buildTypeKey(detectedType, detectedSubType), 'Custom');
-        morphIntoBubble(host, shadow, 'Custom', text);
-      }
-    } else if (e.key === 'Escape') {
-      e.preventDefault();
-      exitInputMode(shadow, pencilBtn, inputField, sendBtn, host);
-    }
-  });
-
-  sendBtn.addEventListener('click', (e) => {
-    e.stopPropagation();
-    const text = inputField.value.trim();
-    if (text) {
-      const detectedType = host._detectedType || 'default';
-      const detectedSubType = host._detectedSubType || null;
-      recordPresetUsage(buildTypeKey(detectedType, detectedSubType), 'Custom');
-      morphIntoBubble(host, shadow, 'Custom', text);
-    }
-  });
-
-  inputField.addEventListener('input', () => {
-    if (inputField.value.trim()) {
-      sendBtn.classList.remove('disabled');
-    } else {
-      sendBtn.classList.add('disabled');
-    }
-  });
+  const reactRoot = mountReactRoot(shadow, renderToolbar(getToolbarStyles(await detectTheme())));
+  host._reactCleanup = reactRoot.unmount;
+  host._themeCleanup = watchThemeChanges((theme) => reactRoot.render(renderToolbar(getToolbarStyles(theme))));
 
   document.body.appendChild(host);
   setToolbarHost(host);
@@ -198,63 +104,6 @@ async function createToolbar(): Promise<ToolbarHost> {
   setTriggerButton(host);
 
   return host;
-}
-
-// --- Expand / Collapse ---
-
-function expandToolbar(host: ToolbarHost, shadow: ShadowRoot): void {
-  const toolbar = shadow.querySelector<HTMLElement>('.toolbar')!;
-  const actionsDiv = shadow.querySelector<HTMLElement>('.toolbar-actions')!;
-
-  // Lazily detect content type
-  const text = host._selectedText || '';
-  const anchorNode = host._anchorNode || null;
-  const detected = detectContentType(text, anchorNode);
-  let presets = getSuggestedPresetsForType(detected.type, detected.subType);
-
-  // Store detected info for input mode
-  host._detectedType = detected.type;
-  host._detectedSubType = detected.subType;
-
-  // Fallback if 0 presets
-  if (!presets || presets.length === 0) {
-    presets = [
-      { label: 'Summarize', instruction: 'Summarize the following' },
-      { label: 'Explain', instruction: 'Explain the following in simple terms' },
-    ];
-  }
-
-  // Clear old actions
-  actionsDiv.innerHTML = '';
-
-  // Show first 2 presets
-  const shownPresets = presets.slice(0, 2);
-  shownPresets.forEach((preset) => {
-    const btn = document.createElement('button');
-    btn.className = 'toolbar-action';
-    btn.textContent = preset.label;
-    btn.addEventListener('click', (e) => {
-      e.stopPropagation();
-      recordPresetUsage(buildTypeKey(detected.type, detected.subType), preset.label);
-      morphIntoBubble(host, shadow, preset.label, preset.instruction);
-    });
-    actionsDiv.appendChild(btn);
-  });
-
-  // Measure natural width and set CSS variable
-  toolbar.style.width = 'auto';
-  toolbar.classList.add('expanded');
-  const naturalWidth = toolbar.scrollWidth;
-  toolbar.style.width = '';
-  toolbar.style.setProperty('--toolbar-expanded-width', Math.max(naturalWidth + 8, 180) + 'px');
-  // Re-add expanded class (was set above but width was auto)
-  setToolbarState('expanded');
-}
-
-function collapseToolbar(shadow: ShadowRoot): void {
-  const toolbar = shadow.querySelector<HTMLElement>('.toolbar')!;
-  toolbar.classList.remove('expanded');
-  setToolbarState('collapsed');
 }
 
 // --- Morph into chat ---
@@ -421,90 +270,6 @@ function removeSelectionHighlight(): void {
   selectionHighlights = [];
 }
 
-// --- Input mode ---
-
-let outsideClickHandler: ((event: MouseEvent) => void) | null = null;
-
-function enterInputMode(
-  shadow: ShadowRoot,
-  pencilBtn: HTMLButtonElement,
-  inputField: HTMLInputElement,
-  sendBtn: HTMLButtonElement,
-  host: ToolbarHost,
-): void {
-  clearAutoHide();
-
-  // Show highlight overlay before focus steals the visual selection
-  showSelectionHighlight();
-
-  const expandSection = shadow.querySelector<HTMLElement>('.toolbar-expand')!;
-  const actionsDiv = shadow.querySelector<HTMLElement>('.toolbar-actions')!;
-  const inputSection = shadow.querySelector<HTMLElement>('.toolbar-input-section')!;
-  const seps = expandSection.querySelectorAll<HTMLElement>('.toolbar-sep');
-
-  actionsDiv.style.opacity = '0';
-  actionsDiv.style.pointerEvents = 'none';
-  seps.forEach(s => { s.style.opacity = '0'; });
-
-  pencilBtn.innerHTML = closeSvg;
-  pencilBtn.classList.add('close-mode');
-  pencilBtn.title = 'Cancel';
-
-  inputSection.classList.add('visible');
-
-  inputField.value = '';
-  sendBtn.classList.add('disabled');
-  setTimeout(() => inputField.focus(), 50);
-
-  setToolbarState('input');
-
-  outsideClickHandler = (e: MouseEvent) => {
-    if (!host.contains(e.target as Node | null) && !host.shadowRoot!.contains(e.target as Node | null)) {
-      exitInputMode(shadow, pencilBtn, inputField, sendBtn, host);
-    }
-  };
-  setTimeout(() => {
-    document.addEventListener('mousedown', outsideClickHandler!, true);
-  }, 0);
-}
-
-function exitInputMode(
-  shadow: ShadowRoot,
-  pencilBtn: HTMLButtonElement,
-  inputField: HTMLInputElement,
-  sendBtn: HTMLButtonElement,
-  host: ToolbarHost,
-): void {
-  removeSelectionHighlight();
-
-  const expandSection = shadow.querySelector<HTMLElement>('.toolbar-expand')!;
-  const actionsDiv = shadow.querySelector<HTMLElement>('.toolbar-actions')!;
-  const inputSection = shadow.querySelector<HTMLElement>('.toolbar-input-section')!;
-  const seps = expandSection.querySelectorAll<HTMLElement>('.toolbar-sep');
-
-  inputSection.classList.remove('visible');
-
-  actionsDiv.style.opacity = '';
-  actionsDiv.style.pointerEvents = '';
-  seps.forEach(s => { s.style.opacity = ''; });
-
-  pencilBtn.innerHTML = pencilSvg;
-  pencilBtn.classList.remove('close-mode');
-  pencilBtn.title = 'Custom prompt';
-
-  inputField.value = '';
-  sendBtn.classList.add('disabled');
-
-  setToolbarState('expanded');
-
-  startAutoHide(host);
-
-  if (outsideClickHandler) {
-    document.removeEventListener('mousedown', outsideClickHandler, true);
-    outsideClickHandler = null;
-  }
-}
-
 // --- Public API ---
 
 let toolbarCreating: Promise<ToolbarHost> | null = null;
@@ -546,15 +311,12 @@ export function hideTrigger(): void {
   clearAutoHide();
   removeSelectionHighlight();
   if (typeof document === 'undefined') return;
-  if (outsideClickHandler) {
-    document.removeEventListener('mousedown', outsideClickHandler, true);
-    outsideClickHandler = null;
-  }
   const host = document.getElementById('dobby-ai-toolbar-host') as ToolbarHost | null;
   if (host) {
     if (host._themeCleanup) {
       host._themeCleanup();
     }
+    host._reactCleanup?.();
     host.remove();
   }
   setToolbarHost(null);

--- a/src/content/trigger/toolbar-shell.tsx
+++ b/src/content/trigger/toolbar-shell.tsx
@@ -1,0 +1,218 @@
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type MouseEvent,
+} from 'react';
+import { flushSync } from 'react-dom';
+import { BRAND_MARK_DATA_URI, BRAND_NAME } from '../../shared/brand.js';
+import type { Preset, ToolbarHost, ToolbarState } from '../../shared/types';
+
+type ToolbarShellProps = {
+  styles: string;
+  host: ToolbarHost;
+  getPresets: () => Preset[];
+  onPreset: (preset: Preset) => void;
+  onCustom: (instruction: string) => void;
+  onModeChange: (mode: ToolbarState) => void;
+  onEnterInput: () => void;
+  onExitInput: () => void;
+  onPauseAutoHide: () => void;
+  onResumeAutoHide: () => void;
+};
+
+function PencilIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
+      <path d="m15 5 4 4" />
+    </svg>
+  );
+}
+
+function CloseIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <line x1="18" y1="6" x2="6" y2="18" />
+      <line x1="6" y1="6" x2="18" y2="18" />
+    </svg>
+  );
+}
+
+function SendIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <line x1="22" y1="2" x2="11" y2="13" />
+      <polygon points="22 2 15 22 11 13 2 9 22 2" />
+    </svg>
+  );
+}
+
+export function ToolbarShell({
+  styles,
+  host,
+  getPresets,
+  onPreset,
+  onCustom,
+  onModeChange,
+  onEnterInput,
+  onExitInput,
+  onPauseAutoHide,
+  onResumeAutoHide,
+}: ToolbarShellProps) {
+  const [mode, setMode] = useState<ToolbarState>('collapsed');
+  const [presets, setPresets] = useState<Preset[]>([]);
+  const [input, setInput] = useState('');
+  const toolbarRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const changeMode = (nextMode: ToolbarState) => {
+    onModeChange(nextMode);
+    flushSync(() => setMode(nextMode));
+  };
+
+  const expand = () => {
+    onPauseAutoHide();
+    if (mode !== 'collapsed') return;
+    const nextPresets = getPresets();
+    onModeChange('expanded');
+    flushSync(() => {
+      setPresets(nextPresets);
+      setMode('expanded');
+    });
+  };
+
+  const collapse = () => {
+    if (mode !== 'expanded') return;
+    changeMode('collapsed');
+    onResumeAutoHide();
+  };
+
+  const enterInput = () => {
+    onPauseAutoHide();
+    onEnterInput();
+    flushSync(() => setInput(''));
+    changeMode('input');
+    setTimeout(() => inputRef.current?.focus(), 50);
+  };
+
+  const exitInput = () => {
+    onExitInput();
+    flushSync(() => setInput(''));
+    changeMode('expanded');
+    onResumeAutoHide();
+  };
+
+  const submit = () => {
+    const instruction = inputRef.current?.value.trim() || input.trim();
+    if (instruction) onCustom(instruction);
+  };
+
+  useLayoutEffect(() => {
+    if (mode !== 'expanded') return;
+    const toolbar = toolbarRef.current;
+    if (!toolbar) return;
+    toolbar.style.width = 'auto';
+    const naturalWidth = toolbar.scrollWidth;
+    toolbar.style.width = '';
+    toolbar.style.setProperty('--toolbar-expanded-width', `${Math.max(naturalWidth + 8, 180)}px`);
+  }, [mode, presets]);
+
+  useEffect(() => {
+    if (mode !== 'input') return;
+    const handleOutsideClick = (event: globalThis.MouseEvent) => {
+      const target = event.target as Node | null;
+      if (!host.contains(target) && !host.shadowRoot?.contains(target)) exitInput();
+    };
+    const timer = setTimeout(() => document.addEventListener('mousedown', handleOutsideClick, true), 0);
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener('mousedown', handleOutsideClick, true);
+    };
+  }, [mode, host]);
+
+  const handleInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      submit();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      exitInput();
+    }
+  };
+
+  const handlePencilClick = (event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    if (mode === 'input') exitInput();
+    else enterInput();
+  };
+
+  return (
+    <>
+      <style>{styles}</style>
+      <div
+        className={`toolbar${mode !== 'collapsed' ? ' expanded' : ''}`}
+        ref={toolbarRef}
+        onMouseEnter={expand}
+        onMouseLeave={collapse}
+      >
+        <div className="toolbar-row">
+          <div className="toolbar-icon">
+            <img src={BRAND_MARK_DATA_URI} alt={BRAND_NAME} />
+          </div>
+          <div className="toolbar-expand">
+            <div className="toolbar-sep" style={mode === 'input' ? { opacity: 0 } : undefined} />
+            <div
+              className="toolbar-actions"
+              style={mode === 'input' ? { opacity: 0, pointerEvents: 'none' } : undefined}
+            >
+              {presets.slice(0, 2).map((preset) => (
+                <button
+                  className="toolbar-action"
+                  key={`${preset.label}-${preset.instruction}`}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onPreset(preset);
+                  }}
+                >
+                  {preset.label}
+                </button>
+              ))}
+            </div>
+            <div className="toolbar-sep" style={mode === 'input' ? { opacity: 0 } : undefined} />
+            <button
+              className={`toolbar-pencil${mode === 'input' ? ' close-mode' : ''}`}
+              title={mode === 'input' ? 'Cancel' : 'Custom prompt'}
+              onClick={handlePencilClick}
+            >
+              {mode === 'input' ? <CloseIcon /> : <PencilIcon />}
+            </button>
+          </div>
+          <div className={`toolbar-input-section${mode === 'input' ? ' visible' : ''}`}>
+            <input
+              className="toolbar-input-field"
+              type="text"
+              placeholder="Ask about this..."
+              ref={inputRef}
+              value={input}
+              onInput={(event) => flushSync(() => setInput(event.currentTarget.value))}
+              onKeyDown={handleInputKeyDown}
+            />
+            <button
+              className={`toolbar-send${input.trim() ? '' : ' disabled'}`}
+              title="Send"
+              onClick={(event) => {
+                event.stopPropagation();
+                submit();
+              }}
+            >
+              <SendIcon />
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/shared/types/ui.ts
+++ b/src/shared/types/ui.ts
@@ -18,6 +18,7 @@ export type SelectionData = {
 
 export interface ToolbarHost extends HTMLDivElement {
   _themeCleanup?: Cleanup;
+  _reactCleanup?: Cleanup;
   _detectedType?: ContentType;
   _detectedSubType?: ContentSubtype;
   _selectedText?: string;

--- a/tests/bubble.test.js
+++ b/tests/bubble.test.js
@@ -856,5 +856,23 @@ describe('bubble.js', () => {
       shadow.querySelector('.img-lightbox').click();
       expect(shadow.querySelector('.img-lightbox')).toBeNull();
     });
+
+    it('closes lightbox on Escape without closing the bubble', async () => {
+      await showBubble({ bottom: 100, left: 50, right: 250 }, []);
+      const container = _getBubbleContainer();
+      const shadow = container.shadowRoot;
+      shadow.querySelector('.response-text').innerHTML =
+        '<img class="response-img" src="https://example.com/img.png" alt="test">';
+
+      shadow.querySelector('.response-img').click();
+      shadow.querySelector('.img-lightbox').dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        composed: true,
+      }));
+
+      expect(shadow.querySelector('.img-lightbox')).toBeNull();
+      expect(_getBubbleContainer()).toBe(container);
+    });
   });
 });

--- a/tests/toolbar.test.js
+++ b/tests/toolbar.test.js
@@ -158,7 +158,7 @@ describe('hover expand/collapse', () => {
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
-    toolbar.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    toolbar.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
 
     expect(toolbar.classList.contains('expanded')).toBe(true);
     const actions = shadow.querySelectorAll('.toolbar-action');
@@ -170,7 +170,7 @@ describe('hover expand/collapse', () => {
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
-    toolbar.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    toolbar.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
 
     expect(detectContentType).toHaveBeenCalledWith('test text', document.body);
     expect(getSuggestedPresetsForType).toHaveBeenCalled();
@@ -181,10 +181,10 @@ describe('hover expand/collapse', () => {
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
-    toolbar.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    toolbar.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
     expect(toolbar.classList.contains('expanded')).toBe(true);
 
-    toolbar.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
+    toolbar.dispatchEvent(new MouseEvent('mouseout', { bubbles: true }));
     expect(toolbar.classList.contains('expanded')).toBe(false);
   });
 
@@ -193,13 +193,13 @@ describe('hover expand/collapse', () => {
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
-    toolbar.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    toolbar.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
 
     // Enter input mode by clicking pencil
     const pencilBtn = shadow.querySelector('.toolbar-pencil');
     pencilBtn.click();
 
-    toolbar.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
+    toolbar.dispatchEvent(new MouseEvent('mouseout', { bubbles: true }));
     expect(toolbar.classList.contains('expanded')).toBe(true);
   });
 });
@@ -222,7 +222,7 @@ describe('auto-hide timer', () => {
 
     // Hover after 1 second
     vi.advanceTimersByTime(1000);
-    toolbar.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    toolbar.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
 
     // Wait past the original 3s timeout
     vi.advanceTimersByTime(3000);
@@ -235,8 +235,8 @@ describe('auto-hide timer', () => {
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
-    toolbar.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
-    toolbar.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
+    toolbar.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+    toolbar.dispatchEvent(new MouseEvent('mouseout', { bubbles: true }));
 
     // Now the auto-hide should restart
     vi.advanceTimersByTime(3100);
@@ -251,7 +251,7 @@ describe('input mode', () => {
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
-    toolbar.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    toolbar.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
 
     const pencilBtn = shadow.querySelector('.toolbar-pencil');
     expect(pencilBtn).not.toBeNull();
@@ -263,7 +263,7 @@ describe('input mode', () => {
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
-    toolbar.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    toolbar.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
     shadow.querySelector('.toolbar-pencil').click();
 
     const inputSection = shadow.querySelector('.toolbar-input-section');
@@ -278,7 +278,7 @@ describe('input mode', () => {
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
-    toolbar.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    toolbar.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
     const pencilBtn = shadow.querySelector('.toolbar-pencil');
     pencilBtn.click();
 
@@ -291,7 +291,7 @@ describe('input mode', () => {
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
-    toolbar.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    toolbar.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
     const pencilBtn = shadow.querySelector('.toolbar-pencil');
     pencilBtn.click(); // enter
     pencilBtn.click(); // exit (now it's close button)
@@ -308,7 +308,7 @@ describe('input mode', () => {
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
-    toolbar.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    toolbar.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
     shadow.querySelector('.toolbar-pencil').click();
 
     const inputField = shadow.querySelector('.toolbar-input-field');
@@ -323,7 +323,7 @@ describe('input mode', () => {
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
-    toolbar.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    toolbar.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
     shadow.querySelector('.toolbar-pencil').click();
 
     const sendBtn = shadow.querySelector('.toolbar-send');
@@ -335,7 +335,7 @@ describe('input mode', () => {
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
-    toolbar.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    toolbar.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
     shadow.querySelector('.toolbar-pencil').click();
 
     const inputField = shadow.querySelector('.toolbar-input-field');
@@ -349,7 +349,7 @@ describe('input mode', () => {
   it('keeps typing shortcuts from reaching the host page', async () => {
     await showTrigger(200, 100, { text: 'test text', anchorNode: null });
     const shadow = getShadow();
-    shadow.querySelector('.toolbar').dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    shadow.querySelector('.toolbar').dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
     shadow.querySelector('.toolbar-pencil').click();
 
     const pageShortcut = vi.fn();
@@ -369,7 +369,7 @@ describe('input mode', () => {
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
-    toolbar.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    toolbar.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
     shadow.querySelector('.toolbar-pencil').click();
 
     const inputField = shadow.querySelector('.toolbar-input-field');
@@ -383,7 +383,7 @@ describe('input mode', () => {
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
-    toolbar.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    toolbar.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
     shadow.querySelector('.toolbar-pencil').click();
 
     const inputField = shadow.querySelector('.toolbar-input-field');
@@ -399,7 +399,7 @@ describe('input mode', () => {
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
-    toolbar.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    toolbar.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
     shadow.querySelector('.toolbar-pencil').click();
 
     const inputField = shadow.querySelector('.toolbar-input-field');
@@ -417,7 +417,7 @@ describe('input mode', () => {
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
-    toolbar.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    toolbar.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
     shadow.querySelector('.toolbar-pencil').click();
 
     vi.advanceTimersByTime(5000);
@@ -429,10 +429,10 @@ describe('input mode', () => {
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
-    toolbar.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    toolbar.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
     shadow.querySelector('.toolbar-pencil').click();
 
-    toolbar.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
+    toolbar.dispatchEvent(new MouseEvent('mouseout', { bubbles: true }));
     expect(toolbar.classList.contains('expanded')).toBe(true);
   });
 
@@ -442,7 +442,7 @@ describe('input mode', () => {
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
-    toolbar.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    toolbar.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
     shadow.querySelector('.toolbar-pencil').click();
 
     vi.advanceTimersByTime(1);
@@ -458,7 +458,7 @@ describe('input mode', () => {
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
-    toolbar.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    toolbar.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
     shadow.querySelector('.toolbar-pencil').click();
 
     const sendBtn = shadow.querySelector('.toolbar-send');
@@ -473,7 +473,7 @@ describe('input mode', () => {
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
-    toolbar.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    toolbar.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
     const pencilBtn = shadow.querySelector('.toolbar-pencil');
     pencilBtn.click();
     pencilBtn.click();
@@ -489,7 +489,7 @@ describe('preset click opens bubble', () => {
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
-    toolbar.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    toolbar.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
     shadow.querySelector('.toolbar-action').click();
 
     expect(showBubble).toHaveBeenCalledTimes(1);
@@ -513,7 +513,7 @@ describe('preset click opens bubble', () => {
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
-    toolbar.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    toolbar.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
     shadow.querySelector('.toolbar-action').click();
 
     expect(buildChatMessages).toHaveBeenCalledWith('test text', 'Summarize the following', true, null);
@@ -543,7 +543,7 @@ describe('preset click opens bubble', () => {
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
-    toolbar.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    toolbar.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
     shadow.querySelector('.toolbar-action').click();
     await getToolbarHost()._imagesPromise;
     await Promise.resolve();
@@ -559,7 +559,7 @@ describe('preset click opens bubble', () => {
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
-    toolbar.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    toolbar.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
     shadow.querySelector('.toolbar-action').click();
 
     // Flush async microtasks (showBubble is now async)
@@ -591,7 +591,7 @@ describe('fallback presets', () => {
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
-    toolbar.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    toolbar.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
     const actions = shadow.querySelectorAll('.toolbar-action');
     expect(actions.length).toBe(2);
     expect(actions[0].textContent).toBe('Summarize');
@@ -606,7 +606,7 @@ describe('fallback presets', () => {
     const shadow = getShadow();
     const toolbar = shadow.querySelector('.toolbar');
 
-    toolbar.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    toolbar.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
     const actions = shadow.querySelectorAll('.toolbar-action');
     expect(actions.length).toBe(1);
     expect(actions[0].textContent).toBe('Explain code');


### PR DESCRIPTION
Closes #198

## Summary
- render the selection toolbar shell, presets, hover/input modes, and cleanup through React
- render the bubble image lightbox through a React portal at the ShadowRoot boundary
- preserve toolbar host, selection geometry, message/storage contracts, CSS classes, and interaction behavior
- document the audited imperative boundaries intentionally retained for pointer/layout-driven UI and compatibility

## Compatibility decisions
- screenshot overlay/toolbar, long-press progress ring, autosuggest ghost text, and selection highlights remain imperative because they are tightly coupled to pointer or layout updates
- the exported `createCopyButton` adapter remains for backwards compatibility; production bubble copy controls are React-owned

## Verification
- npm run typecheck
- npm run build
- npm test (634 passed)
- npm run test:e2e (24 passed)
- npm audit --omit=dev --audit-level=high (0 vulnerabilities)
- production bundles contain no React development runtime, eval/new Function, or unresolved process.env