### PR TITLE
fix: support autosuggest in rich text editors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ test-results/
 coverage/
 .DS_Store
 .playwright-mcp/
+.playwright-auth/
 .omc/
 .claude/
 mockups/

--- a/e2e/autosuggest.spec.js
+++ b/e2e/autosuggest.spec.js
@@ -1,0 +1,69 @@
+// e2e/autosuggest.spec.js — Real-browser contenteditable autosuggest behavior
+const path = require('node:path');
+const { test, expect } = require('@playwright/test');
+const { launchExtension } = require('./helpers');
+
+let context, page, serviceWorker;
+
+test.beforeAll(async () => {
+  ({ context, page } = await launchExtension());
+  serviceWorker = context.serviceWorkers()[0] || await context.waitForEvent('serviceworker');
+  await serviceWorker.evaluate(async () => {
+    await chrome.storage.local.set({ autosuggestEnabled: true });
+    const originalFetch = globalThis.fetch.bind(globalThis);
+    globalThis.fetch = async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url;
+      if (url.includes('dobby-ai-proxy') || url.includes('api.openai.com')) {
+        return new Response(
+          'data: {"choices":[{"delta":{"content":" from Dobby"}}]}\n\ndata: [DONE]\n\n',
+          { status: 200, headers: { 'Content-Type': 'text/event-stream' } },
+        );
+      }
+      return originalFetch(input, init);
+    };
+  });
+  await page.reload();
+  await page.waitForLoadState('domcontentloaded');
+});
+
+test.afterAll(async () => {
+  await context?.close();
+});
+
+test('contenteditable shows and accepts an autosuggestion', async () => {
+  await page.evaluate(() => {
+    const editor = document.createElement('div');
+    editor.id = 'autosuggest-rich-editor';
+    editor.setAttribute('contenteditable', 'true');
+    editor.setAttribute('aria-label', 'Message');
+    editor.style.cssText = [
+      'width: 560px',
+      'min-height: 96px',
+      'margin: 80px auto',
+      'padding: 16px',
+      'border: 1px solid #777',
+      'border-radius: 8px',
+      'font: 16px/24px Arial, sans-serif',
+      'background: white',
+      'color: black',
+    ].join(';');
+    document.body.appendChild(editor);
+  });
+
+  const editor = page.locator('#autosuggest-rich-editor');
+  await editor.click();
+  await editor.pressSequentially('Please send the project update', { delay: 20 });
+
+  const ghostHost = page.locator('[data-dobby-autosuggest]');
+  await expect(ghostHost).toBeVisible({ timeout: 5000 });
+  await expect(ghostHost.locator('.ghost-text')).toHaveText(' from Dobby');
+
+  await page.screenshot({
+    path: path.resolve('output/playwright/autosuggest-contenteditable-ghost.png'),
+    fullPage: true,
+  });
+
+  await editor.press('Tab');
+  await expect(editor).toHaveText('Please send the project update from Dobby');
+  await expect(ghostHost).toHaveCount(0);
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dobby AI",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Select text and get instant AI explanations inline on any page",
   "permissions": [
     "contextMenus",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dobby-ai",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "description": "Select text or screenshot any region on the web — get instant AI answers right where you are",
   "scripts": {
@@ -8,6 +8,10 @@
     "dev": "node esbuild.config.js --watch",
     "test": "vitest run",
     "test:e2e": "npm run build && npx playwright test",
+    "test:popular-sites:login": "npm run build && node scripts/verify-popular-sites.js login",
+    "test:popular-sites": "npm run build && node scripts/verify-popular-sites.js verify",
+    "test:popular-sites:linkedin": "npm run build && node scripts/verify-popular-sites.js verify linkedin",
+    "test:popular-sites:github": "npm run build && node scripts/verify-popular-sites.js verify github",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },

--- a/scripts/verify-popular-sites.js
+++ b/scripts/verify-popular-sites.js
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+
+const path = require('node:path');
+const readline = require('node:readline');
+const { chromium } = require('playwright');
+
+const mode = process.argv[2] || 'login';
+const site = process.argv[3] || 'all';
+const root = path.resolve(__dirname, '..');
+const extensionPath = path.join(root, 'dist');
+const profilePath = path.join(root, '.playwright-auth', 'popular-sites');
+const testText = 'Dobby autosuggest real site verification';
+
+if (!['login', 'verify'].includes(mode) || !['all', 'linkedin', 'github'].includes(site)) {
+  console.error('Usage: node scripts/verify-popular-sites.js [login|verify] [all|linkedin|github]');
+  process.exit(1);
+}
+
+async function enableAutosuggest(context) {
+  let serviceWorker = context.serviceWorkers().find((worker) => worker.url().startsWith('chrome-extension://'));
+  if (!serviceWorker) {
+    serviceWorker = await context.waitForEvent('serviceworker', {
+      predicate: (worker) => worker.url().startsWith('chrome-extension://'),
+      timeout: 10000,
+    });
+  }
+  const extensionId = new URL(serviceWorker.url()).host;
+  const popup = await context.newPage();
+  try {
+    await popup.goto(`chrome-extension://${extensionId}/popup.html`, { waitUntil: 'domcontentloaded' });
+    const toggle = popup.locator('#autosuggest-enabled');
+    await toggle.waitFor({ state: 'attached', timeout: 10000 });
+    if (!await toggle.isChecked()) await toggle.click({ force: true });
+  } finally {
+    await popup.close();
+  }
+}
+
+async function clearDraft(locator) {
+  await locator.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
+  await locator.press('Backspace');
+}
+
+async function verifyEditor(page, name, locator) {
+  let draftStarted = false;
+  try {
+    await locator.waitFor({ state: 'visible', timeout: 15000 });
+    await locator.click();
+    await locator.type(testText, { delay: 30 });
+    draftStarted = true;
+
+    const ghostHost = page.locator('[data-dobby-autosuggest]');
+    await ghostHost.waitFor({ state: 'visible', timeout: 15000 });
+    const suggestion = await ghostHost.locator('.ghost-text').textContent();
+    await locator.press('Tab');
+    await clearDraft(locator);
+    return { site: name, passed: true, suggestion };
+  } catch (error) {
+    if (draftStarted) {
+      try {
+        await clearDraft(locator);
+      } catch (cleanupError) {
+        return {
+          site: name,
+          passed: false,
+          error: `${error.message.split('\n')[0]}; draft cleanup failed: ${cleanupError.message.split('\n')[0]}`,
+        };
+      }
+    }
+    return { site: name, passed: false, error: error.message.split('\n')[0] };
+  }
+}
+
+async function waitForUser() {
+  console.log('\nLog into LinkedIn and GitHub in the opened browser.');
+  console.log('Press Enter here when finished. The browser profile will be saved for future verification.\n');
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  await new Promise((resolve) => rl.question('', resolve));
+  rl.close();
+}
+
+async function main() {
+  const context = await chromium.launchPersistentContext(profilePath, {
+    headless: false,
+    args: [
+      `--disable-extensions-except=${extensionPath}`,
+      `--load-extension=${extensionPath}`,
+      '--no-first-run',
+      '--no-default-browser-check',
+    ],
+  });
+
+  try {
+    await enableAutosuggest(context);
+    const linkedin = site === 'all' || site === 'linkedin'
+      ? context.pages()[0] || await context.newPage()
+      : null;
+    if (linkedin) await linkedin.goto('https://www.linkedin.com/messaging/', { waitUntil: 'domcontentloaded' });
+    const github = site === 'all' || site === 'github' ? await context.newPage() : null;
+    if (github) await github.goto('https://github.com/Duobi-AI/dobby-ai/issues/new', { waitUntil: 'domcontentloaded' });
+
+    if (mode === 'login') {
+      await waitForUser();
+      return;
+    }
+
+    const results = [];
+    if (linkedin) {
+      results.push(await verifyEditor(
+        linkedin,
+        'LinkedIn messaging',
+        linkedin.getByRole('textbox', { name: 'Write a message…', exact: true }),
+      ));
+    }
+    if (github) {
+      results.push(await verifyEditor(
+        github,
+        'GitHub issue description',
+        github.getByRole('textbox', { name: 'Markdown value', exact: true }),
+      ));
+    }
+
+    console.table(results);
+    if (results.some((result) => !result.passed)) process.exitCode = 1;
+  } finally {
+    await context.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/content/autosuggest/context.ts
+++ b/src/content/autosuggest/context.ts
@@ -1,33 +1,42 @@
 // src/content/autosuggest/context.js — Builds OpenAI chat-format messages for completion
 import { AUTOSUGGEST } from '../shared/constants.js';
 import type { AutosuggestPageContext, ChatMessage } from '../../shared/types';
+import { getEditorText, isTextareaEditor, type AutosuggestEditor } from './editor.js';
 
 /**
- * Gather rich context from the textarea and surrounding page.
- * @param {HTMLTextAreaElement} textarea
+ * Gather rich context from the editor and surrounding page.
+ * @param {AutosuggestEditor} editor
  * @returns {object} pageContext for buildCompletionMessages
  */
-export function gatherPageContext(textarea: HTMLTextAreaElement): AutosuggestPageContext {
+export function gatherPageContext(editor: AutosuggestEditor): AutosuggestPageContext {
   const ctx: AutosuggestPageContext = {
     pageTitle: document.title || '',
     pageUrl: window.location.href || '',
   };
 
-  // Textarea placeholder / label
-  if (textarea.placeholder) {
-    ctx.fieldHint = textarea.placeholder;
+  const placeholder = isTextareaEditor(editor)
+    ? editor.placeholder
+    : editor.getAttribute('aria-placeholder') || editor.getAttribute('data-placeholder') || '';
+  if (placeholder) {
+    ctx.fieldHint = placeholder;
   }
-  const labelEl = textarea.labels?.[0] || (textarea.id && document.querySelector(`label[for="${textarea.id}"]`));
+  const labelEl = isTextareaEditor(editor)
+    ? editor.labels?.[0] || (editor.id && document.querySelector(`label[for="${editor.id}"]`))
+    : editor.getAttribute('aria-labelledby')
+      ? document.getElementById(editor.getAttribute('aria-labelledby')!)
+      : null;
   if (labelEl) {
-    ctx.fieldLabel = labelEl.textContent.trim();
+    ctx.fieldLabel = labelEl.textContent?.trim();
+  } else if (!isTextareaEditor(editor) && editor.getAttribute('aria-label')) {
+    ctx.fieldLabel = editor.getAttribute('aria-label')!;
   }
 
   // Nearby form fields (sibling inputs with values)
-  const form = textarea.closest('form');
+  const form = editor.closest('form');
   if (form) {
     const fields: string[] = [];
     for (const el of form.elements) {
-      if (el === textarea) continue;
+      if (el === editor) continue;
       if ((el.tagName === 'INPUT' || el.tagName === 'SELECT') && (el as HTMLInputElement).value && (el as HTMLInputElement).type !== 'hidden' && (el as HTMLInputElement).type !== 'password') {
         const name = (el as HTMLInputElement).labels?.[0]?.textContent?.trim() || (el as HTMLInputElement).placeholder || (el as HTMLInputElement).name || '';
         if (name && (el as HTMLInputElement).value.length < 200) {
@@ -41,11 +50,11 @@ export function gatherPageContext(textarea: HTMLTextAreaElement): AutosuggestPag
   }
 
   // Surrounding page text (nearest parent section or article, trimmed)
-  const container = textarea.closest('article, section, [role="main"], main, .comment-body, .issue-body') || textarea.parentElement;
+  const container = editor.closest('article, section, [role="main"], main, .comment-body, .issue-body') || editor.parentElement;
   if (container) {
     const text = (container as HTMLElement).innerText || container.textContent || '';
-    // Take first 500 chars of surrounding text, excluding the textarea's own content
-    const surrounding = text.replaceAll(textarea.value, '').trim().substring(0, 500);
+    // Take first 500 chars of surrounding text, excluding the editor's own content
+    const surrounding = text.replaceAll(getEditorText(editor), '').trim().substring(0, 500);
     if (surrounding.length > 20) {
       ctx.surroundingText = surrounding;
     }

--- a/src/content/autosuggest/editor.ts
+++ b/src/content/autosuggest/editor.ts
@@ -1,0 +1,117 @@
+export type AutosuggestEditor = HTMLTextAreaElement | HTMLElement;
+
+export function isTextareaEditor(editor: AutosuggestEditor): editor is HTMLTextAreaElement {
+  return editor instanceof HTMLTextAreaElement;
+}
+
+export function getEditableRoot(target: EventTarget | null): AutosuggestEditor | null {
+  if (target instanceof HTMLTextAreaElement) return target;
+  if (!(target instanceof HTMLElement)) return null;
+
+  let current: HTMLElement | null = target;
+  while (current) {
+    if (current.hasAttribute('contenteditable')) {
+      return current.getAttribute('contenteditable')?.toLowerCase() === 'false' ? null : current;
+    }
+    current = current.parentElement;
+  }
+  return null;
+}
+
+export function getEditorText(editor: AutosuggestEditor): string {
+  if (isTextareaEditor(editor)) return editor.value;
+  return editor.innerText || editor.textContent || '';
+}
+
+function selectionBelongsToEditor(editor: HTMLElement, selection: Selection | null): selection is Selection {
+  if (!selection || selection.rangeCount === 0 || !selection.isCollapsed) return false;
+  const range = selection.getRangeAt(0);
+  return editor.contains(range.commonAncestorContainer);
+}
+
+export function hasCollapsedCaret(editor: AutosuggestEditor): boolean {
+  if (isTextareaEditor(editor)) {
+    return editor.selectionStart != null
+      && editor.selectionEnd != null
+      && editor.selectionStart === editor.selectionEnd;
+  }
+  return selectionBelongsToEditor(editor, window.getSelection());
+}
+
+export function getContenteditableCaretRect(editor: HTMLElement): DOMRect | null {
+  const selection = window.getSelection();
+  if (!selectionBelongsToEditor(editor, selection)) return null;
+
+  const range = selection.getRangeAt(0).cloneRange();
+  range.collapse(false);
+  const rect = range.getBoundingClientRect();
+  if (rect.width || rect.height || rect.top || rect.left) return rect;
+
+  const editorRect = editor.getBoundingClientRect();
+  return new DOMRect(editorRect.left, editorRect.top, 0, editorRect.height);
+}
+
+function createInputEvent(type: 'beforeinput' | 'input', suggestion: string): Event {
+  try {
+    return new InputEvent(type, {
+      bubbles: true,
+      cancelable: type === 'beforeinput',
+      inputType: 'insertText',
+      data: suggestion,
+    });
+  } catch {
+    return new Event(type, { bubbles: true, cancelable: type === 'beforeinput' });
+  }
+}
+
+function insertWithRange(editor: HTMLElement, suggestion: string): boolean {
+  const selection = window.getSelection();
+  if (!selectionBelongsToEditor(editor, selection)) return false;
+  if (!editor.dispatchEvent(createInputEvent('beforeinput', suggestion))) return false;
+
+  const range = selection.getRangeAt(0);
+  range.deleteContents();
+  const textNode = document.createTextNode(suggestion);
+  range.insertNode(textNode);
+  range.setStartAfter(textNode);
+  range.collapse(true);
+  selection.removeAllRanges();
+  selection.addRange(range);
+  editor.dispatchEvent(createInputEvent('input', suggestion));
+  return true;
+}
+
+function insertIntoContenteditable(editor: HTMLElement, suggestion: string): boolean {
+  if (!selectionBelongsToEditor(editor, window.getSelection())) return false;
+
+  let inputObserved = false;
+  const markInput = () => { inputObserved = true; };
+  editor.addEventListener('input', markInput, { once: true });
+
+  let inserted = false;
+  try {
+    inserted = typeof document.execCommand === 'function'
+      && document.execCommand('insertText', false, suggestion);
+  } catch {
+    inserted = false;
+  }
+  editor.removeEventListener('input', markInput);
+
+  if (!inserted) return insertWithRange(editor, suggestion);
+  if (!inputObserved) editor.dispatchEvent(createInputEvent('input', suggestion));
+  return true;
+}
+
+export function insertSuggestion(editor: AutosuggestEditor, suggestion: string): boolean {
+  if (!suggestion || !hasCollapsedCaret(editor)) return false;
+
+  if (isTextareaEditor(editor)) {
+    const start = editor.selectionStart;
+    const end = editor.selectionEnd;
+    editor.setRangeText(suggestion, start, end, 'end');
+    editor.dispatchEvent(createInputEvent('input', suggestion));
+    return true;
+  }
+
+  return insertIntoContenteditable(editor, suggestion);
+}

--- a/src/content/autosuggest/ghost-text.ts
+++ b/src/content/autosuggest/ghost-text.ts
@@ -1,82 +1,122 @@
-// src/content/autosuggest/ghost-text.js — Renders faded suggestion text after the cursor in a textarea
+// src/content/autosuggest/ghost-text.js — Renders faded suggestion text after the editor cursor
 import {
   autosuggestOverlayHost,
   setAutosuggestOverlayHost,
   setAutosuggestCurrentSuggestion,
 } from '../shared/state.js';
 import { getGhostTextStyles } from './styles.js';
+import {
+  getContenteditableCaretRect,
+  insertSuggestion,
+  isTextareaEditor,
+  type AutosuggestEditor,
+} from './editor.js';
 
-export function showGhostText(textarea: HTMLTextAreaElement, suggestion: string) {
-  setAutosuggestCurrentSuggestion(suggestion);
-
-  // Remove existing overlay if any
-  const existing = autosuggestOverlayHost;
-  if (existing) existing.remove();
-
-  // Create Shadow DOM host
+function createOverlayHost(): { host: HTMLDivElement; container: HTMLDivElement } {
   const host = document.createElement('div');
   host.setAttribute('data-dobby-autosuggest', '');
-
-  const computed = window.getComputedStyle(textarea);
-  const rect = textarea.getBoundingClientRect();
-
-  // Position overlay exactly over the textarea
   host.style.position = 'absolute';
-  host.style.top = `${rect.top + window.scrollY}px`;
-  host.style.left = `${rect.left + window.scrollX}px`;
-  host.style.width = `${rect.width}px`;
-  host.style.height = `${rect.height}px`;
   host.style.pointerEvents = 'none';
   host.style.zIndex = '2147483640';
-  host.style.overflow = 'hidden';
 
   const shadow = host.attachShadow({ mode: 'open' });
-
-  // Inject styles
   const style = document.createElement('style');
   style.textContent = getGhostTextStyles();
   shadow.appendChild(style);
 
-  // Create container that mirrors textarea's text metrics
   const container = document.createElement('div');
   container.className = 'ghost-container';
+  shadow.appendChild(container);
+  return { host, container };
+}
+
+function applyTextMetrics(container: HTMLDivElement, computed: CSSStyleDeclaration) {
   container.style.fontSize = computed.fontSize;
   container.style.fontFamily = computed.fontFamily;
+  container.style.fontWeight = computed.fontWeight;
+  container.style.fontStyle = computed.fontStyle;
   container.style.lineHeight = computed.lineHeight;
+  container.style.letterSpacing = computed.letterSpacing;
+  container.style.wordSpacing = computed.wordSpacing;
+}
+
+function positionTextareaOverlay(
+  host: HTMLDivElement,
+  container: HTMLDivElement,
+  textarea: HTMLTextAreaElement,
+  computed: CSSStyleDeclaration,
+) {
+  const rect = textarea.getBoundingClientRect();
+  host.style.top = `${rect.top + window.scrollY}px`;
+  host.style.left = `${rect.left + window.scrollX}px`;
+  host.style.width = `${rect.width}px`;
+  host.style.height = `${rect.height}px`;
+  host.style.overflow = 'hidden';
+
   container.style.paddingTop = computed.paddingTop;
   container.style.paddingLeft = computed.paddingLeft;
   container.style.paddingRight = computed.paddingRight;
   container.style.paddingBottom = computed.paddingBottom;
   container.style.borderTop = `${computed.borderTopWidth} solid transparent`;
   container.style.borderLeft = `${computed.borderLeftWidth} solid transparent`;
-  container.style.letterSpacing = computed.letterSpacing;
-  container.style.wordSpacing = computed.wordSpacing;
   container.style.width = '100%';
   container.style.boxSizing = 'border-box';
+  container.scrollTop = textarea.scrollTop;
 
-  // Mirror text before cursor (invisible) so ghost text is positioned correctly
-  const textBeforeCursor = textarea.value.substring(0, textarea.selectionStart);
   const mirror = document.createElement('span');
   mirror.className = 'ghost-mirror';
-  mirror.textContent = textBeforeCursor;
+  mirror.textContent = textarea.value.substring(0, textarea.selectionStart);
+  container.appendChild(mirror);
+}
 
-  // Ghost suggestion (visible, faded)
+function positionContenteditableOverlay(
+  host: HTMLDivElement,
+  container: HTMLDivElement,
+  editor: HTMLElement,
+  computed: CSSStyleDeclaration,
+): boolean {
+  const caretRect = getContenteditableCaretRect(editor);
+  if (!caretRect) return false;
+  const editorRect = editor.getBoundingClientRect();
+  const lineHeight = Number.parseFloat(computed.lineHeight) || Number.parseFloat(computed.fontSize) || 16;
+  const remainingWidth = editorRect.right - caretRect.right;
+  const wrapToNextLine = remainingWidth < 120;
+
+  host.style.top = `${(wrapToNextLine ? caretRect.bottom : caretRect.top) + window.scrollY}px`;
+  host.style.left = `${(wrapToNextLine ? editorRect.left : caretRect.right) + window.scrollX}px`;
+  host.style.maxWidth = `${wrapToNextLine ? editorRect.width : remainingWidth}px`;
+  host.style.minHeight = `${lineHeight}px`;
+  host.style.overflow = 'visible';
+  container.classList.add('contenteditable');
+  return true;
+}
+
+export function showGhostText(editor: AutosuggestEditor, suggestion: string) {
+  setAutosuggestCurrentSuggestion(suggestion);
+
+  const existing = autosuggestOverlayHost;
+  if (existing) existing.remove();
+
+  const { host, container } = createOverlayHost();
+  const computed = window.getComputedStyle(editor);
+  applyTextMetrics(container, computed);
+  if (isTextareaEditor(editor)) {
+    positionTextareaOverlay(host, container, editor, computed);
+  } else if (!positionContenteditableOverlay(host, container, editor, computed)) {
+    setAutosuggestCurrentSuggestion('');
+    return;
+  }
+
   const ghost = document.createElement('span');
   ghost.className = 'ghost-text';
   ghost.textContent = suggestion;
 
-  // Paw indicator
   const paw = document.createElement('span');
   paw.className = 'ghost-paw';
   paw.textContent = '🐾';
 
-  container.appendChild(mirror);
   container.appendChild(ghost);
   container.appendChild(paw);
-  shadow.appendChild(container);
-
-  // Match textarea scroll position
-  container.scrollTop = textarea.scrollTop;
 
   document.body.appendChild(host);
   setAutosuggestOverlayHost(host);
@@ -91,23 +131,14 @@ export function hideGhostText() {
   setAutosuggestCurrentSuggestion('');
 }
 
-export function acceptSuggestion(textarea: HTMLTextAreaElement) {
+export function acceptSuggestion(editor: AutosuggestEditor): boolean {
   const host = autosuggestOverlayHost;
-  if (!host) return;
+  if (!host) return false;
 
   const ghost = host.shadowRoot!.querySelector('.ghost-text');
-  if (!ghost) return;
+  if (!ghost) return false;
 
-  const suggestion = ghost.textContent!;
-  const pos = textarea.selectionStart;
-
-  // Insert suggestion at cursor position
-  textarea.value = textarea.value.substring(0, pos) + suggestion + textarea.value.substring(pos);
-  textarea.selectionStart = pos + suggestion.length;
-  textarea.selectionEnd = pos + suggestion.length;
-
-  // Dispatch input event so frameworks (React, Vue) pick up the change
-  textarea.dispatchEvent(new Event('input', { bubbles: true }));
-
-  hideGhostText();
+  const accepted = insertSuggestion(editor, ghost.textContent || '');
+  if (accepted) hideGhostText();
+  return accepted;
 }

--- a/src/content/autosuggest/index.ts
+++ b/src/content/autosuggest/index.ts
@@ -1,29 +1,41 @@
-// src/content/autosuggest/index.js — Main lifecycle: textarea detection, input -> debounce -> API -> ghost text
+// src/content/autosuggest/index.js — Main lifecycle: editor detection, input -> debounce -> API -> ghost text
 import {
   autosuggestEnabled,
-  autosuggestActiveTextarea,
+  autosuggestActiveEditor,
   autosuggestCurrentSuggestion,
-  setAutosuggestActiveTextarea,
+  setAutosuggestActiveEditor,
   setAutosuggestPendingRequest,
 } from '../shared/state.js';
 import { debouncedSuggest, cancelPending } from './debounce.js';
 import { buildCompletionMessages, gatherPageContext } from './context.js';
 import { showGhostText, hideGhostText, acceptSuggestion } from './ghost-text.js';
 import { requestAutosuggest } from '../api.js';
+import {
+  getEditableRoot,
+  getEditorText,
+  hasCollapsedCaret,
+  type AutosuggestEditor,
+} from './editor.js';
 
 let focusinHandler: ((event: FocusEvent) => void) | null = null;
 let focusoutHandler: ((event: FocusEvent) => void) | null = null;
+let isComposing = false;
+let requestGeneration = 0;
 
 export function initAutosuggest() {
   if (!autosuggestEnabled) return;
   if (focusinHandler || focusoutHandler) return;
 
   focusinHandler = (e: FocusEvent) => {
-    if ((e.target as HTMLElement).tagName === 'TEXTAREA') attachToTextarea(e.target as HTMLTextAreaElement);
+    const editor = getEditableRoot(e.target);
+    if (editor) attachToEditor(editor);
   };
 
   focusoutHandler = (e: FocusEvent) => {
-    if (e.target === autosuggestActiveTextarea) detachFromTextarea();
+    const activeEditor = autosuggestActiveEditor;
+    if (!activeEditor || !(e.target instanceof Node) || !activeEditor.contains(e.target)) return;
+    if (e.relatedTarget instanceof Node && activeEditor.contains(e.relatedTarget)) return;
+    detachFromEditor();
   };
 
   document.addEventListener('focusin', focusinHandler);
@@ -31,7 +43,7 @@ export function initAutosuggest() {
 }
 
 export function destroyAutosuggest() {
-  detachFromTextarea();
+  detachFromEditor();
   if (focusinHandler) {
     document.removeEventListener('focusin', focusinHandler);
     focusinHandler = null;
@@ -42,53 +54,101 @@ export function destroyAutosuggest() {
   }
 }
 
-function attachToTextarea(textarea: HTMLTextAreaElement) {
-  if (autosuggestActiveTextarea) detachFromTextarea();
-  setAutosuggestActiveTextarea(textarea);
-  textarea.addEventListener('input', handleInput);
-  textarea.addEventListener('keydown', handleKeydown);
+function attachToEditor(editor: AutosuggestEditor) {
+  if (autosuggestActiveEditor === editor) return;
+  if (autosuggestActiveEditor) detachFromEditor();
+  setAutosuggestActiveEditor(editor);
+  editor.addEventListener('input', handleInput);
+  editor.addEventListener('keydown', handleKeydown);
+  editor.addEventListener('compositionstart', handleCompositionStart);
+  editor.addEventListener('compositionend', handleCompositionEnd);
+  editor.addEventListener('click', handleCaretChange);
+  editor.addEventListener('scroll', handleCaretChange);
 }
 
-function detachFromTextarea() {
-  const ta = autosuggestActiveTextarea;
-  if (ta) {
-    ta.removeEventListener('input', handleInput);
-    ta.removeEventListener('keydown', handleKeydown);
+function detachFromEditor() {
+  const editor = autosuggestActiveEditor;
+  if (editor) {
+    editor.removeEventListener('input', handleInput);
+    editor.removeEventListener('keydown', handleKeydown);
+    editor.removeEventListener('compositionstart', handleCompositionStart);
+    editor.removeEventListener('compositionend', handleCompositionEnd);
+    editor.removeEventListener('click', handleCaretChange);
+    editor.removeEventListener('scroll', handleCaretChange);
   }
-  cancelPending();
-  hideGhostText();
-  setAutosuggestActiveTextarea(null);
+  isComposing = false;
+  invalidateSuggestion();
+  setAutosuggestActiveEditor(null);
 }
 
 function handleInput(e: Event) {
-  hideGhostText();
-  const text = (e.target as HTMLTextAreaElement).value;
-  debouncedSuggest(text, (t) => requestSuggestionFromAPI(t, e.target as HTMLTextAreaElement));
+  invalidateSuggestion();
+  const editor = autosuggestActiveEditor;
+  if (!editor || !editor.isConnected || isComposing || (e as InputEvent).isComposing || !hasCollapsedCaret(editor)) {
+    return;
+  }
+  const text = getEditorText(editor);
+  debouncedSuggest(text, (t) => requestSuggestionFromAPI(t, editor));
 }
 
-function handleKeydown(e: KeyboardEvent) {
-  if (e.key === 'Tab' && autosuggestCurrentSuggestion) {
-    e.preventDefault();
-    acceptSuggestion(autosuggestActiveTextarea!);
+function handleKeydown(event: Event) {
+  const e = event as KeyboardEvent;
+  const editor = autosuggestActiveEditor;
+  if (e.key === 'Tab' && autosuggestCurrentSuggestion && editor) {
+    if (acceptSuggestion(editor)) e.preventDefault();
   } else if (e.key === 'Escape' && autosuggestCurrentSuggestion) {
-    hideGhostText();
+    invalidateSuggestion();
+  } else if (['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End'].includes(e.key)) {
+    handleCaretChange();
   }
 }
 
-function requestSuggestionFromAPI(text: string, textarea: HTMLTextAreaElement) {
-  const messages = buildCompletionMessages(text, gatherPageContext(textarea));
+function handleCompositionStart() {
+  isComposing = true;
+  invalidateSuggestion();
+}
+
+function handleCompositionEnd() {
+  isComposing = false;
+}
+
+function handleCaretChange() {
+  invalidateSuggestion();
+}
+
+function invalidateSuggestion() {
+  requestGeneration += 1;
+  cancelPending();
+  hideGhostText();
+}
+
+function requestSuggestionFromAPI(text: string, editor: AutosuggestEditor) {
+  const messages = buildCompletionMessages(text, gatherPageContext(editor));
+  const requestId = ++requestGeneration;
 
   let accumulated = '';
   const handle = requestAutosuggest(
     messages,
     (token) => {
+      if (requestGeneration !== requestId) return;
+      if (
+        autosuggestActiveEditor !== editor
+        || !editor.isConnected
+        || getEditorText(editor) !== text
+        || !hasCollapsedCaret(editor)
+      ) {
+        invalidateSuggestion();
+        return;
+      }
       accumulated += token;
-      showGhostText(textarea, accumulated);
+      showGhostText(editor, accumulated);
     },
     () => {
-      // Done — suggestion is now in state via showGhostText
+      if (requestGeneration === requestId) setAutosuggestPendingRequest(null);
     },
     (code, message) => {
+      if (requestGeneration !== requestId) return;
+      setAutosuggestPendingRequest(null);
       console.error('[Dobby Autosuggest] API error:', code, message);
       hideGhostText();
     }

--- a/src/content/autosuggest/styles.ts
+++ b/src/content/autosuggest/styles.ts
@@ -16,6 +16,10 @@ export function getGhostTextStyles() {
       white-space: pre-wrap;
       word-wrap: break-word;
     }
+    .ghost-container.contenteditable {
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+    }
     .ghost-mirror {
       visibility: hidden;
     }

--- a/src/content/shared/state.ts
+++ b/src/content/shared/state.ts
@@ -81,14 +81,14 @@ export function setScrollTimer(v: ReturnType<typeof setTimeout> | null) { scroll
 
 // Autosuggest state
 export let autosuggestEnabled = false;
-export let autosuggestActiveTextarea: HTMLTextAreaElement | null = null;
+export let autosuggestActiveEditor: HTMLElement | null = null;
 export let autosuggestCurrentSuggestion = '';
 export let autosuggestOverlayHost: HTMLDivElement | null = null;
 export let autosuggestPendingRequest: StreamRequestHandle | null = null;
 export let autosuggestDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
 export function setAutosuggestEnabled(v: boolean) { autosuggestEnabled = v; }
-export function setAutosuggestActiveTextarea(v: HTMLTextAreaElement | null) { autosuggestActiveTextarea = v; }
+export function setAutosuggestActiveEditor(v: HTMLElement | null) { autosuggestActiveEditor = v; }
 export function setAutosuggestCurrentSuggestion(v: string) { autosuggestCurrentSuggestion = v; }
 export function setAutosuggestOverlayHost(v: HTMLDivElement | null) { autosuggestOverlayHost = v; }
 export function setAutosuggestPendingRequest(v: StreamRequestHandle | null) { autosuggestPendingRequest = v; }
@@ -96,7 +96,7 @@ export function setAutosuggestDebounceTimer(v: ReturnType<typeof setTimeout> | n
 
 export function resetAutosuggestState() {
   autosuggestEnabled = false;
-  autosuggestActiveTextarea = null;
+  autosuggestActiveEditor = null;
   autosuggestCurrentSuggestion = '';
   autosuggestOverlayHost = null;
   autosuggestPendingRequest = null;

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -246,7 +246,7 @@ function PopupApp() {
       <SwitchRow
         id="autosuggest-enabled"
         label="Text auto-suggest"
-        title="Works in standard text fields (textarea). Gmail, Docs, and Notion support coming soon."
+        title="Works in standard textareas and rich-text editors such as LinkedIn chat, Gmail, and Notion."
         enabled={state.autosuggestEnabled}
         ariaLabel="Enable or disable auto-suggest"
         onChange={(enabled) => updateToggle('autosuggestEnabled', 'AUTOSUGGEST_TOGGLE', enabled)}

--- a/tests/autosuggest-context.test.js
+++ b/tests/autosuggest-context.test.js
@@ -82,6 +82,18 @@ describe('autosuggest context', () => {
     expect(ctx.fieldLabel).toBe('Description');
   });
 
+  it('gatherPageContext picks up contenteditable hints and labels', () => {
+    const editor = document.createElement('div');
+    editor.setAttribute('contenteditable', 'true');
+    editor.setAttribute('aria-label', 'Message');
+    editor.setAttribute('data-placeholder', 'Write a reply...');
+    document.body.appendChild(editor);
+
+    const ctx = gatherPageContext(editor);
+    expect(ctx.fieldLabel).toBe('Message');
+    expect(ctx.fieldHint).toBe('Write a reply...');
+  });
+
   it('gatherPageContext picks up sibling form fields', () => {
     const form = document.createElement('form');
     const input = document.createElement('input');

--- a/tests/autosuggest-editor.test.js
+++ b/tests/autosuggest-editor.test.js
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  getEditableRoot,
+  getEditorText,
+  hasCollapsedCaret,
+  insertSuggestion,
+} from '../src/content/autosuggest/editor.js';
+
+function placeCaret(editor, node = editor.firstChild, offset = node?.textContent?.length || 0) {
+  const range = document.createRange();
+  range.setStart(node || editor, offset);
+  range.collapse(true);
+  const selection = window.getSelection();
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  window.getSelection()?.removeAllRanges();
+  vi.restoreAllMocks();
+});
+
+describe('autosuggest editor adapter', () => {
+  it('detects textareas and the nearest inherited contenteditable root', () => {
+    const textarea = document.createElement('textarea');
+    const editor = document.createElement('div');
+    editor.setAttribute('contenteditable', 'true');
+    const child = document.createElement('span');
+    editor.appendChild(child);
+    document.body.append(textarea, editor);
+
+    expect(getEditableRoot(textarea)).toBe(textarea);
+    expect(getEditableRoot(child)).toBe(editor);
+  });
+
+  it('does not cross a contenteditable=false boundary', () => {
+    const editor = document.createElement('div');
+    editor.setAttribute('contenteditable', 'true');
+    const disabled = document.createElement('span');
+    disabled.setAttribute('contenteditable', 'false');
+    editor.appendChild(disabled);
+    document.body.appendChild(editor);
+
+    expect(getEditableRoot(disabled)).toBeNull();
+  });
+
+  it('reads textarea and contenteditable text', () => {
+    const textarea = document.createElement('textarea');
+    textarea.value = 'Textarea value';
+    const editor = document.createElement('div');
+    editor.setAttribute('contenteditable', 'true');
+    editor.textContent = 'Rich editor value';
+
+    expect(getEditorText(textarea)).toBe('Textarea value');
+    expect(getEditorText(editor)).toBe('Rich editor value');
+  });
+
+  it('requires a collapsed caret inside the editor', () => {
+    const editor = document.createElement('div');
+    editor.setAttribute('contenteditable', 'true');
+    editor.textContent = 'Hello';
+    document.body.appendChild(editor);
+    placeCaret(editor);
+
+    expect(hasCollapsedCaret(editor)).toBe(true);
+
+    const range = document.createRange();
+    range.selectNodeContents(editor);
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+    expect(hasCollapsedCaret(editor)).toBe(false);
+  });
+
+  it('inserts into a textarea and dispatches input', () => {
+    const textarea = document.createElement('textarea');
+    textarea.value = 'Hello ';
+    textarea.selectionStart = 6;
+    textarea.selectionEnd = 6;
+    const inputSpy = vi.fn();
+    textarea.addEventListener('input', inputSpy);
+
+    expect(insertSuggestion(textarea, 'world')).toBe(true);
+    expect(textarea.value).toBe('Hello world');
+    expect(textarea.selectionStart).toBe(11);
+    expect(inputSpy).toHaveBeenCalledOnce();
+  });
+
+  it('falls back to Range insertion for contenteditable editors', () => {
+    const editor = document.createElement('div');
+    editor.setAttribute('contenteditable', 'true');
+    editor.textContent = 'Hello ';
+    document.body.appendChild(editor);
+    placeCaret(editor);
+    document.execCommand = vi.fn(() => false);
+    const inputSpy = vi.fn();
+    editor.addEventListener('input', inputSpy);
+
+    expect(insertSuggestion(editor, 'world')).toBe(true);
+    expect(editor.textContent).toBe('Hello world');
+    expect(inputSpy).toHaveBeenCalledOnce();
+    expect(document.execCommand).toHaveBeenCalledWith('insertText', false, 'world');
+  });
+});

--- a/tests/autosuggest-ghost-text.test.js
+++ b/tests/autosuggest-ghost-text.test.js
@@ -24,6 +24,8 @@ describe('ghost text overlay', () => {
     window.getComputedStyle = vi.fn(() => ({
       fontSize: '16px',
       fontFamily: 'monospace',
+      fontWeight: '400',
+      fontStyle: 'normal',
       lineHeight: '20px',
       paddingTop: '8px',
       paddingLeft: '8px',
@@ -96,5 +98,58 @@ describe('ghost text overlay', () => {
     textarea.addEventListener('input', inputSpy);
     acceptSuggestion(textarea);
     expect(inputSpy).toHaveBeenCalled();
+  });
+
+  it('positions contenteditable ghost text at the caret', () => {
+    const editor = document.createElement('div');
+    editor.setAttribute('contenteditable', 'true');
+    editor.textContent = 'Hello ';
+    document.body.appendChild(editor);
+    editor.getBoundingClientRect = vi.fn(() => ({
+      top: 100, left: 50, width: 400, height: 40, bottom: 140, right: 450,
+    }));
+    const range = document.createRange();
+    range.selectNodeContents(editor);
+    range.collapse(false);
+    range.getBoundingClientRect = vi.fn(() => ({
+      top: 110, left: 120, width: 0, height: 20, bottom: 130, right: 120,
+    }));
+    range.cloneRange = vi.fn(() => range);
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    showGhostText(editor, 'world');
+
+    const host = document.querySelector('[data-dobby-autosuggest]');
+    expect(host.style.left).toBe('120px');
+    expect(host.shadowRoot.querySelector('.ghost-container').classList.contains('contenteditable')).toBe(true);
+  });
+
+  it('wraps contenteditable ghost text inside the editor near the right edge', () => {
+    const editor = document.createElement('div');
+    editor.setAttribute('contenteditable', 'true');
+    editor.textContent = 'Hello ';
+    document.body.appendChild(editor);
+    editor.getBoundingClientRect = vi.fn(() => ({
+      top: 100, left: 50, width: 400, height: 80, bottom: 180, right: 450,
+    }));
+    const range = document.createRange();
+    range.selectNodeContents(editor);
+    range.collapse(false);
+    range.getBoundingClientRect = vi.fn(() => ({
+      top: 110, left: 430, width: 0, height: 20, bottom: 130, right: 430,
+    }));
+    range.cloneRange = vi.fn(() => range);
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    showGhostText(editor, 'world');
+
+    const host = document.querySelector('[data-dobby-autosuggest]');
+    expect(host.style.top).toBe('130px');
+    expect(host.style.left).toBe('50px');
+    expect(host.style.maxWidth).toBe('400px');
   });
 });

--- a/tests/autosuggest-index.test.js
+++ b/tests/autosuggest-index.test.js
@@ -8,6 +8,7 @@ import {
   setAutosuggestCurrentSuggestion,
 } from '../src/content/shared/state.js';
 import { showGhostText } from '../src/content/autosuggest/ghost-text.js';
+import { requestAutosuggest } from '../src/content/api.js';
 
 // Mock the API module
 vi.mock('../src/content/api.js', () => ({
@@ -22,15 +23,21 @@ vi.mock('../src/content/api.js', () => ({
 describe('autosuggest lifecycle', () => {
   let initAutosuggest, destroyAutosuggest;
   let textarea;
+  let editor;
 
   beforeEach(async () => {
     vi.useFakeTimers();
     resetAutosuggestState();
     setAutosuggestEnabled(true);
+    vi.clearAllMocks();
 
     textarea = document.createElement('textarea');
     textarea.style.cssText = 'font-size:16px;font-family:monospace;padding:8px;line-height:20px;';
     document.body.appendChild(textarea);
+    editor = document.createElement('div');
+    editor.setAttribute('contenteditable', 'true');
+    editor.textContent = 'Hello rich editor';
+    document.body.appendChild(editor);
 
     textarea.getBoundingClientRect = vi.fn(() => ({
       top: 100, left: 50, width: 400, height: 200, bottom: 300, right: 450,
@@ -88,12 +95,61 @@ describe('autosuggest lifecycle', () => {
     expect(removeSpy.mock.calls.filter((c) => c[0] === 'keydown')).toHaveLength(0);
   });
 
+  it('monitors a nested target through its contenteditable root', () => {
+    const child = document.createElement('span');
+    editor.appendChild(child);
+    const addSpy = vi.spyOn(editor, 'addEventListener');
+
+    initAutosuggest();
+    child.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+
+    expect(addSpy.mock.calls.filter((c) => c[0] === 'input')).toHaveLength(1);
+    expect(addSpy.mock.calls.filter((c) => c[0] === 'keydown')).toHaveLength(1);
+  });
+
   it('starts monitoring textarea on focus', () => {
     initAutosuggest();
     textarea.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
     textarea.value = 'Hello world this is a test';
     textarea.selectionStart = textarea.value.length;
     textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(document.querySelector('[data-dobby-autosuggest]')).toBeNull();
+  });
+
+  it('does not request suggestions while an IME composition is active', () => {
+    initAutosuggest();
+    textarea.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+    textarea.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+    textarea.value = 'Hello world this is composing';
+    textarea.selectionStart = textarea.value.length;
+    textarea.selectionEnd = textarea.value.length;
+    textarea.dispatchEvent(new InputEvent('input', { bubbles: true, isComposing: true }));
+    vi.advanceTimersByTime(1000);
+
+    expect(requestAutosuggest).not.toHaveBeenCalled();
+  });
+
+  it('ignores late tokens from a superseded request', () => {
+    let lateToken;
+    requestAutosuggest.mockImplementationOnce((messages, onToken) => {
+      lateToken = onToken;
+      return { cancel: vi.fn() };
+    });
+
+    initAutosuggest();
+    textarea.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+    textarea.value = 'First request text';
+    textarea.selectionStart = textarea.value.length;
+    textarea.selectionEnd = textarea.value.length;
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    vi.advanceTimersByTime(500);
+
+    textarea.value = 'Newer request text';
+    textarea.selectionStart = textarea.value.length;
+    textarea.selectionEnd = textarea.value.length;
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    lateToken('stale suggestion');
+
     expect(document.querySelector('[data-dobby-autosuggest]')).toBeNull();
   });
 
@@ -122,6 +178,18 @@ describe('autosuggest lifecycle', () => {
     showGhostText(textarea, 'world');
 
     textarea.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(document.querySelector('[data-dobby-autosuggest]')).toBeNull();
+  });
+
+  it('scrolling the active editor dismisses the suggestion', () => {
+    initAutosuggest();
+    textarea.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+    textarea.value = 'Hello ';
+    textarea.selectionStart = 6;
+    showGhostText(textarea, 'world');
+
+    textarea.dispatchEvent(new Event('scroll'));
+
     expect(document.querySelector('[data-dobby-autosuggest]')).toBeNull();
   });
 

--- a/tests/autosuggest-state.test.js
+++ b/tests/autosuggest-state.test.js
@@ -17,7 +17,7 @@ describe('autosuggest state', () => {
   it('exports autosuggest state variables with correct defaults', async () => {
     const state = await import('../src/content/shared/state.js');
     expect(state.autosuggestEnabled).toBe(false);
-    expect(state.autosuggestActiveTextarea).toBeNull();
+    expect(state.autosuggestActiveEditor).toBeNull();
     expect(state.autosuggestCurrentSuggestion).toBe('');
     expect(state.autosuggestOverlayHost).toBeNull();
     expect(state.autosuggestPendingRequest).toBeNull();
@@ -41,7 +41,7 @@ describe('autosuggest state', () => {
     state.setAutosuggestCurrentSuggestion('test');
     state.resetAutosuggestState();
     expect(state.autosuggestEnabled).toBe(false);
-    expect(state.autosuggestActiveTextarea).toBeNull();
+    expect(state.autosuggestActiveEditor).toBeNull();
     expect(state.autosuggestCurrentSuggestion).toBe('');
     expect(state.autosuggestOverlayHost).toBeNull();
     expect(state.autosuggestPendingRequest).toBeNull();


### PR DESCRIPTION
## Summary
- support autosuggest in contenteditable rich-text editors such as LinkedIn messaging
- prevent stale suggestions during composition, caret movement, scrolling, and superseded requests
- add deterministic contenteditable E2E coverage and an authenticated popular-sites smoke-test harness
- bump extension version to `1.3.1`

## Validation
- `npm run typecheck`
- `npm test` (648 passed)
- `npm run test:e2e` (26 passed)
- `npm run test:popular-sites:linkedin` (authenticated LinkedIn messaging passed)
- `git diff --check`
