### PR TITLE
Update default OpenAI mini model

### DIFF
--- a/proxy/src/openai.ts
+++ b/proxy/src/openai.ts
@@ -1,8 +1,8 @@
 // proxy/src/openai.ts
+import { DEFAULT_OPENAI_MODEL, DEFAULT_REASONING_EFFORT } from '../../src/shared/model-config.js';
 import type { ChatMessage } from '../../src/shared/types';
 
 const OPENAI_URL = 'https://api.openai.com/v1/chat/completions';
-const MODEL = 'gpt-4.1-mini';
 const DEFAULT_MAX_TOKENS = 1000;
 
 export async function createChatStream(
@@ -18,10 +18,11 @@ export async function createChatStream(
       Authorization: `Bearer ${apiKey}`,
     },
     body: JSON.stringify({
-      model: MODEL,
+      model: DEFAULT_OPENAI_MODEL,
       messages,
       stream: true,
-      max_tokens: maxTokens || DEFAULT_MAX_TOKENS,
+      reasoning_effort: DEFAULT_REASONING_EFFORT,
+      max_completion_tokens: maxTokens || DEFAULT_MAX_TOKENS,
     }),
     signal,
   });

--- a/proxy/tests/openai.test.js
+++ b/proxy/tests/openai.test.js
@@ -28,10 +28,11 @@ describe('createChatStream', () => {
     );
 
     const body = JSON.parse(mockFetch.mock.calls[0][1].body);
-    expect(body.model).toBe('gpt-4.1-mini');
+    expect(body.model).toBe('gpt-5.4-mini');
     expect(body.messages).toEqual(messages);
     expect(body.stream).toBe(true);
-    expect(body.max_tokens).toBe(1000);
+    expect(body.reasoning_effort).toBe('none');
+    expect(body.max_completion_tokens).toBe(1000);
   });
 
   it('passes abort signal when provided', async () => {
@@ -66,15 +67,15 @@ describe('createChatStream', () => {
     await createChatStream([{ role: 'user', content: 'hi' }], 'sk-key', undefined, 200);
 
     const body = JSON.parse(mockFetch.mock.calls[0][1].body);
-    expect(body.max_tokens).toBe(200);
+    expect(body.max_completion_tokens).toBe(200);
   });
 
-  it('falls back to default max_tokens when maxTokens is not provided', async () => {
+  it('falls back to default max_completion_tokens when maxTokens is not provided', async () => {
     mockFetch.mockResolvedValue({ ok: true, body: 'stream' });
 
     await createChatStream([{ role: 'user', content: 'hi' }], 'sk-key');
 
     const body = JSON.parse(mockFetch.mock.calls[0][1].body);
-    expect(body.max_tokens).toBe(1000);
+    expect(body.max_completion_tokens).toBe(1000);
   });
 });

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -2,6 +2,7 @@
 // All API calls from content scripts route through here (MV3 cross-origin constraint)
 
 import { AUTOSUGGEST_MAX_SUGGESTION_TOKENS } from '../shared/autosuggest-limits.js';
+import { DEFAULT_OPENAI_MODEL, DEFAULT_REASONING_EFFORT } from '../shared/model-config.js';
 import { getLocalStorage, setLocalStorage } from '../shared/storage.js';
 
 import type {
@@ -240,10 +241,11 @@ chrome.runtime.onConnect.addListener((port) => {
             Authorization: `Bearer ${stored.userApiKey}`,
           },
           body: JSON.stringify({
-            model: 'gpt-4.1-mini',
+            model: DEFAULT_OPENAI_MODEL,
             messages,
             stream: true,
-            max_tokens: 1000,
+            reasoning_effort: DEFAULT_REASONING_EFFORT,
+            max_completion_tokens: 1000,
           }),
           signal: abortController.signal,
         });
@@ -333,10 +335,11 @@ chrome.runtime.onConnect.addListener((port) => {
             Authorization: `Bearer ${stored.userApiKey}`,
           },
           body: JSON.stringify({
-            model: 'gpt-4.1-mini',
+            model: DEFAULT_OPENAI_MODEL,
             messages,
             stream: true,
-            max_tokens: AUTOSUGGEST_MAX_SUGGESTION_TOKENS,
+            reasoning_effort: DEFAULT_REASONING_EFFORT,
+            max_completion_tokens: AUTOSUGGEST_MAX_SUGGESTION_TOKENS,
           }),
           signal: abortController.signal,
         });

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -184,7 +184,7 @@ function OptionsApp() {
               <li>Click <strong>"Create new secret key"</strong>, give it a name, and copy the key</li>
               <li>Paste the key above and click Save — Dobby AI will validate it automatically</li>
             </ol>
-            <p className="hint">OpenAI keys typically start with <code>sk-</code>. You'll need a payment method on your OpenAI account. Usage is billed per request (~$0.001/question with GPT-4.1-mini).</p>
+            <p className="hint">OpenAI keys typically start with <code>sk-</code>. You'll need a payment method on your OpenAI account. Usage is billed by OpenAI based on model and token usage.</p>
           </div>
           <div className={`provider-panel${provider === 'anthropic' ? ' active' : ''}`} id="panel-anthropic">
             <ol className="steps">
@@ -201,7 +201,7 @@ function OptionsApp() {
       <div className="card">
         <h2>How it works</h2>
         <div className="usage-info">
-          <strong>Free tier:</strong> 30 questions/day powered by GPT-4.1-mini via our proxy server. No setup needed.<br /><br />
+          <strong>Free tier:</strong> 30 questions/day powered by GPT-5.4 mini via our proxy server. No setup needed.<br /><br />
           <strong>Your own key:</strong> Requests go directly to the API provider — your key stays on your device and is never sent to our servers.<br /><br />
           <strong>Helpful links:</strong><br />
           • <a href="https://platform.openai.com/usage" target="_blank" style={{ color: 'inherit' }}>OpenAI usage dashboard</a><br />

--- a/src/shared/model-config.ts
+++ b/src/shared/model-config.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_OPENAI_MODEL = 'gpt-5.4-mini';
+export const DEFAULT_REASONING_EFFORT = 'none';

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -457,6 +457,10 @@ describe('chat-stream integration', () => {
     const calledUrl = fetch.mock.calls[0][0];
     expect(calledUrl).toContain('openai.com');
     expect(fetch.mock.calls[0][1].headers.Authorization).toBe('Bearer sk-user');
+    const body = JSON.parse(fetch.mock.calls[0][1].body);
+    expect(body.model).toBe('gpt-5.4-mini');
+    expect(body.reasoning_effort).toBe('none');
+    expect(body.max_completion_tokens).toBe(1000);
   });
 
   it('forwards 429 rate limit as rate_limited message', async () => {
@@ -542,7 +546,9 @@ describe('autosuggest-stream port', () => {
     const calledUrl = fetch.mock.calls[0][0];
     expect(calledUrl).toContain('openai.com');
     const body = JSON.parse(fetch.mock.calls[0][1].body);
-    expect(body.max_tokens).toBe(AUTOSUGGEST_MAX_SUGGESTION_TOKENS);
+    expect(body.model).toBe('gpt-5.4-mini');
+    expect(body.reasoning_effort).toBe('none');
+    expect(body.max_completion_tokens).toBe(AUTOSUGGEST_MAX_SUGGESTION_TOKENS);
   });
 
   it('passes purpose=autosuggest to proxy when no user key', async () => {


### PR DESCRIPTION
## Summary

- update the default OpenAI model from `gpt-4.1-mini` to `gpt-5.4-mini`
- centralize the active model and reasoning-effort policy for direct and proxy requests
- use `max_completion_tokens` and `reasoning_effort: "none"` for GPT-5.4 mini compatibility while preserving low-latency behavior
- update settings copy and request-payload tests

## Why

OpenAI currently recommends GPT-5.4 mini as its strongest mini model for lower-cost and lower-latency workloads. The previous model string was duplicated across direct BYOK and managed proxy paths, which could allow them to drift.

## Impact

Both BYOK and managed proxy requests will use GPT-5.4 mini after their respective extension/proxy deployments. Autosuggest remains configured for minimal latency with reasoning disabled and its existing completion-token limit.

## Validation

- `npm test` — 634 tests passed
- `npm run typecheck`
- `npm run build`
- `git diff --check`

A live OpenAI request was not run because no `OPENAI_API_KEY` is available in the execution environment.