### PR TITLE
[codex] Harden free proxy access

### DIFF
--- a/e2e/autosuggest.spec.js
+++ b/e2e/autosuggest.spec.js
@@ -13,6 +13,12 @@ test.beforeAll(async () => {
     const originalFetch = globalThis.fetch.bind(globalThis);
     globalThis.fetch = async (input, init) => {
       const url = typeof input === 'string' ? input : input.url;
+      if (url.includes('dobby-ai-proxy') && url.includes('/access-token')) {
+        return new Response(
+          JSON.stringify({ token: 'e2e-proxy-access-token', expiresAt: '2026-06-28T00:00:00.000Z' }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
       if (url.includes('dobby-ai-proxy') || url.includes('api.openai.com')) {
         return new Response(
           'data: {"choices":[{"delta":{"content":" from Dobby"}}]}\n\ndata: [DONE]\n\n',

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dobby AI",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Select text and get instant AI explanations inline on any page",
   "permissions": [
     "contextMenus",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dobby-ai",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dobby-ai",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "react": "^19.2.7",
         "react-dom": "^19.2.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dobby-ai",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "description": "Select text or screenshot any region on the web — get instant AI answers right where you are",
   "scripts": {

--- a/proxy/src/access-token.ts
+++ b/proxy/src/access-token.ts
@@ -1,0 +1,110 @@
+// proxy/src/access-token.ts - Server-issued access tokens for free proxy calls
+import type { KVNamespaceLike } from './types';
+
+export const ACCESS_TOKEN_HEADER = 'X-Dobby-Access-Token';
+
+const ACCESS_TOKEN_TTL_SECONDS = 7 * 24 * 60 * 60;
+const TOKEN_BYTES = 32;
+const ISSUE_LIMIT_PER_DAY = 10;
+
+type StoredAccessToken = {
+  ip: string;
+  createdAt: number;
+  expiresAt: number;
+};
+
+type IssuedAccessToken = {
+  token: string;
+  expiresAt: string;
+};
+
+type AccessTokenIssueLimit = {
+  error: string;
+  retryAfter: number;
+};
+
+type AccessTokenValidation =
+  | { valid: true; tokenHash: string }
+  | { valid: false; reason: string };
+
+function dayBucket(): string {
+  return new Date().toISOString().split('T')[0]!;
+}
+
+function base64Url(bytes: Uint8Array): string {
+  let binary = '';
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return btoa(binary)
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replaceAll('=', '');
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  const encoded = new TextEncoder().encode(value);
+  const digest = await crypto.subtle.digest('SHA-256', encoded);
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export async function issueAccessToken(
+  ip: string,
+  kv: KVNamespaceLike,
+): Promise<IssuedAccessToken | AccessTokenIssueLimit> {
+  const issueKey = `access:issue:${ip}:${dayBucket()}`;
+  const issueCount = await kv.get(issueKey).then((value) => parseInt(value!) || 0);
+  if (issueCount >= ISSUE_LIMIT_PER_DAY) {
+    return { error: 'Access token issuance limit reached', retryAfter: 3600 };
+  }
+
+  const bytes = new Uint8Array(TOKEN_BYTES);
+  crypto.getRandomValues(bytes);
+  const token = base64Url(bytes);
+  const tokenHash = await sha256Hex(token);
+  const now = Date.now();
+  const expiresAt = now + ACCESS_TOKEN_TTL_SECONDS * 1000;
+  const record: StoredAccessToken = { ip, createdAt: now, expiresAt };
+
+  await Promise.all([
+    kv.put(issueKey, String(issueCount + 1), { expirationTtl: 86400 }),
+    kv.put(`access:${tokenHash}`, JSON.stringify(record), { expirationTtl: ACCESS_TOKEN_TTL_SECONDS }),
+  ]);
+
+  return { token, expiresAt: new Date(expiresAt).toISOString() };
+}
+
+export async function verifyAccessToken(
+  token: string | null,
+  ip: string,
+  kv: KVNamespaceLike,
+): Promise<AccessTokenValidation> {
+  if (!token) {
+    return { valid: false, reason: 'missing proxy access token' };
+  }
+
+  const tokenHash = await sha256Hex(token);
+  const raw = await kv.get(`access:${tokenHash}`);
+  if (!raw) {
+    return { valid: false, reason: 'invalid proxy access token' };
+  }
+
+  let record: StoredAccessToken;
+  try {
+    record = JSON.parse(raw) as StoredAccessToken;
+  } catch {
+    return { valid: false, reason: 'invalid proxy access token' };
+  }
+
+  if (record.expiresAt <= Date.now()) {
+    return { valid: false, reason: 'expired proxy access token' };
+  }
+
+  if (record.ip !== ip) {
+    return { valid: false, reason: 'proxy access token IP mismatch' };
+  }
+
+  return { valid: true, tokenHash };
+}

--- a/proxy/src/index.ts
+++ b/proxy/src/index.ts
@@ -2,6 +2,7 @@
 import { validatePayload, verifyHmac } from './validate.js';
 import { checkRateLimit, incrementCounters } from './rate-limit.js';
 import { createChatStream } from './openai.js';
+import { ACCESS_TOKEN_HEADER, issueAccessToken, verifyAccessToken } from './access-token.js';
 import { AUTOSUGGEST_MAX_SUGGESTION_TOKENS } from '../../src/shared/autosuggest-limits.js';
 import type { ProxyPurpose } from '../../src/shared/types';
 import type { ProxyEnv, ValidProxyPayload } from './types';
@@ -15,7 +16,7 @@ function getCorsHeaders(request: Request, env: ProxyEnv): Record<string, string>
   return {
     'Access-Control-Allow-Origin': allowOrigin,
     'Access-Control-Allow-Methods': 'POST, OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type, X-Dev-Token',
+    'Access-Control-Allow-Headers': 'Content-Type, X-Dev-Token, X-Dobby-Access-Token',
     'Access-Control-Max-Age': '86400',
   };
 }
@@ -46,7 +47,7 @@ export default {
 
     const url = new URL(request.url);
 
-    if (url.pathname !== '/chat') {
+    if (url.pathname !== '/chat' && url.pathname !== '/access-token') {
       return jsonResponse({ error: 'Not found' }, 404, corsHeaders);
     }
 
@@ -56,6 +57,21 @@ export default {
 
     if (env.ENABLED === 'false') {
       return jsonResponse({ error: 'Service temporarily disabled' }, 503, corsHeaders);
+    }
+
+    const ip = request.headers.get('CF-Connecting-IP') || 'unknown';
+
+    if (url.pathname === '/access-token') {
+      const tokenResult = await issueAccessToken(ip, env.RATE_LIMIT_KV);
+      if ('error' in tokenResult) {
+        return jsonResponse(
+          { error: tokenResult.error },
+          429,
+          corsHeaders,
+          { 'Retry-After': String(tokenResult.retryAfter) }
+        );
+      }
+      return jsonResponse(tokenResult, 200, corsHeaders);
     }
 
     // Read body as text and check size (Content-Length header is optional and can be omitted)
@@ -88,12 +104,18 @@ export default {
     }
 
     const purpose: ProxyPurpose = (body as ValidProxyPayload).purpose || 'chat';
-    const ip = request.headers.get('CF-Connecting-IP') || 'unknown';
     const devBypass = env.DEV_BYPASS_TOKEN
       && request.headers.get('X-Dev-Token') === env.DEV_BYPASS_TOKEN;
+    const tokenResult = devBypass
+      ? { valid: true as const, tokenHash: 'dev-bypass' }
+      : await verifyAccessToken(request.headers.get(ACCESS_TOKEN_HEADER), ip, env.RATE_LIMIT_KV);
+    if (!tokenResult.valid) {
+      return jsonResponse({ error: tokenResult.reason }, 401, corsHeaders);
+    }
+
     const rateResult = devBypass
       ? { allowed: true, remaining: null }
-      : await checkRateLimit(ip, env.RATE_LIMIT_KV, purpose);
+      : await checkRateLimit(ip, env.RATE_LIMIT_KV, purpose, tokenResult.tokenHash);
     if (!rateResult.allowed) {
       return jsonResponse(
         { error: rateResult.reason, remaining: rateResult.remaining ?? 0 },
@@ -103,7 +125,7 @@ export default {
       );
     }
 
-    if (!devBypass) await incrementCounters(ip, env.RATE_LIMIT_KV, purpose);
+    if (!devBypass) await incrementCounters(ip, env.RATE_LIMIT_KV, purpose, tokenResult.tokenHash);
 
     const maxTokens = purpose === 'autosuggest' ? AUTOSUGGEST_MAX_SUGGESTION_TOKENS : undefined;
     const openaiResponse = await createChatStream((body as ValidProxyPayload).messages, env.OPENAI_API_KEY, undefined, maxTokens);

--- a/proxy/src/rate-limit.ts
+++ b/proxy/src/rate-limit.ts
@@ -33,6 +33,7 @@ export async function checkRateLimit(
   ip: string,
   kv: KVNamespaceLike,
   purpose: ProxyPurpose = 'chat',
+  tokenHash?: string,
 ): Promise<RateLimitResult> {
   // Check block list first (shared across both purposes)
   const blocked = await kv.get(`blocked:${ip}`);
@@ -42,22 +43,27 @@ export async function checkRateLimit(
 
   const prefix = keyPrefix(purpose);
   const limits = purpose === 'autosuggest' ? AUTOSUGGEST_LIMITS : LIMITS;
+  const subject = tokenHash ? `${ip}:${tokenHash}` : ip;
 
-  const minKey = `${prefix}:min:${ip}:${minuteBucket()}`;
-  const dayKey = `${prefix}:day:${ip}:${dayBucket()}`;
+  const minKey = `${prefix}:min:${subject}:${minuteBucket()}`;
+  const dayKey = `${prefix}:day:${subject}:${dayBucket()}`;
+  const ipMinKey = `${prefix}:ipmin:${ip}:${minuteBucket()}`;
+  const ipDayKey = `${prefix}:ipday:${ip}:${dayBucket()}`;
   const globalKey = `rl:global:${dayBucket()}`;
 
-  const [minCount, dayCount, globalCount] = await Promise.all([
+  const [minCount, dayCount, ipMinCount, ipDayCount, globalCount] = await Promise.all([
     kv.get(minKey).then((v) => parseInt(v!) || 0),
     kv.get(dayKey).then((v) => parseInt(v!) || 0),
+    tokenHash ? kv.get(ipMinKey).then((v) => parseInt(v!) || 0) : Promise.resolve(0),
+    tokenHash ? kv.get(ipDayKey).then((v) => parseInt(v!) || 0) : Promise.resolve(0),
     kv.get(globalKey).then((v) => parseInt(v!) || 0),
   ]);
 
-  if (minCount >= limits.perMinute) {
+  if (minCount >= limits.perMinute || ipMinCount >= limits.perMinute) {
     return { allowed: false, reason: 'Rate limit: per-minute limit reached', retryAfter: 60 };
   }
 
-  if (dayCount >= limits.perDay) {
+  if (dayCount >= limits.perDay || ipDayCount >= limits.perDay) {
     return { allowed: false, reason: 'Daily limit reached', remaining: 0 };
   }
 
@@ -65,24 +71,32 @@ export async function checkRateLimit(
     return { allowed: false, reason: 'Service busy, try later', retryAfter: 3600 };
   }
 
-  return { allowed: true, remaining: limits.perDay - dayCount - 1 };
+  const tokenRemaining = limits.perDay - dayCount - 1;
+  const ipRemaining = tokenHash ? limits.perDay - ipDayCount - 1 : tokenRemaining;
+  return { allowed: true, remaining: Math.min(tokenRemaining, ipRemaining) };
 }
 
 export async function incrementCounters(
   ip: string,
   kv: KVNamespaceLike,
   purpose: ProxyPurpose = 'chat',
+  tokenHash?: string,
 ): Promise<void> {
   const prefix = keyPrefix(purpose);
+  const subject = tokenHash ? `${ip}:${tokenHash}` : ip;
 
-  const minKey = `${prefix}:min:${ip}:${minuteBucket()}`;
-  const dayKey = `${prefix}:day:${ip}:${dayBucket()}`;
+  const minKey = `${prefix}:min:${subject}:${minuteBucket()}`;
+  const dayKey = `${prefix}:day:${subject}:${dayBucket()}`;
+  const ipMinKey = `${prefix}:ipmin:${ip}:${minuteBucket()}`;
+  const ipDayKey = `${prefix}:ipday:${ip}:${dayBucket()}`;
   const globalKey = `rl:global:${dayBucket()}`;
   const burstKey = `rl:10s:${ip}:${tenSecBucket()}`;
 
-  const [minCount, dayCount, globalCount, burstCount] = await Promise.all([
+  const [minCount, dayCount, ipMinCount, ipDayCount, globalCount, burstCount] = await Promise.all([
     kv.get(minKey).then((v) => parseInt(v!) || 0),
     kv.get(dayKey).then((v) => parseInt(v!) || 0),
+    tokenHash ? kv.get(ipMinKey).then((v) => parseInt(v!) || 0) : Promise.resolve(0),
+    tokenHash ? kv.get(ipDayKey).then((v) => parseInt(v!) || 0) : Promise.resolve(0),
     kv.get(globalKey).then((v) => parseInt(v!) || 0),
     kv.get(burstKey).then((v) => parseInt(v!) || 0),
   ]);
@@ -94,6 +108,12 @@ export async function incrementCounters(
     kv.put(globalKey, String(globalCount + 1), { expirationTtl: 86400 }),
     kv.put(burstKey, String(burstCount + 1), { expirationTtl: 60 }),
   ];
+  if (tokenHash) {
+    puts.push(
+      kv.put(ipMinKey, String(ipMinCount + 1), { expirationTtl: 120 }),
+      kv.put(ipDayKey, String(ipDayCount + 1), { expirationTtl: 86400 }),
+    );
+  }
 
   // Abuse detection: 10+ requests in 10 seconds → 1-hour block
   if (burstCount + 1 >= 10) {

--- a/proxy/tests/access-token.test.js
+++ b/proxy/tests/access-token.test.js
@@ -1,0 +1,61 @@
+// proxy/tests/access-token.test.js
+import { describe, it, expect, vi } from 'vitest';
+import { issueAccessToken, verifyAccessToken } from '../src/access-token.js';
+
+function createMockKV(data = {}) {
+  const store = { ...data };
+  return {
+    get: vi.fn((key) => Promise.resolve(store[key] || null)),
+    put: vi.fn((key, value, opts) => {
+      store[key] = String(value);
+      return Promise.resolve();
+    }),
+    _store: store,
+  };
+}
+
+describe('proxy access tokens', () => {
+  it('issues and verifies an IP-bound access token', async () => {
+    const kv = createMockKV();
+
+    const issued = await issueAccessToken('1.2.3.4', kv);
+
+    expect(issued).toEqual(expect.objectContaining({
+      token: expect.any(String),
+      expiresAt: expect.any(String),
+    }));
+    const verified = await verifyAccessToken(issued.token, '1.2.3.4', kv);
+    expect(verified).toEqual(expect.objectContaining({ valid: true, tokenHash: expect.any(String) }));
+  });
+
+  it('rejects missing, unknown, and IP-mismatched tokens', async () => {
+    const kv = createMockKV();
+    const issued = await issueAccessToken('1.2.3.4', kv);
+
+    await expect(verifyAccessToken(null, '1.2.3.4', kv)).resolves.toEqual({
+      valid: false,
+      reason: 'missing proxy access token',
+    });
+    await expect(verifyAccessToken('unknown-token', '1.2.3.4', kv)).resolves.toEqual({
+      valid: false,
+      reason: 'invalid proxy access token',
+    });
+    await expect(verifyAccessToken(issued.token, '5.6.7.8', kv)).resolves.toEqual({
+      valid: false,
+      reason: 'proxy access token IP mismatch',
+    });
+  });
+
+  it('rate-limits token issuance per IP per day', async () => {
+    const kv = createMockKV();
+    kv.get.mockImplementation((key) => {
+      if (key.startsWith('access:issue:')) return Promise.resolve('10');
+      return Promise.resolve(null);
+    });
+
+    await expect(issueAccessToken('1.2.3.4', kv)).resolves.toEqual({
+      error: 'Access token issuance limit reached',
+      retryAfter: 3600,
+    });
+  });
+});

--- a/proxy/tests/index.test.js
+++ b/proxy/tests/index.test.js
@@ -23,10 +23,23 @@ vi.mock('../src/openai.js', () => ({
   ),
 }));
 
+vi.mock('../src/access-token.js', () => ({
+  ACCESS_TOKEN_HEADER: 'X-Dobby-Access-Token',
+  issueAccessToken: vi.fn(() => Promise.resolve({
+    token: 'proxy-access-token',
+    expiresAt: '2026-06-28T00:00:00.000Z',
+  })),
+  verifyAccessToken: vi.fn(() => Promise.resolve({
+    valid: true,
+    tokenHash: 'token-hash',
+  })),
+}));
+
 import handler from '../src/index.js';
 import { validatePayload, verifyHmac } from '../src/validate.js';
 import { checkRateLimit, incrementCounters } from '../src/rate-limit.js';
 import { createChatStream } from '../src/openai.js';
+import { issueAccessToken, verifyAccessToken } from '../src/access-token.js';
 
 function makeRequest(path, options = {}) {
   const url = `https://proxy.workers.dev${path}`;
@@ -54,6 +67,7 @@ describe('CORS preflight', () => {
     const res = await handler.fetch(req, makeEnv());
     expect(res.status).toBe(204);
     expect(res.headers.get('Access-Control-Allow-Methods')).toContain('POST');
+    expect(res.headers.get('Access-Control-Allow-Headers')).toContain('X-Dobby-Access-Token');
   });
 
   it('returns CORS headers matching request origin', async () => {
@@ -100,11 +114,51 @@ describe('routing', () => {
   });
 });
 
+describe('POST /access-token', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    issueAccessToken.mockResolvedValue({
+      token: 'proxy-access-token',
+      expiresAt: '2026-06-28T00:00:00.000Z',
+    });
+  });
+
+  it('issues a server-side proxy access token for the caller IP', async () => {
+    const req = makeRequest('/access-token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const res = await handler.fetch(req, makeEnv());
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      token: 'proxy-access-token',
+      expiresAt: '2026-06-28T00:00:00.000Z',
+    });
+    expect(issueAccessToken).toHaveBeenCalledWith('1.2.3.4', expect.anything());
+  });
+
+  it('returns 429 when access token issuance is rate limited', async () => {
+    issueAccessToken.mockResolvedValue({
+      error: 'Access token issuance limit reached',
+      retryAfter: 3600,
+    });
+    const req = makeRequest('/access-token', { method: 'POST' });
+
+    const res = await handler.fetch(req, makeEnv());
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get('Retry-After')).toBe('3600');
+  });
+});
+
 describe('POST /chat', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     validatePayload.mockReturnValue({ valid: true });
     verifyHmac.mockResolvedValue(true);
+    verifyAccessToken.mockResolvedValue({ valid: true, tokenHash: 'token-hash' });
     checkRateLimit.mockResolvedValue({ allowed: true, remaining: 29 });
     incrementCounters.mockResolvedValue();
     createChatStream.mockResolvedValue({ ok: true, status: 200, body: new ReadableStream() });
@@ -130,6 +184,22 @@ describe('POST /chat', () => {
     });
     const res = await handler.fetch(req, makeEnv());
     expect(res.status).toBe(403);
+  });
+
+  it('returns 401 when the proxy access token is missing or invalid', async () => {
+    verifyAccessToken.mockResolvedValue({ valid: false, reason: 'missing proxy access token' });
+    const req = makeRequest('/chat', {
+      method: 'POST',
+      body: { messages: [{ role: 'user', content: 'hi' }], signature: 'x', timestamp: 1 },
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const res = await handler.fetch(req, makeEnv());
+
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({ error: 'missing proxy access token' });
+    expect(checkRateLimit).not.toHaveBeenCalled();
+    expect(createChatStream).not.toHaveBeenCalled();
   });
 
   it('returns 429 when rate limited', async () => {
@@ -191,8 +261,8 @@ describe('POST /chat', () => {
       headers: { 'Content-Type': 'application/json' },
     });
     await handler.fetch(req, makeEnv());
-    expect(checkRateLimit).toHaveBeenCalledWith('1.2.3.4', expect.anything(), 'autosuggest');
-    expect(incrementCounters).toHaveBeenCalledWith('1.2.3.4', expect.anything(), 'autosuggest');
+    expect(checkRateLimit).toHaveBeenCalledWith('1.2.3.4', expect.anything(), 'autosuggest', 'token-hash');
+    expect(incrementCounters).toHaveBeenCalledWith('1.2.3.4', expect.anything(), 'autosuggest', 'token-hash');
   });
 
   it('defaults purpose to chat when not specified', async () => {
@@ -202,8 +272,8 @@ describe('POST /chat', () => {
       headers: { 'Content-Type': 'application/json' },
     });
     await handler.fetch(req, makeEnv());
-    expect(checkRateLimit).toHaveBeenCalledWith('1.2.3.4', expect.anything(), 'chat');
-    expect(incrementCounters).toHaveBeenCalledWith('1.2.3.4', expect.anything(), 'chat');
+    expect(checkRateLimit).toHaveBeenCalledWith('1.2.3.4', expect.anything(), 'chat', 'token-hash');
+    expect(incrementCounters).toHaveBeenCalledWith('1.2.3.4', expect.anything(), 'chat', 'token-hash');
   });
 
   it('passes the shared autosuggest token limit to createChatStream for autosuggest', async () => {

--- a/proxy/tests/rate-limit.test.js
+++ b/proxy/tests/rate-limit.test.js
@@ -84,6 +84,26 @@ describe('checkRateLimit', () => {
     expect(result.allowed).toBe(true);
     expect(result.remaining).toBe(19);
   });
+
+  it('uses the proxy access token identity when provided', async () => {
+    const kv = createMockKV();
+    await checkRateLimit('1.2.3.4', kv, 'chat', 'token-hash');
+
+    expect(kv.get).toHaveBeenCalledWith(expect.stringContaining('1.2.3.4:token-hash'));
+  });
+
+  it('still blocks when the caller IP has exhausted its daily quota across tokens', async () => {
+    const kv = createMockKV();
+    kv.get.mockImplementation((key) => {
+      if (key.startsWith('rl:ipday:')) return Promise.resolve('30');
+      return Promise.resolve(null);
+    });
+
+    const result = await checkRateLimit('1.2.3.4', kv, 'chat', 'token-hash');
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('Daily');
+  });
 });
 
 describe('incrementCounters', () => {
@@ -123,6 +143,28 @@ describe('incrementCounters', () => {
     expect(minuteCall[1]).toBe('4');
     const dayCall = kv.put.mock.calls.find((c) => c[0].startsWith('rl:day:'));
     expect(dayCall[1]).toBe('16');
+  });
+
+  it('increments counters for the proxy access token identity when provided', async () => {
+    const kv = createMockKV();
+    await incrementCounters('1.2.3.4', kv, 'chat', 'token-hash');
+
+    expect(kv.put).toHaveBeenCalledWith(
+      expect.stringContaining('1.2.3.4:token-hash'),
+      '1',
+      expect.anything()
+    );
+  });
+
+  it('also increments caller IP counters when a proxy access token is provided', async () => {
+    const kv = createMockKV();
+    await incrementCounters('1.2.3.4', kv, 'chat', 'token-hash');
+
+    expect(kv.put).toHaveBeenCalledWith(
+      expect.stringContaining('rl:ipday:1.2.3.4'),
+      '1',
+      expect.anything()
+    );
   });
 
   it('blocks IP after 10+ requests in 10s window', async () => {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -3,7 +3,7 @@
 
 import { AUTOSUGGEST_MAX_SUGGESTION_TOKENS } from '../shared/autosuggest-limits.js';
 import { DEFAULT_OPENAI_MODEL, DEFAULT_REASONING_EFFORT } from '../shared/model-config.js';
-import { getLocalStorage, setLocalStorage } from '../shared/storage.js';
+import { getLocalStorage, removeLocalStorage, setLocalStorage } from '../shared/storage.js';
 
 import type {
   AutosuggestBackgroundPort,
@@ -21,10 +21,14 @@ import type {
   ValidateApiKeyResponse,
 } from '../shared/types';
 
-const PROXY_URL = 'https://dobby-ai-proxy.zhongnansu.workers.dev/chat';
+const PROXY_BASE_URL = 'https://dobby-ai-proxy.zhongnansu.workers.dev';
+const PROXY_URL = `${PROXY_BASE_URL}/chat`;
+const PROXY_ACCESS_TOKEN_URL = `${PROXY_BASE_URL}/access-token`;
 const USAGE_STORAGE_KEY = 'dobbyUsage';
-// HMAC_SECRET is intentionally in extension source — it's light obfuscation per spec.
-// Real defense is IP rate limiting on the proxy.
+const PROXY_ACCESS_TOKEN_STORAGE_KEY = 'proxyAccessToken';
+const PROXY_ACCESS_TOKEN_HEADER = 'X-Dobby-Access-Token';
+// HMAC_SECRET is intentionally in extension source — it is request-shape validation, not auth.
+// Free proxy calls also require a server-issued access token and proxy-side quota checks.
 const HMAC_SECRET = 'dobby-ai-v2-hmac-key-change-in-production';
 // Set to your dev token to bypass rate limits during development; leave empty for normal user behavior
 const DEV_BYPASS_TOKEN = '';
@@ -211,6 +215,73 @@ export async function* parseSSEStream(
   }
 }
 
+type ProxyRequestPurpose = 'chat' | 'autosuggest';
+
+async function fetchProxyAccessToken(signal?: AbortSignal): Promise<string> {
+  const response = await fetch(PROXY_ACCESS_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    signal,
+  });
+
+  if (!response.ok) {
+    let errBody = '';
+    try { errBody = await response.text(); } catch (e) { /* ignore */ }
+    throw new Error(errBody ? `Proxy access token failed (${response.status}): ${errBody.substring(0, 200)}` : 'Proxy access token failed');
+  }
+
+  const data = await response.json() as { token?: string };
+  if (!data.token) {
+    throw new Error('Proxy access token response was missing token');
+  }
+
+  await setLocalStorage({ [PROXY_ACCESS_TOKEN_STORAGE_KEY]: data.token });
+  return data.token;
+}
+
+async function getProxyAccessToken(forceRefresh: boolean, signal?: AbortSignal): Promise<string> {
+  if (!forceRefresh) {
+    const stored = await getLocalStorage(PROXY_ACCESS_TOKEN_STORAGE_KEY);
+    if (stored.proxyAccessToken) return stored.proxyAccessToken;
+  }
+  if (forceRefresh) {
+    await removeLocalStorage(PROXY_ACCESS_TOKEN_STORAGE_KEY);
+  }
+  return fetchProxyAccessToken(signal);
+}
+
+async function fetchViaProxy(
+  messages: ChatMessage[],
+  purpose: ProxyRequestPurpose,
+  signal: AbortSignal,
+): Promise<Response> {
+  const request = async (forceRefreshToken: boolean): Promise<Response> => {
+    const timestamp = Math.floor(Date.now() / 1000);
+    const signature = await generateSignature(messages, timestamp, HMAC_SECRET);
+    const token = await getProxyAccessToken(forceRefreshToken, signal);
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      [PROXY_ACCESS_TOKEN_HEADER]: token,
+    };
+    if (DEV_BYPASS_TOKEN) headers['X-Dev-Token'] = DEV_BYPASS_TOKEN;
+    const body = purpose === 'autosuggest'
+      ? { messages, signature, timestamp, purpose }
+      : { messages, signature, timestamp };
+
+    return fetch(PROXY_URL, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      signal,
+    });
+  };
+
+  const response = await request(false);
+  if (response.status !== 401) return response;
+
+  return request(true);
+}
+
 // --- Chat Stream Port Handler ---
 
 chrome.runtime.onConnect.addListener((port) => {
@@ -250,17 +321,7 @@ chrome.runtime.onConnect.addListener((port) => {
           signal: abortController.signal,
         });
       } else {
-        // Via proxy with HMAC signing
-        const timestamp = Math.floor(Date.now() / 1000);
-        const signature = await generateSignature(messages, timestamp, HMAC_SECRET);
-        const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-        if (DEV_BYPASS_TOKEN) headers['X-Dev-Token'] = DEV_BYPASS_TOKEN;
-        response = await fetch(PROXY_URL, {
-          method: 'POST',
-          headers,
-          body: JSON.stringify({ messages, signature, timestamp }),
-          signal: abortController.signal,
-        });
+        response = await fetchViaProxy(messages, 'chat', abortController.signal);
       }
 
       if (response.status === 429) {
@@ -344,17 +405,7 @@ chrome.runtime.onConnect.addListener((port) => {
           signal: abortController.signal,
         });
       } else {
-        // Via proxy with HMAC signing — include purpose for rate limiting
-        const timestamp = Math.floor(Date.now() / 1000);
-        const signature = await generateSignature(messages, timestamp, HMAC_SECRET);
-        const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-        if (DEV_BYPASS_TOKEN) headers['X-Dev-Token'] = DEV_BYPASS_TOKEN;
-        response = await fetch(PROXY_URL, {
-          method: 'POST',
-          headers,
-          body: JSON.stringify({ messages, signature, timestamp, purpose: 'autosuggest' }),
-          signal: abortController.signal,
-        });
+        response = await fetchViaProxy(messages, 'autosuggest', abortController.signal);
       }
 
       if (response.status === 429) {

--- a/src/shared/types/storage.ts
+++ b/src/shared/types/storage.ts
@@ -42,6 +42,7 @@ export type StorageState = {
   autosuggestEnabled?: boolean;
   theme?: ThemeMode;
   userApiKey?: string;
+  proxyAccessToken?: string;
   dobbyUsage?: UsageState;
   chatHistory?: HistoryEntry[];
   presetUsage?: PresetUsage;

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -6,6 +6,7 @@ const mockCreate = vi.fn();
 const mockSendMessage = vi.fn();
 const mockStorageGet = vi.fn();
 const mockStorageSet = vi.fn();
+const mockStorageRemove = vi.fn();
 const mockTabsQuery = vi.fn();
 const connectListeners = [];
 const messageListeners = [];
@@ -33,6 +34,7 @@ global.chrome = {
     local: {
       get: mockStorageGet,
       set: mockStorageSet,
+      remove: mockStorageRemove,
     },
   },
   notifications: {
@@ -384,8 +386,20 @@ describe('chat-stream integration', () => {
     return { ok: true, status: 200, body, headers: { get: (k) => headers.get(k) } };
   }
 
+  function makeAccessTokenResponse(token = 'proxy-access-token') {
+    return {
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({
+        token,
+        expiresAt: '2026-06-28T00:00:00.000Z',
+      }),
+    };
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
+    fetch.mockReset();
     mockStorageGet.mockImplementation((key) => Promise.resolve({}));
   });
 
@@ -394,7 +408,9 @@ describe('chat-stream integration', () => {
     const connectHandler = connectListeners[0];
     connectHandler(port);
 
-    fetch.mockResolvedValue(makeSSEResponse([
+    fetch
+      .mockResolvedValueOnce(makeAccessTokenResponse())
+      .mockResolvedValueOnce(makeSSEResponse([
       'data: {"choices":[{"delta":{"content":"Hi"}}]}\n\n',
       'data: [DONE]\n\n',
     ]));
@@ -407,9 +423,11 @@ describe('chat-stream integration', () => {
       expect(port.postMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'done', remaining: 25, usingOwnKey: false }));
     });
 
-    // Verify it called proxy URL (not OpenAI directly)
-    const calledUrl = fetch.mock.calls[0][0];
+    expect(fetch.mock.calls[0][0]).toContain('/access-token');
+    const calledUrl = fetch.mock.calls[1][0];
     expect(calledUrl).toContain('workers.dev');
+    expect(fetch.mock.calls[1][1].headers['X-Dobby-Access-Token']).toBe('proxy-access-token');
+    expect(mockStorageSet).toHaveBeenCalledWith({ proxyAccessToken: 'proxy-access-token' });
   });
 
   it('records chat usage with remaining free quota', async () => {
@@ -417,7 +435,9 @@ describe('chat-stream integration', () => {
     const connectHandler = connectListeners[0];
     connectHandler(port);
 
-    fetch.mockResolvedValue(makeSSEResponse([
+    fetch
+      .mockResolvedValueOnce(makeAccessTokenResponse())
+      .mockResolvedValueOnce(makeSSEResponse([
       'data: {"choices":[{"delta":{"content":"Hi"}}]}\n\n',
       'data: [DONE]\n\n',
     ]));
@@ -463,12 +483,61 @@ describe('chat-stream integration', () => {
     expect(body.max_completion_tokens).toBe(1000);
   });
 
+  it('reuses a stored proxy access token for no-key chat requests', async () => {
+    const { port, getHandler } = createStreamPort();
+    const connectHandler = connectListeners[0];
+    connectHandler(port);
+
+    mockStorageGet.mockImplementation((key) => Promise.resolve({ proxyAccessToken: 'stored-token' }));
+    fetch.mockResolvedValue(makeSSEResponse([
+      'data: {"choices":[{"delta":{"content":"Hi"}}]}\n\n',
+      'data: [DONE]\n\n',
+    ]));
+
+    const handler = getHandler();
+    await handler({ type: 'CHAT_REQUEST', messages: [{ role: 'user', content: 'test' }] });
+
+    await vi.waitFor(() => {
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    expect(fetch.mock.calls[0][1].headers['X-Dobby-Access-Token']).toBe('stored-token');
+  });
+
+  it('refreshes the proxy access token once when the proxy rejects it', async () => {
+    const { port, getHandler } = createStreamPort();
+    const connectHandler = connectListeners[0];
+    connectHandler(port);
+
+    mockStorageGet.mockImplementation((key) => Promise.resolve({ proxyAccessToken: 'expired-token' }));
+    fetch
+      .mockResolvedValueOnce({ ok: false, status: 401, text: () => Promise.resolve('Unauthorized') })
+      .mockResolvedValueOnce(makeAccessTokenResponse('fresh-token'))
+      .mockResolvedValueOnce(makeSSEResponse([
+        'data: {"choices":[{"delta":{"content":"Hi"}}]}\n\n',
+        'data: [DONE]\n\n',
+      ]));
+
+    const handler = getHandler();
+    await handler({ type: 'CHAT_REQUEST', messages: [{ role: 'user', content: 'test' }] });
+
+    await vi.waitFor(() => {
+      expect(port.postMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'done', remaining: 25, usingOwnKey: false }));
+    });
+
+    expect(fetch.mock.calls[0][1].headers['X-Dobby-Access-Token']).toBe('expired-token');
+    expect(fetch.mock.calls[1][0]).toContain('/access-token');
+    expect(fetch.mock.calls[2][1].headers['X-Dobby-Access-Token']).toBe('fresh-token');
+  });
+
   it('forwards 429 rate limit as rate_limited message', async () => {
     const { port, getHandler } = createStreamPort();
     const connectHandler = connectListeners[0];
     connectHandler(port);
 
-    fetch.mockResolvedValue({ ok: false, status: 429, json: () => Promise.resolve({ remaining: 0 }) });
+    fetch
+      .mockResolvedValueOnce(makeAccessTokenResponse())
+      .mockResolvedValueOnce({ ok: false, status: 429, json: () => Promise.resolve({ remaining: 0 }) });
 
     const handler = getHandler();
     await handler({ type: 'CHAT_REQUEST', messages: [{ role: 'user', content: 'test' }] });
@@ -503,8 +572,20 @@ describe('autosuggest-stream port', () => {
     return { ok: true, status: 200, body };
   }
 
+  function makeAccessTokenResponse(token = 'proxy-access-token') {
+    return {
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({
+        token,
+        expiresAt: '2026-06-28T00:00:00.000Z',
+      }),
+    };
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
+    fetch.mockReset();
     mockStorageGet.mockImplementation(() => Promise.resolve({}));
   });
 
@@ -556,7 +637,9 @@ describe('autosuggest-stream port', () => {
     const autosuggestHandler = connectListeners[1];
     autosuggestHandler(port);
 
-    fetch.mockResolvedValue(makeSSEResponse([
+    fetch
+      .mockResolvedValueOnce(makeAccessTokenResponse())
+      .mockResolvedValueOnce(makeSSEResponse([
       'data: {"choices":[{"delta":{"content":"Hi"}}]}\n\n',
       'data: [DONE]\n\n',
     ]));
@@ -568,9 +651,10 @@ describe('autosuggest-stream port', () => {
       expect(fetch).toHaveBeenCalled();
     });
 
-    const calledUrl = fetch.mock.calls[0][0];
+    const calledUrl = fetch.mock.calls[1][0];
     expect(calledUrl).toContain('workers.dev');
-    const body = JSON.parse(fetch.mock.calls[0][1].body);
+    expect(fetch.mock.calls[1][1].headers['X-Dobby-Access-Token']).toBe('proxy-access-token');
+    const body = JSON.parse(fetch.mock.calls[1][1].body);
     expect(body.purpose).toBe('autosuggest');
   });
 
@@ -610,11 +694,13 @@ describe('autosuggest-stream port', () => {
     const autosuggestHandler = connectListeners[1];
     autosuggestHandler(port);
 
-    fetch.mockResolvedValue(makeSSEResponse([
-      'data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n',
-      'data: {"choices":[{"delta":{"content":" world"}}]}\n\n',
-      'data: [DONE]\n\n',
-    ]));
+    fetch
+      .mockResolvedValueOnce(makeAccessTokenResponse())
+      .mockResolvedValueOnce(makeSSEResponse([
+        'data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n',
+        'data: {"choices":[{"delta":{"content":" world"}}]}\n\n',
+        'data: [DONE]\n\n',
+      ]));
 
     const handler = getHandler();
     await handler({ type: 'AUTOSUGGEST_REQUEST', messages: [{ role: 'user', content: 'test' }] });
@@ -631,10 +717,12 @@ describe('autosuggest-stream port', () => {
     const autosuggestHandler = connectListeners[1];
     autosuggestHandler(port);
 
-    fetch.mockResolvedValue(makeSSEResponse([
-      'data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n',
-      'data: [DONE]\n\n',
-    ]));
+    fetch
+      .mockResolvedValueOnce(makeAccessTokenResponse())
+      .mockResolvedValueOnce(makeSSEResponse([
+        'data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n',
+        'data: [DONE]\n\n',
+      ]));
 
     const handler = getHandler();
     await handler({ type: 'AUTOSUGGEST_REQUEST', messages: [{ role: 'user', content: 'test' }] });
@@ -654,7 +742,9 @@ describe('autosuggest-stream port', () => {
     const autosuggestHandler = connectListeners[1];
     autosuggestHandler(port);
 
-    fetch.mockResolvedValue({ ok: false, status: 429, json: () => Promise.resolve({ remaining: 0 }) });
+    fetch
+      .mockResolvedValueOnce(makeAccessTokenResponse())
+      .mockResolvedValueOnce({ ok: false, status: 429, json: () => Promise.resolve({ remaining: 0 }) });
 
     const handler = getHandler();
     await handler({ type: 'AUTOSUGGEST_REQUEST', messages: [{ role: 'user', content: 'test' }] });


### PR DESCRIPTION
## Summary
- add server-issued, IP-bound access tokens for free proxy requests so the public extension signing secret is no longer the only reusable gate
- scope proxy quotas by access token and caller IP to limit token rotation as a quota multiplier
- fetch, persist, and refresh proxy access tokens in the extension no-key flow
- bump extension version to 1.4.1

Fixes #210
Follow-up: #211
Follow-up: #212

## Validation
- `npm run typecheck`
- `npm test`
- `cd proxy && npm test`
- `npm run build`
- `npm run test:e2e`
