### PR TITLE
Add guided bug reporting flow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,84 @@
+name: Bug report
+description: Tell us about something that is not working as expected
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve Dobby AI. Please do not include API keys, private page content, or other sensitive information.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Where did the bug happen?
+      options:
+        - Text selection toolbar
+        - AI response bubble
+        - Screenshot capture
+        - Text auto-suggest
+        - Extension popup
+        - Settings
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: What did you do before the problem appeared?
+      placeholder: |
+        1. Open ...
+        2. Select ...
+        3. Click ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: What happened instead?
+      placeholder: Include any visible error message, but remove sensitive information.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Dobby AI version
+      description: Find this next to the Dobby AI name in the extension popup.
+      placeholder: v1.3.0
+    validations:
+      required: true
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser and operating system
+      placeholder: Chrome 137 on macOS 15
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or additional context
+      description: Optional. Remove private page content before attaching screenshots.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I removed API keys, private page content, and other sensitive information.
+          required: true

--- a/e2e/extension.spec.js
+++ b/e2e/extension.spec.js
@@ -80,3 +80,19 @@ test('popup page loads and toggle works', async () => {
 
   await popupPage.close();
 });
+
+test('popup links to the guided bug report form', async () => {
+  const popupPage = await context.newPage();
+  await popupPage.goto(`chrome-extension://${extensionId}/popup.html`);
+
+  const reportBug = popupPage.locator('#report-bug');
+  await expect(reportBug).toBeVisible();
+  await expect(reportBug).toHaveAttribute(
+    'href',
+    'https://github.com/Duobi-AI/dobby-ai/issues/new?template=bug_report.yml',
+  );
+  await expect(reportBug).toHaveAttribute('target', '_blank');
+  await expect(reportBug).toHaveAttribute('rel', 'noopener noreferrer');
+
+  await popupPage.close();
+});

--- a/popup.html
+++ b/popup.html
@@ -19,6 +19,52 @@
     margin-bottom: 10px;
     border-bottom: 1px solid var(--color-border-divider);
   }
+  .support-link {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 34px;
+    padding: 7px 8px;
+    border: 1px solid var(--color-border-interactive);
+    border-radius: 7px;
+    background: var(--color-surface-interactive);
+    color: var(--color-text-primary);
+    text-decoration: none;
+    transition: background 0.15s, border-color 0.15s;
+  }
+  .support-link:hover {
+    background: var(--color-surface-interactive-hover);
+    border-color: var(--color-border-strong);
+  }
+  .support-link:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+  }
+  .support-icon {
+    width: 16px;
+    height: 16px;
+    flex: 0 0 auto;
+    color: var(--color-accent-interactive);
+  }
+  .support-copy {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    gap: 1px;
+    min-width: 0;
+  }
+  .support-title {
+    font-size: 11px;
+    font-weight: 600;
+  }
+  .support-detail {
+    color: var(--color-text-muted);
+    font-size: 10px;
+  }
+  .support-arrow {
+    color: var(--color-text-muted);
+    font-size: 13px;
+  }
   .theme-segment {
     display: flex;
     border: 1px solid var(--color-border-segment);

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -273,6 +273,23 @@ function PopupApp() {
           ))}
         </div>
       </div>
+      <a
+        className="support-link"
+        id="report-bug"
+        href="https://github.com/Duobi-AI/dobby-ai/issues/new?template=bug_report.yml"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Report a bug on GitHub"
+      >
+        <svg className="support-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden="true">
+          <path d="M8 9h8m-8 4h8m-5 4h3a4 4 0 0 0 4-4V8a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v5a4 4 0 0 0 4 4h1l3 3v-3Z" />
+        </svg>
+        <span className="support-copy">
+          <span className="support-title">Report a bug</span>
+          <span className="support-detail">Tell us what went wrong</span>
+        </span>
+        <span className="support-arrow" aria-hidden="true">&gt;</span>
+      </a>
     </>
   );
 }

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -90,6 +90,14 @@ describe('popup.js', () => {
       expect(document.getElementById('version').textContent).toBe('v1.2.0');
     });
 
+    it('links to the guided bug report form', () => {
+      const reportBug = document.getElementById('report-bug');
+
+      expect(reportBug.href).toBe('https://github.com/Duobi-AI/dobby-ai/issues/new?template=bug_report.yml');
+      expect(reportBug.target).toBe('_blank');
+      expect(reportBug.rel).toBe('noopener noreferrer');
+    });
+
     it('loads default toggle states', () => {
       expect(document.getElementById('enabled').checked).toBe(true);
       expect(document.getElementById('status').textContent).toBe('On');


### PR DESCRIPTION
## Summary
- add a visible Report a bug action to the extension popup
- add a guided GitHub issue form with reproduction, environment, and privacy prompts
- cover the report link with unit and extension E2E tests

## Why
Users need a low-friction way to report problems immediately after encountering them without Dobby automatically collecting private page content or API keys.

## Validation
- `npm run typecheck`
- `npm test` (635 passed)
- `npm run build`
- `npm run test:e2e` (25 passed)
- issue template YAML parse
- visual review in light and dark themes