### PR TITLE
[codex] Prevent accidental selection toolbar popups

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dobby AI",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Select text and get instant AI explanations inline on any page",
   "permissions": [
     "contextMenus",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dobby-ai",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dobby-ai",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "dependencies": {
         "react": "^19.2.7",
         "react-dom": "^19.2.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dobby-ai",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": true,
   "description": "Select text or screenshot any region on the web — get instant AI answers right where you are",
   "scripts": {

--- a/src/content/trigger/selection.ts
+++ b/src/content/trigger/selection.ts
@@ -20,9 +20,17 @@ import { showTrigger, hideTrigger, createTriggerButton } from './button.js';
 import { startScreenshotMode, cancelScreenshotMode } from './screenshot.js';
 import { _showProgressRing, _removeProgressRing } from './progress-ring.js';
 
+const SELECTION_SUPPRESS_MS = 1000;
+const SELECTION_RELEASE_GRACE_MS = 750;
+
 const INTERACTIVE_TAGS = new Set([
   'INPUT', 'TEXTAREA', 'SELECT', 'BUTTON', 'A', 'VIDEO', 'AUDIO', 'LABEL', 'OPTION',
 ]);
+
+let primarySelectionActive = false;
+let suppressSelectionUntil = 0;
+let lastPrimarySelectionReleaseAt = 0;
+let canReshowSelectionOnScroll = false;
 
 function isInteractiveElement(el: HTMLElement | null): boolean {
   if (!el || !el.tagName) return false;
@@ -34,8 +42,10 @@ function isInteractiveElement(el: HTMLElement | null): boolean {
 
 function isScrollbarClick(e: MouseEvent): boolean {
   // Page-level scrollbars
-  if (e.clientX >= document.documentElement.clientWidth ||
-    e.clientY >= document.documentElement.clientHeight) return true;
+  const viewportWidth = document.documentElement.clientWidth;
+  const viewportHeight = document.documentElement.clientHeight;
+  if ((viewportWidth > 0 && e.clientX >= viewportWidth) ||
+    (viewportHeight > 0 && e.clientY >= viewportHeight)) return true;
   // Element-level scrollbars (e.g. scrollable divs)
   const el = e.target as HTMLElement | null;
   if (el && el.getBoundingClientRect) {
@@ -48,30 +58,90 @@ function isScrollbarClick(e: MouseEvent): boolean {
   return false;
 }
 
+function now(): number {
+  return Date.now();
+}
+
+function suppressSelectionTriggers(): void {
+  primarySelectionActive = false;
+  canReshowSelectionOnScroll = false;
+  suppressSelectionUntil = now() + SELECTION_SUPPRESS_MS;
+}
+
+function isSuppressedSelection(): boolean {
+  return now() < suppressSelectionUntil;
+}
+
+function isEligibleSelectionPointerDown(e: MouseEvent): boolean {
+  if (e.button !== 0) return false;
+  if (isClickInsideUI(e.target, getBubbleContainer)) return false;
+  if (isInteractiveElement(e.target as HTMLElement | null)) return false;
+  if (isScrollbarClick(e)) return false;
+  return true;
+}
+
+function markAcceptedSelection(): void {
+  canReshowSelectionOnScroll = true;
+}
+
+function showTriggerForCurrentSelection(x: number, y: number): void {
+  const text = getSelectedText();
+
+  if (text.length >= 3 && dobbyEnabled) {
+    const sel = window.getSelection()!;
+    const anchorNode = sel.anchorNode || null;
+    markAcceptedSelection();
+    showTrigger(x, y, { text, anchorNode, selection: sel }).catch(() => {});
+  } else {
+    canReshowSelectionOnScroll = false;
+    hideTrigger();
+  }
+}
+
 export function registerListeners(): void {
+  document.addEventListener('contextmenu', () => {
+    suppressSelectionTriggers();
+  }, true);
+
+  document.addEventListener('mousedown', (e) => {
+    if (e.button !== 0) {
+      suppressSelectionTriggers();
+      return;
+    }
+
+    primarySelectionActive = isEligibleSelectionPointerDown(e);
+    if (primarySelectionActive) {
+      canReshowSelectionOnScroll = false;
+    }
+  }, true);
+
   // Listen for text selection
   document.addEventListener('mouseup', (e) => {
+    if (e.button !== 0) {
+      suppressSelectionTriggers();
+      return;
+    }
+    if (!primarySelectionActive || isSuppressedSelection()) return;
+
+    primarySelectionActive = false;
+    lastPrimarySelectionReleaseAt = now();
+
     if (isClickInsideUI(e.target, getBubbleContainer)) return;
 
     const cursorX = e.clientX;
     const cursorY = e.clientY;
     setTimeout(() => {
-      const text = getSelectedText();
-
-      if (text.length >= 3 && dobbyEnabled) {
-        const sel = window.getSelection()!;
-        const anchorNode = sel.anchorNode || null;
-        showTrigger(cursorX, cursorY, { text, anchorNode, selection: sel }).catch(() => {});
-      } else {
-        hideTrigger();
-      }
+      showTriggerForCurrentSelection(cursorX, cursorY);
     }, TIMING.MOUSEUP_DELAY);
-  });
+  }, true);
 
   // Fallback: selectionchange fires even when sites (Gmail, etc.) capture mouseup
   document.addEventListener('selectionchange', () => {
     clearTimeout(selectionChangeTimer!);
     setSelectionChangeTimer(setTimeout(() => {
+      if (primarySelectionActive || isSuppressedSelection()) return;
+      if (now() - lastPrimarySelectionReleaseAt > SELECTION_RELEASE_GRACE_MS) return;
+
       const text = getSelectedText();
       const selection = window.getSelection()!;
       if (text.length >= 3 && dobbyEnabled && selection.rangeCount > 0) {
@@ -79,6 +149,7 @@ export function registerListeners(): void {
         if (!triggerButton || triggerButton.style.display === 'none') {
           const anchorNode = selection.anchorNode || null;
           const rect = getSelectionRect();
+          markAcceptedSelection();
           showTrigger(rect.right, rect.bottom, { text, anchorNode, selection }).catch(() => {});
         }
       }
@@ -90,6 +161,8 @@ export function registerListeners(): void {
     hideTrigger();
     clearTimeout(scrollTimer!);
     setScrollTimer(setTimeout(() => {
+      if (!canReshowSelectionOnScroll || isSuppressedSelection()) return;
+
       const text = getSelectedText();
       const selection = window.getSelection()!;
       if (text.length >= 3 && dobbyEnabled && selection.rangeCount > 0) {
@@ -103,6 +176,7 @@ export function registerListeners(): void {
   // Hide on click away
   document.addEventListener('mousedown', (e) => {
     if (isClickInsideUI(e.target, getBubbleContainer)) return;
+    canReshowSelectionOnScroll = false;
     hideTrigger();
   });
 
@@ -177,6 +251,10 @@ export function _resetTriggerForTesting(): void {
   if (longPressState.ringTimer) { clearTimeout(longPressState.ringTimer); longPressState.ringTimer = null; }
   longPressState.startX = 0;
   longPressState.startY = 0;
+  primarySelectionActive = false;
+  suppressSelectionUntil = 0;
+  lastPrimarySelectionReleaseAt = 0;
+  canReshowSelectionOnScroll = false;
   _removeProgressRing();
   cancelScreenshotMode();
 }

--- a/tests/trigger.test.js
+++ b/tests/trigger.test.js
@@ -142,13 +142,83 @@ describe('event-driven behavior', () => {
     sharedMockSelection(text);
   }
 
+  function dispatchLeftSelectionRelease() {
+    document.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, button: 0, clientX: 10, clientY: 10 }));
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, button: 0, clientX: 40, clientY: 10 }));
+  }
+
   it('mouseup with selection >= 3 chars shows trigger', async () => {
     vi.useFakeTimers();
     mockSelection('hello world');
 
-    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    dispatchLeftSelectionRelease();
     vi.advanceTimersByTime(20);
     // flush microtask queue multiple times so async showTrigger/createToolbar resolve
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const host = getHost();
+    expect(host).not.toBeNull();
+    expect(host.style.display).toBe('block');
+    vi.useRealTimers();
+  });
+
+  it('right-click mouseup with selection does not show trigger', async () => {
+    vi.useFakeTimers();
+    mockSelection('hello world');
+
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, button: 2 }));
+    vi.advanceTimersByTime(20);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(getHost()).toBeNull();
+    vi.useRealTimers();
+  });
+
+  it('context menu selectionchange does not show trigger', async () => {
+    vi.useFakeTimers();
+    mockSelection('hello world');
+
+    document.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, button: 2 }));
+    document.dispatchEvent(new Event('selectionchange', { bubbles: true }));
+    vi.advanceTimersByTime(350);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(getHost()).toBeNull();
+    vi.useRealTimers();
+  });
+
+  it('scroll does not resurrect a context-menu selection', async () => {
+    vi.useFakeTimers();
+    mockSelection('hello world');
+
+    document.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, button: 2 }));
+    window.dispatchEvent(new Event('scroll'));
+    vi.advanceTimersByTime(200);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(getHost()).toBeNull();
+    vi.useRealTimers();
+  });
+
+  it('selectionchange during an active left-button drag waits for mouseup', async () => {
+    vi.useFakeTimers();
+    mockSelection('hello world');
+
+    document.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, button: 0, clientX: 10, clientY: 10 }));
+    document.dispatchEvent(new Event('selectionchange', { bubbles: true }));
+    vi.advanceTimersByTime(350);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(getHost()).toBeNull();
+
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, button: 0, clientX: 40, clientY: 10 }));
+    vi.advanceTimersByTime(20);
     await Promise.resolve();
     await Promise.resolve();
     await Promise.resolve();
@@ -165,7 +235,7 @@ describe('event-driven behavior', () => {
     await showTrigger(100, 100);
     mockSelection('ab');
 
-    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    dispatchLeftSelectionRelease();
     vi.advanceTimersByTime(20);
 
     expect(getHost()).toBeNull();
@@ -177,7 +247,7 @@ describe('event-driven behavior', () => {
     _setDobbyEnabled(false);
     mockSelection('hello world');
 
-    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    dispatchLeftSelectionRelease();
     vi.advanceTimersByTime(20);
 
     // Should not exist or should be hidden


### PR DESCRIPTION
## Summary
- gate the text-selection toolbar behind an eligible left-button selection gesture
- suppress toolbar activation from right-click/context-menu selections and arbitrary selectionchange events
- prevent scroll from resurrecting ignored or stale selections
- keep normal left-drag selection opening after mouse release

## Validation
- `npm test -- tests/trigger.test.js`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm run test:e2e`
